### PR TITLE
fix: prevent wiki sync failure on files without markdown links

### DIFF
--- a/.github/scripts/sync-wiki.sh
+++ b/.github/scripts/sync-wiki.sh
@@ -116,8 +116,8 @@ validate_wiki() {
     broken_links=0
 
     find "$WIKI_DIR" -type f -name "*.md" | while read -r file; do
-        # Extract all markdown links
-        grep -o '\[.*\]([^)]*)'  "$file" 2>/dev/null | grep -o '([^)]*)' | tr -d '()' | while read -r link; do
+        # Extract all markdown links (allow grep to return no matches without failing)
+        (grep -o '\[.*\]([^)]*)'  "$file" 2>/dev/null || true) | (grep -o '([^)]*)' || true) | tr -d '()' | while read -r link; do
             # Skip external links
             if [[ "$link" =~ ^https?:// ]] || [[ "$link" =~ ^# ]]; then
                 continue
@@ -134,7 +134,7 @@ validate_wiki() {
                     ((broken_links++))
                 fi
             fi
-        done
+        done || true  # while read returns 1 on EOF, don't fail the script
     done
 
     if [ $broken_links -eq 0 ]; then


### PR DESCRIPTION
## Summary

Fixes the wiki sync workflow failure that occurred after merging PR #109. The `sync-wiki.yml` GitHub Action was failing during the link validation step when processing markdown files that contain no links.

## Root Cause

The `sync-wiki.sh` script uses `set -euo pipefail` for strict error handling. Three issues caused premature script termination:

1. **First grep failure**: When `grep -o '\[.*\]([^)]*)'` finds no links in a file, it returns exit code 1
2. **Second grep failure**: When the first grep produces empty output, the second `grep -o '([^)]*)'` also returns exit code 1  
3. **while-read EOF behavior**: The `while read` loop returns exit code 1 when reaching EOF (normal termination)

With `pipefail` enabled, any command in the pipeline returning non-zero causes the entire script to exit.

## Changes

Modified `.github/scripts/sync-wiki.sh` line 120:

**Before:**
```bash
grep -o '\[.*\]([^)]*)'  "$file" 2>/dev/null | grep -o '([^)]*)' | tr -d '()' | while read -r link; do
```

**After:**
```bash
(grep -o '\[.*\]([^)]*)'  "$file" 2>/dev/null || true) | (grep -o '([^)]*)' || true) | tr -d '()' | while read -r link; do
    # ...
done || true  # while read returns 1 on EOF, don't fail the script
```

## Testing

Local testing confirms:
- ✅ Script completes successfully with files containing no links
- ✅ Script still validates and reports all broken links (51 found)
- ✅ Script processes all 17 markdown files across 9 categories
- ✅ Exit code 0 (success) instead of 1 (failure)

## Impact

This unblocks the wiki sync automation introduced in PR #109. The workflow will now:
- Successfully sync `docs/wiki/` content to GitHub Wiki
- Report broken links as warnings without failing deployment
- Auto-generate sidebar navigation
- Provide searchable web interface for conventions

## Note

The `broken_links` counter still shows "✅ No broken links found" despite reporting 51 broken links. This is a pre-existing bug (variable scope in subshell from pipeline) and is out of scope for this fix. The links are still being reported in the output for awareness.