### PR TITLE
fix: expand wiki sync workflow trigger to include script changes

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - 'docs/wiki/**'
+      - '.github/scripts/sync-wiki.sh'
+      - '.github/scripts/generate-sidebar.sh'
+      - '.github/workflows/sync-wiki.yml'
   workflow_dispatch:  # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
## Summary

Expands the `sync-wiki.yml` workflow trigger paths to include the sync scripts themselves, ensuring changes to the wiki sync system are automatically tested in CI.

## Problem

The workflow currently only triggers on changes to `docs/wiki/**`, which means:
- ❌ PR #112 (sync-wiki.sh fix) didn't trigger the workflow
- ❌ The sidebar script fix (generate-sidebar.sh) wasn't tested in CI
- ❌ Both bugs had to be discovered through manual testing
- ❌ Workflow changes themselves don't trigger validation

## Root Cause

**Workflow trigger configuration (lines 8-9):**
```yaml
paths:
  - 'docs/wiki/**'
```

This is too narrow. Changes to the scripts that **process** the wiki content should also trigger the workflow to validate they work correctly.

## Changes

Added three paths to the workflow trigger:

```yaml
paths:
  - 'docs/wiki/**'                          # Existing: wiki content
  - '.github/scripts/sync-wiki.sh'          # NEW: main sync script
  - '.github/scripts/generate-sidebar.sh'   # NEW: sidebar generation
  - '.github/workflows/sync-wiki.yml'       # NEW: workflow itself
```

## Benefits

1. **Automatic testing**: Script changes trigger CI validation
2. **Earlier bug detection**: Syntax errors caught before merge
3. **Self-validating**: Workflow changes trigger a test run
4. **Reduced manual work**: No need to remember `gh workflow run sync-wiki.yml`

## Impact

**If this had been in place:**
- PR #112's grep fix would have triggered the workflow automatically
- The bash syntax error in generate-sidebar.sh would have been caught in CI
- Both bugs would have been detected before requiring manual intervention

**After this PR:**
- Any changes to sync-wiki.sh will automatically test the sync
- Any changes to generate-sidebar.sh will automatically test sidebar generation
- Any changes to the workflow itself will validate the updated configuration

## Testing

This PR itself will trigger the workflow due to the `.github/workflows/sync-wiki.yml` path being added. You can verify:

```bash
gh run list --workflow=sync-wiki.yml --limit 3
```

The workflow should run and succeed, validating that the trigger expansion works correctly.

## Notes

- ✅ No changes to workflow behavior, only when it runs
- ✅ Manual triggering via `workflow_dispatch` still supported
- ✅ Backward compatible with existing content triggers