### PR TITLE
refactor(encryption): Replace secret key with reference from terrafor…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -440,7 +440,6 @@ export async function handleRegisterUser(event: APIGatewayEvent, context: Contex
 
 export async function handleLoginUser(event: APIGatewayEvent, context: Context) {
   logInfo('event <=', event)
-  logInfo('ENV <=', process.env)
   const token = await createAccessToken(uuidv4())
   return response(context, 200, {token})
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -440,6 +440,7 @@ export async function handleRegisterUser(event: APIGatewayEvent, context: Contex
 
 export async function handleLoginUser(event: APIGatewayEvent, context: Context) {
   logInfo('event <=', event)
+  logInfo('ENV <=', process.env)
   const token = await createAccessToken(uuidv4())
   return response(context, 200, {token})
 }

--- a/src/util/secretsmanager-helpers.ts
+++ b/src/util/secretsmanager-helpers.ts
@@ -33,8 +33,8 @@ export async function getServerPrivateKey() {
     return PRIVATEKEY
   }
   // This SecretId has to map to the CloudFormation file (LoginUser)
-  logDebug('getSecretValue', {SecretId: 'PrivateEncryptionKey'})
-  const privateKeySecretResponse = await getSecretValue({SecretId: 'PrivateEncryptionKey'})
+  logDebug('getSecretValue', {SecretId: process.env.EncryptionKeySecretId})
+  const privateKeySecretResponse = await getSecretValue({SecretId: process.env.EncryptionKeySecretId})
   logDebug('getSecretValue', privateKeySecretResponse)
   PRIVATEKEY = privateKeySecretResponse.SecretString
   return PRIVATEKEY

--- a/terraform/login_user.tf
+++ b/terraform/login_user.tf
@@ -50,6 +50,7 @@ resource "aws_lambda_function" "LoginUser" {
   environment {
     variables = {
       Bucket = aws_s3_bucket.Files.id
+      EncryptionKeySecretId = aws_secretsmanager_secret.PrivateEncryptionKey.name
     }
   }
 }
@@ -81,6 +82,7 @@ resource "aws_api_gateway_integration" "LoginUserPost" {
 resource "aws_secretsmanager_secret" "PrivateEncryptionKey" {
   name        = "PrivateEncryptionKey"
   description = "The secret for generating/validating server-issued JWTs."
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "PrivateEncryptionKey" {

--- a/terraform/register_user.tf
+++ b/terraform/register_user.tf
@@ -57,6 +57,7 @@ resource "aws_lambda_function" "RegisterUser" {
   environment {
     variables = {
       DynamoDBTable = aws_dynamodb_table.Users.arn
+      EncryptionKeySecretId = aws_secretsmanager_secret.PrivateEncryptionKey.name
     }
   }
 }


### PR DESCRIPTION
In order for the the AWS SecretManager secret to be deleted when all Terraform resources are destroyed, you need to set the recovery window to zero days. Otherwise, Amazon will require you wait 7 days and result in the name having to be changed. In a production context, this is great! But for the state of this project, it's annoying.

[X] - Add the `recovery_window_in_days` attribute to the server encryption secret
[X] - Replaced hardcoded name references with an environment variable