### PR TITLE
chore: quality of life improvements

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,6 +1,7 @@
 {
     "extends": "@istanbuljs/nyc-config-typescript",
-    "reporter": ["html", "text"],
+    "reporter": [ "html", "text" ],
+    "exclude": [ "src/util/mocha-setup.ts", "src/types" ],
     "include": [ "src" ],
     "all": true
 }

--- a/bin/document-source.sh
+++ b/bin/document-source.sh
@@ -23,7 +23,7 @@ fi
 rm "${test_file_path}"
 
 # generate the documentation
-typedoc_command="${bin_dir}/../node_modules/typedoc/bin/typedoc"
+typedoc_command="${bin_dir}/../node_modules/typedoc/bin/typedoc --entryPointStrategy expand"
 eval $typedoc_command
 
 # retrieve or rebuild the files

--- a/config/.mocharc.yml
+++ b/config/.mocharc.yml
@@ -1,10 +1,12 @@
 bail: true
+extension:
+  - ts
 full-trace: true
+ignore:
+  - 'src/util/mocha-setup.ts'
+package: ./package.json
 require:
   - 'ts-node/register'
   - 'source-map-support/register'
   - 'src/util/mocha-setup.ts'
 spec: 'src/**/**/*.test.ts'
-extension:
-  - ts
-package: ./package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "ts-node": "^10.9.1",
         "typedoc": "^0.23.9",
         "typedoc-plugin-banish": "^1.0.1",
+        "typedoc-plugin-missing-exports": "^1.0.0",
         "typedoc-plugin-not-exported": "^0.1.6",
         "typescript": "^4.7.4",
         "webpack": "^5.74.0",
@@ -10703,6 +10704,15 @@
         "typedoc": ">= 0.19 && <= 1.0"
       }
     },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-1.0.0.tgz",
+      "integrity": "sha512-7s6znXnuAj1eD9KYPyzVzR1lBF5nwAY8IKccP5sdoO9crG4lpd16RoFpLsh2PccJM+I2NASpr0+/NMka6ThwVA==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.22.x || 0.23.x"
+      }
+    },
     "node_modules/typedoc-plugin-not-exported": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/typedoc-plugin-not-exported/-/typedoc-plugin-not-exported-0.1.6.tgz",
@@ -19504,6 +19514,13 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
+    },
+    "typedoc-plugin-missing-exports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-1.0.0.tgz",
+      "integrity": "sha512-7s6znXnuAj1eD9KYPyzVzR1lBF5nwAY8IKccP5sdoO9crG4lpd16RoFpLsh2PccJM+I2NASpr0+/NMka6ThwVA==",
+      "dev": true,
+      "requires": {}
     },
     "typedoc-plugin-not-exported": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "check-types": "tsc",
-    "coverage": "AWS_REGION=us-west-2 ./node_modules/nyc/bin/nyc.js --config config/.nycrc.json npm run test",
+    "coverage": "AWS_REGION=us-west-2 ./node_modules/nyc/bin/nyc.js npm run test",
     "document-source": "./bin/document-source.sh",
     "document-terraform": "terraform-docs markdown terraform/ > docs/terraform.md",
     "build": "./node_modules/webpack-cli/bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "check-types": "tsc",
-    "coverage": "AWS_REGION=us-west-2 ./node_modules/nyc/bin/nyc.js npm run test",
+    "coverage": "AWS_REGION=us-west-2 ./node_modules/nyc/bin/nyc.js --config config/.nycrc.json npm run test",
     "document-source": "./bin/document-source.sh",
     "document-terraform": "terraform-docs markdown terraform/ > docs/terraform.md",
     "build": "./node_modules/webpack-cli/bin/cli.js",
@@ -27,7 +27,7 @@
     "test-remote-registerDevice": "./bin/test-registerDevice.sh",
     "test-remote-userSubscribe": "./bin/test-userSubscribe.sh",
     "test-setup-config": "cat tsconfig.json | sed 's/\"module\": \"es6\"/\"module\": \"commonjs\"/g' tsconfig.json > tsconfig.testing.json",
-    "test-setup-mocha": "TS_NODE_PROJECT=\"tsconfig.testing.json\" AWS_REGION=us-west-2 ./node_modules/mocha/bin/mocha.js",
+    "test-setup-mocha": "TS_NODE_PROJECT=\"tsconfig.testing.json\" AWS_REGION=us-west-2 ./node_modules/mocha/bin/mocha.js --config config/.mocharc.yml",
     "deploy": "cd terraform && terraform apply -auto-approve"
   },
   "author": "Jonathan Lloyd",

--- a/src/lambdas/ListFiles/src/index.ts
+++ b/src/lambdas/ListFiles/src/index.ts
@@ -29,6 +29,7 @@ async function getFileIdsByUser(userId: string) {
   logDebug('query =>', userFilesResponse)
   return userFilesResponse
 }
+
 /**
  * Returns a list of files available to the user.
  *

--- a/src/lambdas/RegisterDevice/src/index.ts
+++ b/src/lambdas/RegisterDevice/src/index.ts
@@ -42,7 +42,6 @@ async function getUserDevice(table: string, userId: string, userDevice: UserDevi
 /**
  * Unsubscribes an endpoint (a client device) to an SNS topic
  * @param subscriptionArn - The SubscriptionArn of a endpoint+topic
- * @notExported
  */
 export async function unsubscribeEndpointToTopic(subscriptionArn: string) {
   logDebug('unsubscribe <=')

--- a/src/lambdas/RegisterUser/test/index.test.ts
+++ b/src/lambdas/RegisterUser/test/index.test.ts
@@ -39,4 +39,9 @@ describe('#RegisterUser', () => {
     const body = JSON.parse(output.body)
     expect(body.body.token).to.be.a('string')
   })
+  it('should handle an invalid payload', async () => {
+    event.body = ''
+    const output = await handler(event, context)
+    expect(output.statusCode).to.equal(400)
+  })
 })

--- a/src/lambdas/SendPushNotification/src/index.ts
+++ b/src/lambdas/SendPushNotification/src/index.ts
@@ -31,6 +31,9 @@ export async function handler(event: SQSEvent): Promise<void> {
       const notificationType = record.body
       const userId = record.messageAttributes.userId.stringValue
       const userResponse = await getUserDeviceByUserId(userId)
+      if (userResponse.Count == 0) {
+        return
+      }
       // There will always be 1 result; but with the possibility of multiple devices
       for (const userDevice of userResponse.Items[0].userDevice) {
         const targetArn = userDevice.endpointArn

--- a/src/lambdas/SendPushNotification/test/index.test.ts
+++ b/src/lambdas/SendPushNotification/test/index.test.ts
@@ -29,4 +29,14 @@ describe('#SendPushNotification', () => {
     queryStub.rejects('Error')
     expect(handler(event)).to.be.rejectedWith(Error)
   })
+  it('should exit gracefully if no devices exist', async () => {
+    queryStub.returns({
+      Items: [],
+      Count: 0,
+      ScannedCount: 0
+    })
+    const notificationsSent = await handler(event)
+    expect(notificationsSent).to.be.undefined
+    expect(publishSnsEventStub.notCalled)
+  })
 })

--- a/src/lib/vendor/AWS/StepFunctions.ts
+++ b/src/lib/vendor/AWS/StepFunctions.ts
@@ -1,5 +1,4 @@
 import {StartExecutionOutput, Types} from 'aws-sdk/clients/stepfunctions'
-
 import * as AWS from 'aws-sdk'
 import * as AWSXRay from 'aws-xray-sdk'
 const stepfunctions = AWSXRay.captureAWSClient(new AWS.StepFunctions({apiVersion: '2016-11-23'}))

--- a/src/util/apigateway-helpers.ts
+++ b/src/util/apigateway-helpers.ts
@@ -18,10 +18,10 @@ export function getPayloadFromEvent(event: APIGatewayEvent): Webhook | DeviceReg
   if ('body' in event) {
     try {
       const requestBody = JSON.parse(event.body)
-      logDebug('processEventAndValidate.event.body <=', event.body)
+      logDebug('getPayloadFromEvent.event.body <=', event.body)
       return requestBody
     } catch (error) {
-      logError('processEventAndValidate =>', `Invalid JSON: ${error}`)
+      logError('getPayloadFromEvent =>', `Invalid JSON: ${error}`)
       throw new ValidationError('Request body must be valid JSON')
     }
   }

--- a/src/util/dynamodb-helpers.ts
+++ b/src/util/dynamodb-helpers.ts
@@ -44,7 +44,7 @@ export function scanForFileParams(tableName: string): DocumentClient.ScanInput {
       '#FN': 'url'
     },
     ExpressionAttributeValues: {
-      ':aa': Date.now().toString()
+      ':aa': parseInt(Date.now().toString(), 10)
     },
     FilterExpression: '#AA <= :aa AND attribute_not_exists(#FN)',
     ProjectionExpression: '#AA, #FID',
@@ -124,7 +124,7 @@ export function getUserDeviceByUserIdParams(tableName: string, userId: string): 
 export function newFileParams(tableName: string, fileId: string): DocumentClient.UpdateItemInput {
   return {
     ExpressionAttributeNames: {'#AA': 'availableAt'},
-    ExpressionAttributeValues: {':aa': Date.now().toString()},
+    ExpressionAttributeValues: {':aa': parseInt(Date.now().toString(), 10)},
     Key: {fileId: fileId},
     ReturnValues: 'ALL_OLD',
     UpdateExpression: 'SET #AA = if_not_exists(#AA, :aa)',

--- a/src/util/mocha-setup.ts
+++ b/src/util/mocha-setup.ts
@@ -2,6 +2,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import fs from 'fs'
 import path from 'path'
+import * as sinon from 'sinon'
 chai.use(chaiAsPromised)
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -33,5 +34,22 @@ export const testContext = {
   },
   succeed: () => {
     return
+  }
+}
+
+export const mochaHooks = {
+  beforeEach(): void {
+    this.consoleLogStub = sinon.stub(console, 'log')
+    this.consoleInfoStub = sinon.stub(console, 'info')
+    this.consoleDebugStub = sinon.stub(console, 'debug')
+    this.consoleWarnStub = sinon.stub(console, 'warn')
+    this.consoleErrorStub = sinon.stub(console, 'error')
+  },
+  afterEach(): void {
+    this.consoleLogStub.restore()
+    this.consoleInfoStub.restore()
+    this.consoleDebugStub.restore()
+    this.consoleWarnStub.restore()
+    this.consoleErrorStub.restore()
   }
 }

--- a/src/util/mocha-setup.ts
+++ b/src/util/mocha-setup.ts
@@ -2,7 +2,6 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import fs from 'fs'
 import path from 'path'
-import * as sinon from 'sinon'
 chai.use(chaiAsPromised)
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -34,22 +33,5 @@ export const testContext = {
   },
   succeed: () => {
     return
-  }
-}
-
-export const mochaHooks = {
-  beforeEach(): void {
-    this.consoleLogStub = sinon.stub(console, 'log')
-    this.consoleInfoStub = sinon.stub(console, 'info')
-    this.consoleDebugStub = sinon.stub(console, 'debug')
-    this.consoleWarnStub = sinon.stub(console, 'warn')
-    this.consoleErrorStub = sinon.stub(console, 'error')
-  },
-  afterEach(): void {
-    this.consoleLogStub.restore()
-    this.consoleInfoStub.restore()
-    this.consoleDebugStub.restore()
-    this.consoleWarnStub.restore()
-    this.consoleErrorStub.restore()
   }
 }

--- a/src/util/secretsmanager-helpers.test.ts
+++ b/src/util/secretsmanager-helpers.test.ts
@@ -1,16 +1,75 @@
 import chai from 'chai'
-import { getAppleConfig, getApplePrivateKey } from "./secretsmanager-helpers"
+import {createAccessToken, getAppleClientSecret, getAppleConfig, getApplePrivateKey, getServerPrivateKey, validateAuthCodeForToken, verifyAccessToken, verifyAppleToken} from './secretsmanager-helpers'
+import jwt, {JsonWebTokenError} from 'jsonwebtoken'
 import * as sinon from 'sinon'
 import * as SecretsManager from '../lib/vendor/AWS/SecretsManager'
+import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
+import {SignInWithAppleVerifiedToken} from '../types/main'
+import {UnauthorizedError} from './errors'
+import JwksRsa from "jwks-rsa"
 const expect = chai.expect
+// Randomly generated key; not actually used anywhere (safe)
+// openssl ecparam -name prime256v1 -genkey -noout -out private.ec.key
+const fakePrivateKey = [
+  '-----BEGIN EC PRIVATE KEY-----',
+  'MHcCAQEEIF8qMhsznLgSjN49y4F1cmJZapGowo+PA33LR03WqIhroAoGCCqGSM49',
+  'AwEHoUQDQgAES1HCPTVyKI7fwl1Muq0ydgYqNpaFjHVKbDT+efytL6HYw+IWsMV/',
+  'X7Osbx+t4v7TzjVyKsLbMIwZ2GuRXg1QpA==',
+  '-----END EC PRIVATE KEY-----'
+].join('\n')
+// openssl ec -in private.ec.key -pubout -out public.ec.key
+const fakePublicKey = ['-----BEGIN PUBLIC KEY-----', 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES1HCPTVyKI7fwl1Muq0ydgYqNpaF', 'jHVKbDT+efytL6HYw+IWsMV/X7Osbx+t4v7TzjVyKsLbMIwZ2GuRXg1QpA==', '-----END PUBLIC KEY-----'].join('\n')
+
+const fakeTokenResponse = {
+  access_token: 'accessToken',
+  token_type: 'Bearer',
+  expires_in: 3600,
+  refresh_token: 'refreshToken',
+  id_token: 'idToken'
+}
+const fakeTokenHeader = {
+  kid: 'W6WcOKB',
+  alg: 'RS256'
+}
+const fakeTokenPayload: SignInWithAppleVerifiedToken = {
+  iss: 'https://appleid.apple.com',
+  aud: 'lifegames.OfflineMediaDownloader',
+  exp: 1660525825,
+  iat: 1660439425,
+  sub: '000185.7720315570fc49d99a265f9af4b46879.2034',
+  at_hash: 'U_Bxoy9yUIRYDfczHsG1gw',
+  email: 'webmaster@lifegames.org',
+  email_verified: true,
+  is_private_email: false,
+  auth_time: 1660439421,
+  nonce_supported: true
+}
+
+const fakeKeyPayload = {
+  kid: 'W6WcOKB',
+  alg: 'RS256',
+  publicKey:
+    '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2Zc5d0+zkZ5AKmtYTvxH\nc3vRc41YfbklflxG9SWsg5qXUxvfgpktGAcxXLFAd9Uglzow9ezvmTGce5d3DhAY\nKwHAEPT9hbaMDj7DfmEwuNO8UahfnBkBXsCoUaL3QITF5/DAPsZroTqs7tkQQZ7q\nPkQXCSu2aosgOJmaoKQgwcOdjD0D49ne2B/dkxBcNCcJT9pTSWJ8NfGycjWAQsvC\n8CGstH8oKwhC5raDcc2IGXMOQC7Qr75d6J5Q24CePHj/JD7zjbwYy9KNH8wyr829\neO/G4OEUW50FAN6HKtvjhJIguMl/1BLZ93z2KJyxExiNTZBUBQbbgCNBfzTv7Jrx\nMwIDAQAB\n-----END PUBLIC KEY-----\n',
+  rsaPublicKey:
+    '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2Zc5d0+zkZ5AKmtYTvxH\nc3vRc41YfbklflxG9SWsg5qXUxvfgpktGAcxXLFAd9Uglzow9ezvmTGce5d3DhAY\nKwHAEPT9hbaMDj7DfmEwuNO8UahfnBkBXsCoUaL3QITF5/DAPsZroTqs7tkQQZ7q\nPkQXCSu2aosgOJmaoKQgwcOdjD0D49ne2B/dkxBcNCcJT9pTSWJ8NfGycjWAQsvC\n8CGstH8oKwhC5raDcc2IGXMOQC7Qr75d6J5Q24CePHj/JD7zjbwYy9KNH8wyr829\neO/G4OEUW50FAN6HKtvjhJIguMl/1BLZ93z2KJyxExiNTZBUBQbbgCNBfzTv7Jrx\nMwIDAQAB\n-----END PUBLIC KEY-----\n'
+}
 
 describe('#Util:SecretsManager', () => {
   let getSecretValueStub
+  let jwksClientSigningKeyStub
+  let mock
   beforeEach(() => {
     getSecretValueStub = sinon.stub(SecretsManager, 'getSecretValue')
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    jwksClientSigningKeyStub = sinon.stub(JwksRsa.JwksClient.prototype, 'getSigningKey').returns(Promise.resolve(fakeKeyPayload))
+    mock = new MockAdapter(axios)
   })
   afterEach(() => {
     getSecretValueStub.restore()
+    jwksClientSigningKeyStub.restore()
+    mock.reset()
   })
   it('should getAppleConfig', async () => {
     const jsonString = '{"client_id":"lifegames.OfflineMediaDownloader","team_id":"XXXXXX","redirect_uri":"","key_id":"XXXXXX","scope":"email name"}'
@@ -23,8 +82,7 @@ describe('#Util:SecretsManager', () => {
     expect(getSecretValueStub.calledOnce)
   })
   it('should getApplePrivateKey', async () => {
-    const jsonString = '-----BEGIN PRIVATE KEY-----'
-    getSecretValueStub.returns(Promise.resolve({SecretString: jsonString}))
+    getSecretValueStub.returns(Promise.resolve({SecretString: fakePrivateKey}))
     const responseOne = await getApplePrivateKey()
     expect(responseOne).to.have.length.greaterThan(0)
     const responseTwo = await getApplePrivateKey()
@@ -33,13 +91,79 @@ describe('#Util:SecretsManager', () => {
     expect(getSecretValueStub.calledOnce)
   })
   it('should getServerPrivateKey', async () => {
-    const jsonString = '-----BEGIN PRIVATE KEY-----'
-    getSecretValueStub.returns(Promise.resolve({SecretString: jsonString}))
-    const responseOne = await getApplePrivateKey()
+    const secretString = 'randomly-generated-secret-id'
+    process.env.EncryptionKeySecretId = 'PrivateEncryptionKey'
+    getSecretValueStub.returns(Promise.resolve({SecretString: secretString}))
+    const responseOne = await getServerPrivateKey()
     expect(responseOne).to.have.length.greaterThan(0)
-    const responseTwo = await getApplePrivateKey()
+    const responseTwo = await getServerPrivateKey()
     expect(responseTwo).to.have.length.greaterThan(0)
     expect(responseOne).to.eql(responseTwo)
     expect(getSecretValueStub.calledOnce)
+  })
+  it('should getAppleClientSecret', async () => {
+    const token = await getAppleClientSecret()
+    const jwtPayload = jwt.verify(token, fakePublicKey)
+    expect(jwtPayload).to.have.all.keys('iss', 'aud', 'sub', 'iat', 'exp')
+  })
+  it('should validateAuthCodeForToken', async () => {
+    mock.onAny().reply(200, fakeTokenResponse)
+    const data = await validateAuthCodeForToken('test')
+    expect(data).to.have.all.keys(Object.keys(fakeTokenResponse))
+  })
+  it('should createAccessToken', async () => {
+    const secretString = 'randomly-generated-secret-id'
+    process.env.EncryptionKeySecretId = 'PrivateEncryptionKey'
+    getSecretValueStub.returns(Promise.resolve({SecretString: secretString}))
+    const userId = '1234'
+    const token = await createAccessToken(userId)
+    const jwtPayload = jwt.verify(token, secretString)
+    expect(jwtPayload).to.have.all.keys('userId', 'iat', 'exp')
+    expect(jwtPayload['userId']).to.eql(userId)
+  })
+  it('should verifyAccessToken successfully', async () => {
+    const secretString = 'randomly-generated-secret-id'
+    process.env.EncryptionKeySecretId = 'PrivateEncryptionKey'
+    getSecretValueStub.returns(Promise.resolve({SecretString: secretString}))
+    const userId = '1234'
+    const token = await createAccessToken(userId)
+    const jwtPayload = await verifyAccessToken(token)
+    expect(jwtPayload).to.have.all.keys('userId', 'iat', 'exp')
+    expect(jwtPayload['userId']).to.eql(userId)
+  })
+  it('should verifyAccessToken unsuccessfully', async () => {
+    const token = 'invalid-token'
+    await expect(verifyAccessToken(token)).to.be.rejectedWith(JsonWebTokenError)
+  })
+  it('should verifyAppleToken successfully', async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const jwtVerifyStub = sinon.stub(jwt, 'verify').returns(fakeTokenPayload)
+    const token = jwt.sign(fakeTokenPayload, fakePrivateKey, {header: fakeTokenHeader})
+    const newToken = await verifyAppleToken(token)
+    jwtVerifyStub.restore()
+    expect(newToken).to.have.all.keys('iss', 'aud', 'sub', 'iat', 'exp', 'at_hash', 'email', 'email_verified', 'is_private_email', 'auth_time', 'nonce_supported')
+  })
+  it('should verifyAppleToken handle an unexpected string payload', async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const jwtVerifyStub = sinon.stub(jwt, 'verify').returns('a string'.toString())
+    const token = jwt.sign(fakeTokenPayload, fakePrivateKey, {header: fakeTokenHeader})
+    await expect(verifyAppleToken(token)).to.be.rejectedWith(UnauthorizedError)
+    jwtVerifyStub.restore()
+  })
+  it('should verifyAppleToken handle token verification error', async () => {
+    const token = jwt.sign(fakeTokenPayload, fakePrivateKey, {header: fakeTokenHeader})
+    await expect(verifyAppleToken(token)).to.be.rejectedWith(UnauthorizedError)
+  })
+  it('should verifyAppleToken handle invalid token header', async () => {
+    const fakeKeyPayloadWithoutHeader = fakeKeyPayload
+    delete fakeKeyPayloadWithoutHeader.rsaPublicKey
+    jwksClientSigningKeyStub.returns(Promise.resolve(fakeKeyPayloadWithoutHeader))
+    const token = jwt.sign(fakeTokenPayload, fakePrivateKey)
+    await expect(verifyAppleToken(token)).to.be.rejectedWith(UnauthorizedError)
+  })
+  it('should verifyAppleToken handle invalid token', async () => {
+    await expect(verifyAppleToken('invalid-token')).to.be.rejectedWith(UnauthorizedError)
   })
 })

--- a/src/util/secretsmanager-helpers.test.ts
+++ b/src/util/secretsmanager-helpers.test.ts
@@ -1,0 +1,45 @@
+import chai from 'chai'
+import { getAppleConfig, getApplePrivateKey } from "./secretsmanager-helpers"
+import * as sinon from 'sinon'
+import * as SecretsManager from '../lib/vendor/AWS/SecretsManager'
+const expect = chai.expect
+
+describe('#Util:SecretsManager', () => {
+  let getSecretValueStub
+  beforeEach(() => {
+    getSecretValueStub = sinon.stub(SecretsManager, 'getSecretValue')
+  })
+  afterEach(() => {
+    getSecretValueStub.restore()
+  })
+  it('should getAppleConfig', async () => {
+    const jsonString = '{"client_id":"lifegames.OfflineMediaDownloader","team_id":"XXXXXX","redirect_uri":"","key_id":"XXXXXX","scope":"email name"}'
+    getSecretValueStub.returns(Promise.resolve({SecretString: jsonString}))
+    const responseOne = await getAppleConfig()
+    expect(responseOne).to.have.all.keys('client_id', 'team_id', 'redirect_uri', 'key_id', 'scope')
+    const responseTwo = await getAppleConfig()
+    expect(responseTwo).to.have.all.keys('client_id', 'team_id', 'redirect_uri', 'key_id', 'scope')
+    expect(responseOne).to.eql(responseTwo)
+    expect(getSecretValueStub.calledOnce)
+  })
+  it('should getApplePrivateKey', async () => {
+    const jsonString = '-----BEGIN PRIVATE KEY-----'
+    getSecretValueStub.returns(Promise.resolve({SecretString: jsonString}))
+    const responseOne = await getApplePrivateKey()
+    expect(responseOne).to.have.length.greaterThan(0)
+    const responseTwo = await getApplePrivateKey()
+    expect(responseTwo).to.have.length.greaterThan(0)
+    expect(responseOne).to.eql(responseTwo)
+    expect(getSecretValueStub.calledOnce)
+  })
+  it('should getServerPrivateKey', async () => {
+    const jsonString = '-----BEGIN PRIVATE KEY-----'
+    getSecretValueStub.returns(Promise.resolve({SecretString: jsonString}))
+    const responseOne = await getApplePrivateKey()
+    expect(responseOne).to.have.length.greaterThan(0)
+    const responseTwo = await getApplePrivateKey()
+    expect(responseTwo).to.have.length.greaterThan(0)
+    expect(responseOne).to.eql(responseTwo)
+    expect(getSecretValueStub.calledOnce)
+  })
+})

--- a/src/util/secretsmanager-helpers.ts
+++ b/src/util/secretsmanager-helpers.ts
@@ -1,5 +1,4 @@
 import axios, {AxiosRequestConfig} from 'axios'
-import querystring from 'querystring'
 import {getSecretValue} from '../lib/vendor/AWS/SecretsManager'
 import jwt, {SignOptions} from 'jsonwebtoken'
 import jwksClient from 'jwks-rsa'
@@ -34,7 +33,7 @@ export async function getApplePrivateKey(): Promise<string> {
 }
 
 export async function getServerPrivateKey(): Promise<string> {
-  if (PRIVATEKEY) {
+  if (PRIVATEKEY !== undefined) {
     return PRIVATEKEY
   }
   // This SecretId has to map to the CloudFormation file (LoginUser)
@@ -83,7 +82,7 @@ export async function validateAuthCodeForToken(authCode: string): Promise<AppleT
   const options: AxiosRequestConfig = {
     method: 'POST',
     url: 'https://appleid.apple.com/auth/token',
-    data: querystring.stringify(requestData),
+    data: new URLSearchParams(requestData).toString(),
     headers: {'Content-Type': 'application/x-www-form-urlencoded'}
   }
   logDebug('axios <=', options)
@@ -97,34 +96,43 @@ export async function validateAuthCodeForToken(authCode: string): Promise<AppleT
 export async function verifyAppleToken(token: string): Promise<SignInWithAppleVerifiedToken> {
   logInfo('verifyAppleToken')
   // decode the token (insecurely), to determine the appropriate public key
-  const decodedPayload = jwt.decode(token, {complete: true})
-  const kid = decodedPayload.header.kid
+  try {
+    const decodedPayload = jwt.decode(token, { complete: true })
+    logDebug('verifyAppleToken.decodedPayload', decodedPayload)
+    const kid = decodedPayload.header.kid
 
-  // Verify the nonce for the authentication
-  // Verify that the iss field contains https://appleid.apple.com
-  // Verify that the aud field is the developer’s client_id
-  // Verify that the time is earlier than the exp value of the token
+    // Verify the nonce for the authentication
+    // Verify that the iss field contains https://appleid.apple.com
+    // Verify that the aud field is the developer’s client_id
+    // Verify that the time is earlier than the exp value of the token
 
-  // lookup Apple's public keys (via JSON) and convert to a proper key file
-  const client = jwksClient({jwksUri: 'https://appleid.apple.com/auth/keys'})
-  const getSigningKey = promisify(client.getSigningKey)
-  const key = await getSigningKey(kid)
-  if ('rsaPublicKey' in key) {
-    try {
-      const jwtPayload = jwt.verify(token, key.rsaPublicKey) as SignInWithAppleVerifiedToken
-      logDebug('verifyAppleToken.jwtPayload <=', jwtPayload)
-      logDebug(`verifyAppleToken.jwtPayload.typeof <= ${typeof jwtPayload}`)
-      if (typeof jwtPayload === 'string') {
-        throw new UnauthorizedError('Invalid JWT payload')
+    // lookup Apple's public keys (via JSON) and convert to a proper key file
+    logInfo('verifyAppleToken.jwksClient')
+    const client = jwksClient({jwksUri: 'https://appleid.apple.com/auth/keys'})
+    const getSigningKey = promisify(client.getSigningKey)
+    const key = await getSigningKey(kid)
+    logDebug('verifyAppleToken.key', key)
+    if ('rsaPublicKey' in key) {
+      try {
+        const jwtPayload = jwt.verify(token, key.rsaPublicKey) as SignInWithAppleVerifiedToken
+        logDebug('verifyAppleToken.jwtPayload <=', jwtPayload)
+        logDebug(`verifyAppleToken.jwtPayload.typeof <= ${typeof jwtPayload}`)
+        if (typeof jwtPayload === 'string') {
+          throw new UnauthorizedError('Invalid JWT payload')
+        }
+        return jwtPayload
+      } catch (error) {
+        const message = `Token verification error: ${error.message}`
+        logError(`jwt.verify <= ${message}`)
+        throw new UnauthorizedError(message)
       }
-      return jwtPayload
-    } catch (error) {
-      const message = `Token verification error: ${error.message}`
+    } else {
+      const message = 'rsaPublicKey not present in payload'
       logError(`jwt.verify <= ${message}`)
       throw new UnauthorizedError(message)
     }
-  } else {
-    const message = 'rsaPublicKey not present in payload'
+  } catch (err) {
+    const message = 'Invalid token'
     logError(`jwt.verify <= ${message}`)
     throw new UnauthorizedError(message)
   }

--- a/src/util/secretsmanager-helpers.ts
+++ b/src/util/secretsmanager-helpers.ts
@@ -10,6 +10,11 @@ let APPLE_CONFIG
 let APPLE_PRIVATEKEY
 let PRIVATEKEY
 
+/**
+ * Retrieves the configuration (object) for Sign In With Apple via Secrets Manager or cache.
+ * @returns SignInWithAppleConfig - The configuration object
+ * @notExported
+ */
 export async function getAppleConfig(): Promise<SignInWithAppleConfig> {
   if (APPLE_CONFIG) {
     return APPLE_CONFIG
@@ -21,6 +26,11 @@ export async function getAppleConfig(): Promise<SignInWithAppleConfig> {
   return APPLE_CONFIG
 }
 
+/**
+ * Retrieves the private key for Sign In With Apple via Secrets Manager or cache.
+ * @returns string - The private key file
+ * @notExported
+ */
 export async function getApplePrivateKey(): Promise<string> {
   if (APPLE_PRIVATEKEY) {
     return APPLE_PRIVATEKEY
@@ -32,6 +42,11 @@ export async function getApplePrivateKey(): Promise<string> {
   return APPLE_PRIVATEKEY
 }
 
+/**
+ * Retrieves the private key for user-based login via Secrets Manager or cache.
+ * @returns string - The private key file
+ * @notExported
+ */
 export async function getServerPrivateKey(): Promise<string> {
   if (PRIVATEKEY !== undefined) {
     return PRIVATEKEY
@@ -46,6 +61,11 @@ export async function getServerPrivateKey(): Promise<string> {
   return PRIVATEKEY
 }
 
+/**
+ * Creates [a client secret](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens) for Sign In With Apple
+ * @returns string - A JSON Web Token (JWT)
+ * @notExported
+ */
 export async function getAppleClientSecret(): Promise<string> {
   const config = await getAppleConfig()
   const privateKey = await getApplePrivateKey()
@@ -65,6 +85,12 @@ export async function getAppleClientSecret(): Promise<string> {
   } as SignOptions)
 }
 
+/**
+ * Validates an authorization grant code for Sign In With Apple
+ * @param authCode - An authorization grant code.
+ * @returns AppleTokenResponse - An Apple [TokenResponse](https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse)
+ * @notExported
+ */
 export async function validateAuthCodeForToken(authCode: string): Promise<AppleTokenResponse> {
   logInfo('validateAuthCodeForToken')
   logDebug('getAppleClientSecret')
@@ -93,11 +119,18 @@ export async function validateAuthCodeForToken(authCode: string): Promise<AppleT
   return data
 }
 
+/**
+ * Fetches Apple's public key for verifying token signature, then verifies.
+ * Used during first-time registration or login.
+ * @param token - A JSON Web Token (JWT)
+ * @returns SignInWithAppleVerifiedToken - A verified token for Sign In With Apple.
+ * @notExported
+ */
 export async function verifyAppleToken(token: string): Promise<SignInWithAppleVerifiedToken> {
   logInfo('verifyAppleToken')
   // decode the token (insecurely), to determine the appropriate public key
   try {
-    const decodedPayload = jwt.decode(token, { complete: true })
+    const decodedPayload = jwt.decode(token, {complete: true})
     logDebug('verifyAppleToken.decodedPayload', decodedPayload)
     const kid = decodedPayload.header.kid
 
@@ -138,6 +171,11 @@ export async function verifyAppleToken(token: string): Promise<SignInWithAppleVe
   }
 }
 
+/**
+ * Creates an access token using server encryption key for user-login.
+ * @param userId - The userId to tokenize.
+ * @returns string - A JSON Web Token (JWT)
+ */
 export async function createAccessToken(userId: string): Promise<string> {
   const secret = await getServerPrivateKey()
   return jwt.sign({userId}, secret, {
@@ -145,6 +183,12 @@ export async function createAccessToken(userId: string): Promise<string> {
   })
 }
 
+/**
+ * Verifies an access token using server encryption key (user-login).
+ * @param token - A JSON Web Token (JWT)
+ * @returns ServerVerifiedToken - A verified token for user login.
+ * @notExported
+ */
 export async function verifyAccessToken(token: string): Promise<ServerVerifiedToken> {
   const secret = await getServerPrivateKey()
   try {

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -86,11 +86,28 @@ resource "aws_api_gateway_gateway_response" "Default500GatewayResponse" {
   }
 }
 
-resource "aws_iam_role" "GatewayLogRole" {
-  name               = "GatewayLogRole"
-  assume_role_policy = data.aws_iam_policy_document.LambdaGatewayAssumeRole.json
+resource "aws_iam_role" "ApiGatewayCloudwatchRole" {
+  name               = "ApiGatewayCloudwatchRole"
+  assume_role_policy = data.aws_iam_policy_document.ApiGatewayCloudwatchRole.json
+}
+
+data "aws_iam_policy_document" "ApiGatewayCloudwatchRole" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["apigateway.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "ApiGatewayCloudwatchRolePolicy" {
+  name   = "ApiGatewayCloudwatchRolePolicy"
+  role   = aws_iam_role.ApiGatewayCloudwatchRole.id
+  policy = data.aws_iam_policy_document.CommonLambdaLogging.json
 }
 
 resource "aws_api_gateway_account" "Main" {
-  cloudwatch_role_arn = aws_iam_role.GatewayLogRole.arn
+  cloudwatch_role_arn = aws_iam_role.ApiGatewayCloudwatchRole.arn
 }

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -94,7 +94,7 @@ resource "aws_iam_role" "ApiGatewayCloudwatchRole" {
 data "aws_iam_policy_document" "ApiGatewayCloudwatchRole" {
   statement {
     actions = ["sts:AssumeRole"]
-    effect = "Allow"
+    effect  = "Allow"
     principals {
       type        = "Service"
       identifiers = ["apigateway.amazonaws.com"]

--- a/terraform/file_bucket.tf
+++ b/terraform/file_bucket.tf
@@ -1,5 +1,9 @@
 resource "aws_s3_bucket" "Files" {
   bucket = "lifegames-media-downloader-files"
+}
+
+resource "aws_s3_bucket_acl" "Files" {
+  bucket = aws_s3_bucket.Files.id
   acl    = "public-read"
 }
 

--- a/terraform/list_files.tf
+++ b/terraform/list_files.tf
@@ -64,9 +64,9 @@ resource "aws_lambda_function" "ListFiles" {
       DynamoTableFiles       = aws_dynamodb_table.Files.name
       DynamoTableUserFiles   = aws_dynamodb_table.UserFiles.name
       DefaultFileSize        = 436743
-      DefaultFileName        = aws_s3_bucket_object.DefaultFile.key
-      DefaultFileUrl         = "https://${aws_s3_bucket_object.DefaultFile.bucket}.s3.amazonaws.com/${aws_s3_bucket_object.DefaultFile.key}"
-      DefaultFileContentType = aws_s3_bucket_object.DefaultFile.content_type
+      DefaultFileName        = aws_s3_object.DefaultFile.key
+      DefaultFileUrl         = "https://${aws_s3_object.DefaultFile.bucket}.s3.amazonaws.com/${aws_s3_object.DefaultFile.key}"
+      DefaultFileContentType = aws_s3_object.DefaultFile.content_type
     }
   }
 }
@@ -111,8 +111,8 @@ data "local_file" "DefaultFile" {
   filename = "${path.module}/../static/videos/default-file.mp4"
 }
 
-resource "aws_s3_bucket_object" "DefaultFile" {
-  bucket       = aws_s3_bucket.Files.bucket
+resource "aws_s3_object" "DefaultFile" {
+  bucket       = aws_s3_bucket.Files.id
   content_type = "video/mp4"
   key          = "default-file.mp4"
   source       = data.local_file.DefaultFile.filename

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
 provider "aws" {
   profile = "default"
   region  = "us-west-2"

--- a/terraform/user_subscribe.tf
+++ b/terraform/user_subscribe.tf
@@ -5,7 +5,7 @@ resource "aws_iam_role" "UserSubscribeRole" {
 
 data "aws_iam_policy_document" "UserSubscribe" {
   statement {
-    actions = [ "sns:Subscribe" ]
+    actions = ["sns:Subscribe"]
     resources = compact([
       aws_sns_topic.PushNotifications.arn,
       length(aws_sns_platform_application.OfflineMediaDownloader) == 1 ? aws_sns_platform_application.OfflineMediaDownloader[0].arn : ""
@@ -57,7 +57,7 @@ resource "aws_lambda_function" "UserSubscribe" {
 
   environment {
     variables = {
-      PlatformApplicationArn   = length(aws_sns_platform_application.OfflineMediaDownloader) == 1 ? aws_sns_platform_application.OfflineMediaDownloader[0].arn : ""
+      PlatformApplicationArn = length(aws_sns_platform_application.OfflineMediaDownloader) == 1 ? aws_sns_platform_application.OfflineMediaDownloader[0].arn : ""
     }
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,15 +1,15 @@
 {
   "entryPoints": ["src"],
   "exclude": [
-    "**/*+(index|.spec|.e2e|.test).ts",
+    "**/*+(.spec|.e2e|.test).ts",
     "src/pipeline/terraform.environment.test.ts"
   ],
   "banish": [
-    "**/*+(index|.spec|.e2e|.test).ts",
+    "**/*+(.spec|.e2e|.test).ts",
     "src/pipeline/terraform.environment.test.ts"
   ],
   "externalPattern": [
-    "**/*+(index|.spec|.e2e|.test).ts",
+    "**/*+(.spec|.e2e|.test).ts",
     "src/pipeline/terraform.environment.test.ts"
   ],
   "excludeExternals": true,


### PR DESCRIPTION
This PR is a hodge-podge of changes following dependency upgrades. It includes increased unit test coverage, removing deprecated dependencies, and various quality of life improvements.

## Changes made

- [x] Changed `attributedAt` to be a `Number` instead of a string
- [x] Revised handling of the role for the `aws_api_gateway_account` resource in Terraform
- [x] Moved the `mocha` configuration to the `config` directory
- [x] Updated code coverage to ignore certain files
- [x] Updated the entry point strategy for TypeDoc configuration
- [x] Improved unit test coverage; mostly through SecretsManager testing
- [x] Removed usage of `querystring` and replaced with `URLSearchParams`
- [x] Added JsDoc to SecretsManager helper methods
- [x] Upgraded Terraform to latest
- [x] Upgraded Terraform aws provider to latest