### PR TITLE
Conditionally create platform application from APNS certifcate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ build
 coverage
 dist
 docs
+secure
 node_modules
 cloudformation.json
 terraform/terraform.tfstate*
+terraform/.terraform.tfstate.lock.info
 terraform/.terraform

--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ brew install jq
 brew install terraform
 ```
 
+## Configuring Push Notifications
+
+In order for this project to work out-of-the-box, you will need to do some additional configuration in order to support push notifications. This includes generating a certificate to use the Apple Push Notification Service (APNS) and a subsequent p12 file. Instructions can be found [here](https://calvium.com/how-to-make-a-p12-file/).
+
+Once created, you will extract the certificate and the private key in to separate files and move them in to the `secure/APNS_SANDBOX` directory at the root of the project:
+
+```bash
+# Extract the private key
+openssl pkcs12 -in certificate.p12 -nodes -nocerts | sed -ne '/-BEGIN PRIVATE KEY-/,/-END PRIVATE KEY-/p' > privateKey.txt
+
+# Extract the certificate file
+openssl pkcs12 -in certificate.p12 -clcerts -nokeys | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > certificate.txt
+
+# Create the directories
+mkdir -p secure/APNS_SANDBOX
+
+# Move the files in to the directory
+mv privateKey.txt certificate.txt secure/APNS_SANDBOX
+```
+
+Once complete, run `terraform apply` and a new platform application will be created so you can register your device to receive push notifications.
+
 ## Deployment
 
 * Deploy Code - To deploy code changes only, this command will package the distribution files and trigger a terraform apply.

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,11 +127,13 @@ export async function handleDeviceRegistration(event: APIGatewayEvent, context: 
     return response(context, statusCode, message)
   }
   const body = (requestBody as DeviceRegistration)
-  if (!process.env.PlatformApplicationArn) {
+  logInfo('process.env.PlatformApplicationArn <=', process.env.PlatformApplicationArn)
+  if (process.env.PlatformApplicationArn.length === 0) {
     return response(context, 200, {
       endpointArn: 'requires configuration'
     })
   }
+
   // TODO: Add the device ID attribute, and figure out how to stop multiple subscriptions
   // const deviceId = event.headers['x-device-uuid']
   const createPlatformEndpointParams = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,11 @@ export async function handleDeviceRegistration(event: APIGatewayEvent, context: 
     return response(context, statusCode, message)
   }
   const body = (requestBody as DeviceRegistration)
+  if (!process.env.PlatformApplicationArn) {
+    return response(context, 200, {
+      endpointArn: 'requires configuration'
+    })
+  }
   // TODO: Add the device ID attribute, and figure out how to stop multiple subscriptions
   // const deviceId = event.headers['x-device-uuid']
   const createPlatformEndpointParams = {

--- a/src/util/secretsmanager-helpers.ts
+++ b/src/util/secretsmanager-helpers.ts
@@ -33,8 +33,8 @@ export async function getServerPrivateKey() {
     return PRIVATEKEY
   }
   // This SecretId has to map to the CloudFormation file (LoginUser)
-  logDebug('getSecretValue', {SecretId: 'ServerEncryptionKey'})
-  const privateKeySecretResponse = await getSecretValue({SecretId: 'ServerEncryptionKey'})
+  logDebug('getSecretValue', {SecretId: 'PrivateEncryptionKey'})
+  const privateKeySecretResponse = await getSecretValue({SecretId: 'PrivateEncryptionKey'})
   logDebug('getSecretValue', privateKeySecretResponse)
   PRIVATEKEY = privateKeySecretResponse.SecretString
   return PRIVATEKEY

--- a/terraform/login_user.tf
+++ b/terraform/login_user.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role" "LoginUserRole" {
 data "aws_iam_policy_document" "LoginUser" {
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = [aws_secretsmanager_secret.ServerEncryptionKey.arn]
+    resources = [aws_secretsmanager_secret.PrivateEncryptionKey.arn]
   }
 }
 
@@ -78,17 +78,17 @@ resource "aws_api_gateway_integration" "LoginUserPost" {
   uri                     = aws_lambda_function.LoginUser.invoke_arn
 }
 
-resource "aws_secretsmanager_secret" "ServerEncryptionKey" {
-  name        = "ServerEncryptionKey"
+resource "aws_secretsmanager_secret" "PrivateEncryptionKey" {
+  name        = "PrivateEncryptionKey"
   description = "The secret for generating/validating server-issued JWTs."
 }
 
-resource "aws_secretsmanager_secret_version" "ServerEncryptionKey" {
-  secret_id     = aws_secretsmanager_secret.ServerEncryptionKey.id
-  secret_string = random_password.ServerEncryptionKey.result
+resource "aws_secretsmanager_secret_version" "PrivateEncryptionKey" {
+  secret_id     = aws_secretsmanager_secret.PrivateEncryptionKey.id
+  secret_string = random_password.PrivateEncryptionKey.result
 }
 
-resource "random_password" "ServerEncryptionKey" {
+resource "random_password" "PrivateEncryptionKey" {
   length  = 50
   special = true
 }

--- a/terraform/register_device.tf
+++ b/terraform/register_device.tf
@@ -10,8 +10,8 @@ data "aws_iam_policy_document" "RegisterDevice" {
       "sns:Subscribe"
     ]
     resources = [
-      aws_sns_platform_application.OfflineMediaDownloader.arn,
-      aws_sns_topic.PushNotifications.arn
+      aws_sns_topic.PushNotifications.arn,
+      length(aws_sns_platform_application.OfflineMediaDownloader) == 1 ? aws_sns_platform_application.OfflineMediaDownloader[0].arn : ""
     ]
   }
 }
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "RegisterDevice" {
 
   environment {
     variables = {
-      PlatformApplicationArn   = aws_sns_platform_application.OfflineMediaDownloader.arn
+      PlatformApplicationArn   = aws_sns_platform_application.OfflineMediaDownloader[0].arn
       PushNotificationTopicArn = aws_sns_topic.PushNotifications.arn
     }
   }
@@ -89,11 +89,22 @@ resource "aws_sns_topic" "PushNotifications" {
   name = "PushNotifications"
 }
 
+variable "apnsPrivateKeyPath" {
+  type    = string
+  default = "./../secure/APNS_SANDBOX/privateKey.txt"
+}
+
+variable "apnsCertificatePath" {
+  type    = string
+  default = "./../secure/APNS_SANDBOX/privateKey.txt"
+}
+
 resource "aws_sns_platform_application" "OfflineMediaDownloader" {
+  count                     = fileexists(var.apnsPrivateKeyPath) && fileexists(var.apnsCertificatePath) ? 1 : 0
   name                      = "OfflineMediaDownloader"
   platform                  = "APNS_SANDBOX"
-  platform_credential       = file("./../secure/APNS_SANDBOX/privateKey.txt")  # APNS PRIVATE KEY
-  platform_principal        = file("./../secure/APNS_SANDBOX/certificate.txt") # APNS CERTIFICATE
+  platform_credential       = file(var.apnsPrivateKeyPath)  # APNS PRIVATE KEY
+  platform_principal        = file(var.apnsCertificatePath) # APNS CERTIFICATE
   success_feedback_role_arn = aws_iam_role.SNSLoggingRole.arn
   failure_feedback_role_arn = aws_iam_role.SNSLoggingRole.arn
 }

--- a/terraform/register_device.tf
+++ b/terraform/register_device.tf
@@ -9,10 +9,10 @@ data "aws_iam_policy_document" "RegisterDevice" {
       "sns:CreatePlatformEndpoint",
       "sns:Subscribe"
     ]
-    resources = [
+    resources = compact([
       aws_sns_topic.PushNotifications.arn,
       length(aws_sns_platform_application.OfflineMediaDownloader) == 1 ? aws_sns_platform_application.OfflineMediaDownloader[0].arn : ""
-    ]
+    ])
   }
 }
 
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "RegisterDevice" {
 
   environment {
     variables = {
-      PlatformApplicationArn   = aws_sns_platform_application.OfflineMediaDownloader[0].arn
+      PlatformApplicationArn   = length(aws_sns_platform_application.OfflineMediaDownloader) == 1 ? aws_sns_platform_application.OfflineMediaDownloader[0].arn : ""
       PushNotificationTopicArn = aws_sns_topic.PushNotifications.arn
     }
   }
@@ -96,7 +96,7 @@ variable "apnsPrivateKeyPath" {
 
 variable "apnsCertificatePath" {
   type    = string
-  default = "./../secure/APNS_SANDBOX/privateKey.txt"
+  default = "./../secure/APNS_SANDBOX/certificate.txt"
 }
 
 resource "aws_sns_platform_application" "OfflineMediaDownloader" {

--- a/terraform/register_user.tf
+++ b/terraform/register_user.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "RegisterUser" {
     actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:prod/SignInWithApple/*",
-      aws_secretsmanager_secret.ServerEncryptionKey.arn
+      aws_secretsmanager_secret.PrivateEncryptionKey.arn
     ]
   }
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -198,6 +198,7 @@ describe('main', () => {
       createPlatformEndpointStub = sinon.stub(SNS, 'createPlatformEndpoint')
       subscribeStub = sinon.stub(SNS, 'subscribe')
       event = getFixture('handleRegisterDevice/APIGatewayEvent.json')
+      process.env.PlatformApplicationArn = 'arn:aws:sns:region:account_id:topic:uuid'
     })
     afterEach(() => {
       mock.resetHandlers()
@@ -212,6 +213,14 @@ describe('main', () => {
       const body = JSON.parse(output.body)
       expect(output.statusCode).to.equal(201)
       expect(body.body).to.have.property('endpointArn')
+    })
+    it('should return a valid response if APNS is not configured', async () => {
+      delete process.env.PlatformApplicationArn
+      const output = await handleDeviceRegistration(event, context)
+      expect(output.statusCode).to.equal(200)
+      const body = JSON.parse(output.body)
+      expect(body.body).to.have.property('endpointArn')
+      expect(body.body.endpointArn).to.have.string('requires configuration')
     })
     it('should handle an invalid request (no token)', async () => {
       event.body = null

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -215,7 +215,7 @@ describe('main', () => {
       expect(body.body).to.have.property('endpointArn')
     })
     it('should return a valid response if APNS is not configured', async () => {
-      delete process.env.PlatformApplicationArn
+      process.env.PlatformApplicationArn = ""
       const output = await handleDeviceRegistration(event, context)
       expect(output.statusCode).to.equal(200)
       const body = JSON.parse(output.body)


### PR DESCRIPTION
In order for this project to work out-of-the-box, I have configured Terraform to only conditionally create the [platform application](https://docs.aws.amazon.com/sns/latest/dg/mobile-push-send-register.html) if the required files are present.

- [X] Configured the source code to work in both cases
- [X] Updated the name of the server-side secret (this is unrelated, but required because of AWS secret destruction rules)
- [X] Updated the README to articulate how to configure this resource
- [X] Added the `secure` directory to be excluded from version control (along with some additional Terraform files)