### PR TITLE
fix: add missing || true to while-read loops in process substitution

### DIFF
--- a/.github/scripts/sync-wiki.sh
+++ b/.github/scripts/sync-wiki.sh
@@ -138,8 +138,8 @@ validate_wiki() {
                     ((broken_links++))
                 fi
             fi
-        done < <((grep -o '\[.*\]([^)]*)'  "$file" 2>/dev/null || true) | (grep -o '([^)]*)' || true) | tr -d '()')
-    done < <(find "$WIKI_DIR" -type f -name "*.md")
+        done < <((grep -o '\[.*\]([^)]*)'  "$file" 2>/dev/null || true) | (grep -o '([^)]*)' || true) | tr -d '()') || true
+    done < <(find "$WIKI_DIR" -type f -name "*.md") || true
 
     if [ $broken_links -eq 0 ]; then
         echo "  ✅ No broken links found"


### PR DESCRIPTION
## Summary

Fixes the wiki sync workflow that started failing after PR #114. The script was exiting on the first broken link instead of processing all files and reporting the total count.

## Problem

**After merging PR #114, the workflow fails:**
```
  - Checking for broken internal links...
    ⚠️ Broken link in Coverage-Philosophy.md: Integration-Testing
  ##[error]Process completed with exit code 1
```

The script exits immediately instead of checking all files and reporting the summary.

## Root Cause

**Missing `|| true` on while-read loops:**

When using process substitution with `while read`, the loop returns exit code 1 when it reaches EOF (normal termination). With `set -euo pipefail`, this causes immediate script failure.

PR #114 switched from pipeline syntax to process substitution:
```bash
# Old (pipeline): Subshell created, but || true at end
find ... | while read; do ... done || true

# New (process sub): No subshell, but missing || true
while read; do ... done < <(find ...)
```

The `|| true` was on the outer loop in the original code, but **both** loops need it with process substitution because both while-read loops return 1 on EOF.

## Changes

**Modified `.github/scripts/sync-wiki.sh` lines 141-142:**

```bash
        done < <(...) || true  # Inner loop needs || true
    done < <(find ...) || true  # Outer loop needs || true
```

## Testing

**Before (exit on first broken link):**
```
$ bash sync-wiki.sh
  - Checking for broken internal links...
    ⚠️ Broken link in Coverage-Philosophy.md: Integration-Testing
  [script exits with code 1]
```

**After (processes all files):**
```
$ bash sync-wiki.sh
  - Checking for broken internal links...
    ⚠️ Broken link in Coverage-Philosophy.md: Integration-Testing
    ⚠️ Broken link in Jest-ESM-Mocking-Strategy.md: Lazy-Initialization-Pattern
    ... (49 more)
  ⚠️ Found 51 broken link(s)
✅ Validation complete
✨ Wiki sync completed successfully!
```

## Impact

- ✅ Workflow succeeds instead of failing on first broken link
- ✅ Full broken link report (51 links) shown
- ✅ Wiki syncs complete successfully
- ✅ Broken links counter works correctly (from PR #114)

## Related

- Fixes regression introduced in PR #114
- Completes the broken links counter fix from PR #114
- Required for wiki sync automation to work properly
