### PR TITLE
feat(mcp): add convention querying and validation tools

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "media-downloader": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["tsx", "src/mcp/server.ts"]
+    }
+  }
+}

--- a/docs/wiki/MCP/Convention-Tools.md
+++ b/docs/wiki/MCP/Convention-Tools.md
@@ -1,0 +1,198 @@
+# MCP Convention Tools
+
+## Quick Reference
+- **When to use**: AI assistants querying project conventions and validating code
+- **Enforcement**: Automated via MCP server and optional CI integration
+- **Impact if violated**: Varies by rule severity (CRITICAL to LOW)
+
+## Overview
+
+The MCP server provides 5 tools for convention querying and code validation:
+
+| Tool | Purpose | Primary Use Case |
+|------|---------|-----------------|
+| `query_conventions` | Search project conventions | Understanding rules before coding |
+| `validate_pattern` | AST-based code validation | Checking code against conventions |
+| `check_coverage` | Mock analysis for tests | Identifying required Jest mocks |
+| `lambda_impact` | Dependency impact analysis | Understanding change scope |
+| `suggest_tests` | Test scaffolding generation | Creating new test files |
+
+## Tool Details
+
+### query_conventions
+
+Search and filter project conventions from `docs/conventions-tracking.md` and wiki pages.
+
+**Query Types:**
+- `list` - List all conventions grouped by severity
+- `search` - Full-text search across conventions and wiki
+- `category` - Filter by category (testing, aws, typescript, etc.)
+- `enforcement` - Filter by severity (CRITICAL, HIGH, MEDIUM, LOW)
+- `detail` - Get full details for a specific convention
+- `wiki` - List or search wiki documentation
+
+**Examples:**
+```typescript
+// Find all testing conventions
+query_conventions({ query: "category", category: "testing" })
+
+// Search for mock-related conventions
+query_conventions({ query: "search", term: "mock" })
+
+// Get CRITICAL rules that must not be violated
+query_conventions({ query: "enforcement", severity: "CRITICAL" })
+```
+
+### validate_pattern
+
+Validate TypeScript files against project conventions using AST analysis (ts-morph).
+
+**Query Types:**
+- `rules` - List all available validation rules
+- `all` - Run all applicable validations on a file
+- `aws-sdk` - Check AWS SDK encapsulation (CRITICAL)
+- `electrodb` - Check ElectroDB mocking patterns (CRITICAL)
+- `imports` - Check import ordering (MEDIUM)
+- `response` - Check response helper usage (HIGH)
+- `summary` - Concise validation summary
+
+**Validation Rules:**
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| aws-sdk-encapsulation | CRITICAL | No direct AWS SDK imports outside lib/vendor/AWS/ |
+| electrodb-mocking | CRITICAL | Test files must use createElectroDBEntityMock() |
+| response-helpers | HIGH | Lambda handlers must use response() helper |
+| import-order | MEDIUM | Imports grouped: node → aws-lambda → external → entities → vendor → types → utilities → relative |
+
+**Examples:**
+```typescript
+// Full validation of a Lambda handler
+validate_pattern({ file: "src/lambdas/ListFiles/src/index.ts", query: "all" })
+
+// Check only AWS SDK encapsulation
+validate_pattern({ file: "src/lambdas/ListFiles/src/index.ts", query: "aws-sdk" })
+
+// List all available rules
+validate_pattern({ query: "rules" })
+```
+
+### check_coverage
+
+Analyze which dependencies need mocking for Jest tests using build/graph.json.
+
+**Query Types:**
+- `required` - List all dependencies that need mocking
+- `missing` - Compare required mocks to existing test file
+- `all` - Full analysis with categorization
+- `summary` - Quick summary of mock requirements
+
+**Dependency Categories:**
+- **Entities**: ElectroDB entities (use createElectroDBEntityMock)
+- **Vendors**: AWS SDK wrappers (lib/vendor/AWS/*)
+- **Utilities**: Shared helpers (util/*)
+- **External**: Third-party packages
+
+**Examples:**
+```typescript
+// Get all mocks needed for a Lambda
+check_coverage({ file: "src/lambdas/ListFiles/src/index.ts", query: "required" })
+
+// Find missing mocks in existing test
+check_coverage({ file: "src/lambdas/ListFiles/src/index.ts", query: "missing" })
+```
+
+### lambda_impact
+
+Show what's affected by changing a file - dependents, tests, and infrastructure.
+
+**Query Types:**
+- `dependents` - Direct files that import this file
+- `cascade` - Full transitive dependency cascade
+- `tests` - Test files that need updating
+- `infrastructure` - Terraform files that may be affected
+- `all` - Comprehensive impact analysis
+
+**Examples:**
+```typescript
+// See what's affected by changing an entity
+lambda_impact({ file: "src/entities/Files.ts", query: "cascade" })
+
+// Find tests that need updating
+lambda_impact({ file: "src/util/lambda-helpers.ts", query: "tests" })
+
+// Full impact analysis
+lambda_impact({ file: "src/entities/Users.ts", query: "all" })
+```
+
+### suggest_tests
+
+Generate test file scaffolding with all required mocks based on dependency analysis.
+
+**Query Types:**
+- `scaffold` - Complete test file with all mocks
+- `mocks` - Just the mock setup section
+- `fixtures` - Suggested test fixtures
+- `structure` - Test structure outline (describe/it blocks)
+
+**Examples:**
+```typescript
+// Generate complete test file
+suggest_tests({ file: "src/lambdas/NewLambda/src/index.ts", query: "scaffold" })
+
+// Get just the mock setup
+suggest_tests({ file: "src/lambdas/NewLambda/src/index.ts", query: "mocks" })
+```
+
+## CI Integration
+
+The validation rules in `src/mcp/validation/` are designed for reuse in CI pipelines:
+
+```typescript
+import { validateFile, allRules } from './src/mcp/validation/index.js'
+
+// Validate a file
+const result = await validateFile('src/lambdas/ListFiles/src/index.ts')
+
+// Check for CRITICAL violations
+const critical = result.violations.filter(v => v.severity === 'CRITICAL')
+if (critical.length > 0) {
+  process.exit(1)
+}
+```
+
+## Architecture
+
+```
+src/mcp/
+├── server.ts              # MCP server with tool definitions
+├── README.md              # Tool documentation
+├── handlers/
+│   ├── conventions.ts     # query_conventions handler
+│   ├── coverage.ts        # check_coverage handler
+│   ├── validation.ts      # validate_pattern handler
+│   ├── impact.ts          # lambda_impact handler
+│   ├── test-scaffold.ts   # suggest_tests handler
+│   └── data-loader.ts     # Shared data loading with caching
+├── parsers/
+│   └── convention-parser.ts  # Convention file parser
+└── validation/
+    ├── types.ts           # Shared validation types
+    ├── index.ts           # Unified validation interface
+    └── rules/
+        ├── aws-sdk-encapsulation.ts
+        ├── electrodb-mocking.ts
+        ├── import-order.ts
+        └── response-helpers.ts
+```
+
+## Related Documentation
+
+- [Dependency Graph Analysis](../Testing/Dependency-Graph-Analysis.md) - build/graph.json usage
+- [Jest ESM Mocking Strategy](../Testing/Jest-ESM-Mocking-Strategy.md) - Mocking patterns
+- [SDK Encapsulation Policy](../AWS/SDK-Encapsulation-Policy.md) - AWS SDK rules
+- [ElectroDB Testing Patterns](../Testing/ElectroDB-Testing-Patterns.md) - Entity mocking
+
+---
+
+*Use these MCP tools to understand and validate code against project conventions before implementation.*

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,8 @@ export default [
       'src/types/terraform.d.ts',
       'src/types/infrastructure.d.ts',
       'eslint.config.mjs',
-      '.dependency-cruiser.cjs'
+      '.dependency-cruiser.cjs',
+      'src/mcp/test/fixtures/**/*'
     ]
   },
   ...compat.extends('eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended', 'plugin:@typescript-eslint/recommended'),

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -100,6 +100,65 @@ query_dependencies({
 })                                                      // Get all transitive dependencies
 ```
 
+### 5. query_conventions
+Search project conventions and wiki documentation.
+
+```typescript
+// Examples:
+query_conventions({ query: "list" })                    // List all conventions by severity
+query_conventions({ query: "search", term: "mock" })    // Search conventions and wiki
+query_conventions({ query: "category", category: "testing" }) // Filter by category
+query_conventions({ query: "enforcement", severity: "CRITICAL" }) // Get critical rules
+query_conventions({ query: "detail", convention: "AWS SDK" }) // Get full convention details
+query_conventions({ query: "wiki" })                    // List all wiki pages
+```
+
+### 6. validate_pattern
+Validate code against project conventions using AST analysis.
+
+```typescript
+// Examples:
+validate_pattern({ query: "rules" })                    // List all validation rules
+validate_pattern({ file: "src/lambdas/ListFiles/src/index.ts", query: "all" }) // Full validation
+validate_pattern({ file: "src/lambdas/ListFiles/src/index.ts", query: "aws-sdk" }) // Check SDK encapsulation
+validate_pattern({ file: "src/lambdas/ListFiles/test/index.test.ts", query: "electrodb" }) // Check ElectroDB mocking
+validate_pattern({ file: "src/lambdas/ListFiles/src/index.ts", query: "summary" }) // Concise summary
+```
+
+### 7. check_coverage
+Analyze which dependencies need mocking for Jest tests.
+
+```typescript
+// Examples:
+check_coverage({ file: "src/lambdas/ListFiles/src/index.ts", query: "required" }) // List mocks needed
+check_coverage({ file: "src/lambdas/ListFiles/src/index.ts", query: "missing" })  // Compare to existing test
+check_coverage({ file: "src/lambdas/ListFiles/src/index.ts", query: "all" })      // Full analysis
+check_coverage({ file: "src/lambdas/ListFiles/src/index.ts", query: "summary" })  // Quick summary
+```
+
+### 8. lambda_impact
+Show what's affected by changing a file.
+
+```typescript
+// Examples:
+lambda_impact({ file: "src/entities/Files.ts", query: "dependents" })  // Direct dependents
+lambda_impact({ file: "src/entities/Files.ts", query: "cascade" })     // Full cascade
+lambda_impact({ file: "src/entities/Files.ts", query: "tests" })       // Tests to update
+lambda_impact({ file: "src/entities/Files.ts", query: "infrastructure" }) // Terraform files
+lambda_impact({ file: "src/util/lambda-helpers.ts", query: "all" })    // Comprehensive analysis
+```
+
+### 9. suggest_tests
+Generate test file scaffolding with all required mocks.
+
+```typescript
+// Examples:
+suggest_tests({ file: "src/lambdas/ListFiles/src/index.ts", query: "scaffold" }) // Complete test file
+suggest_tests({ file: "src/lambdas/ListFiles/src/index.ts", query: "mocks" })    // Just mock setup
+suggest_tests({ file: "src/lambdas/ListFiles/src/index.ts", query: "fixtures" }) // Suggested fixtures
+suggest_tests({ file: "src/lambdas/ListFiles/src/index.ts", query: "structure" }) // Test structure outline
+```
+
 ## Usage Examples
 
 ### Understanding Entity Relationships

--- a/src/mcp/handlers/conventions.ts
+++ b/src/mcp/handlers/conventions.ts
@@ -1,0 +1,204 @@
+/**
+ * Convention query handler for MCP server
+ * Provides access to project conventions from conventions-tracking.md and wiki
+ *
+ * Data is dynamically loaded from:
+ * - docs/conventions-tracking.md (structured convention registry)
+ * - docs/wiki/ (detailed documentation pages)
+ */
+
+import {discoverWikiPages, loadConventions, loadWikiPage, searchWikiPages} from './data-loader.js'
+import {filterByCategory, filterBySeverity, searchConventions, type ConventionCategory, type ConventionSeverity} from '../parsers/convention-parser.js'
+
+export type ConventionQueryType = 'list' | 'search' | 'category' | 'enforcement' | 'detail' | 'wiki'
+
+export interface ConventionQueryArgs {
+  query: ConventionQueryType
+  term?: string
+  category?: ConventionCategory
+  severity?: ConventionSeverity
+  convention?: string
+}
+
+export async function handleConventionsQuery(args: ConventionQueryArgs) {
+  const {query, term, category, severity, convention} = args
+
+  // Load conventions dynamically
+  const conventions = await loadConventions()
+
+  switch (query) {
+    case 'list': {
+      // Return all conventions with summary info
+      const summary = conventions.map((c) => ({
+        name: c.name,
+        type: c.type,
+        category: c.category,
+        severity: c.severity,
+        status: c.status,
+        enforcement: c.enforcement,
+        wikiPath: c.wikiPath
+      }))
+
+      // Group by severity for easier reading
+      const bySeverity = {
+        CRITICAL: summary.filter((c) => c.severity === 'CRITICAL'),
+        HIGH: summary.filter((c) => c.severity === 'HIGH'),
+        MEDIUM: summary.filter((c) => c.severity === 'MEDIUM'),
+        LOW: summary.filter((c) => c.severity === 'LOW')
+      }
+
+      return {
+        conventions: bySeverity,
+        count: conventions.length,
+        summary: {critical: bySeverity.CRITICAL.length, high: bySeverity.HIGH.length, medium: bySeverity.MEDIUM.length, low: bySeverity.LOW.length}
+      }
+    }
+
+    case 'search': {
+      if (!term) {
+        return {error: 'Search term required for search query', example: {query: 'search', term: 'mock'}}
+      }
+
+      // Search conventions
+      const conventionMatches = searchConventions(conventions, term)
+
+      // Also search wiki pages
+      const wikiMatches = await searchWikiPages(term)
+
+      return {
+        term,
+        conventionMatches: conventionMatches.map((c) => ({name: c.name, severity: c.severity, what: c.what, wikiPath: c.wikiPath})),
+        wikiMatches: wikiMatches.slice(0, 10), // Limit wiki results
+        totalConventions: conventionMatches.length,
+        totalWikiPages: wikiMatches.length
+      }
+    }
+
+    case 'category': {
+      if (!category) {
+        // List available categories with counts
+        const categories: Record<string, number> = {}
+        for (const c of conventions) {
+          categories[c.category] = (categories[c.category] || 0) + 1
+        }
+        return {availableCategories: Object.keys(categories).sort(), counts: categories, example: {query: 'category', category: 'testing'}}
+      }
+
+      const filtered = filterByCategory(conventions, category)
+      return {
+        category,
+        conventions: filtered.map((c) => ({name: c.name, severity: c.severity, what: c.what, enforcement: c.enforcement})),
+        count: filtered.length
+      }
+    }
+
+    case 'enforcement': {
+      if (!severity) {
+        // Return conventions grouped by severity
+        return {
+          CRITICAL: filterBySeverity(conventions, 'CRITICAL').map((c) => ({name: c.name, what: c.what, enforcement: c.enforcement})),
+          HIGH: filterBySeverity(conventions, 'HIGH').map((c) => ({name: c.name, what: c.what, enforcement: c.enforcement})),
+          MEDIUM: filterBySeverity(conventions, 'MEDIUM').map((c) => ({name: c.name, what: c.what})),
+          availableSeverities: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'],
+          example: {query: 'enforcement', severity: 'CRITICAL'}
+        }
+      }
+
+      const filtered = filterBySeverity(conventions, severity)
+      return {
+        severity,
+        conventions: filtered.map((c) => ({name: c.name, what: c.what, why: c.why, enforcement: c.enforcement, wikiPath: c.wikiPath})),
+        count: filtered.length
+      }
+    }
+
+    case 'detail': {
+      if (!convention) {
+        return {
+          error: 'Convention name required for detail query',
+          availableConventions: conventions.map((c) => c.name),
+          example: {query: 'detail', convention: 'AWS SDK Encapsulation Policy'}
+        }
+      }
+
+      // Find convention by name (case-insensitive partial match)
+      const conventionLower = convention.toLowerCase()
+      const match = conventions.find((c) => c.name.toLowerCase().includes(conventionLower))
+
+      if (!match) {
+        return {error: `Convention '${convention}' not found`, availableConventions: conventions.map((c) => c.name)}
+      }
+
+      // If wiki path exists, load the full documentation
+      let wikiContent: string | undefined
+      if (match.wikiPath) {
+        try {
+          wikiContent = await loadWikiPage(match.wikiPath)
+        } catch {
+          wikiContent = `Wiki page not found at: ${match.wikiPath}`
+        }
+      }
+
+      return {
+        convention: {
+          name: match.name,
+          type: match.type,
+          category: match.category,
+          severity: match.severity,
+          status: match.status,
+          what: match.what,
+          why: match.why,
+          enforcement: match.enforcement,
+          detectedDate: match.detectedDate,
+          wikiPath: match.wikiPath
+        },
+        wikiContent: wikiContent ? wikiContent.substring(0, 3000) : undefined // Limit content size
+      }
+    }
+
+    case 'wiki': {
+      // List all wiki pages or get specific page content
+      if (!term) {
+        const pages = await discoverWikiPages()
+
+        // Group by directory
+        const byDirectory: Record<string, string[]> = {}
+        for (const page of pages) {
+          const parts = page.split('/')
+          const dir = parts.length > 3 ? parts[2] : 'root' // docs/wiki/[Category]/
+          if (!byDirectory[dir]) {
+            byDirectory[dir] = []
+          }
+          byDirectory[dir].push(page)
+        }
+
+        return {totalPages: pages.length, byDirectory, example: {query: 'wiki', term: 'docs/wiki/Testing/Jest-ESM-Mocking-Strategy.md'}}
+      }
+
+      // Load specific page
+      try {
+        const content = await loadWikiPage(term)
+        return {
+          path: term,
+          content: content.substring(0, 5000) // Limit content size
+        }
+      } catch {
+        return {error: `Wiki page not found: ${term}`}
+      }
+    }
+
+    default:
+      return {
+        error: `Unknown query: ${query}`,
+        availableQueries: ['list', 'search', 'category', 'enforcement', 'detail', 'wiki'],
+        examples: [
+          {query: 'list'},
+          {query: 'search', term: 'mock'},
+          {query: 'category', category: 'testing'},
+          {query: 'enforcement', severity: 'CRITICAL'},
+          {query: 'detail', convention: 'AWS SDK Encapsulation'},
+          {query: 'wiki'}
+        ]
+      }
+  }
+}

--- a/src/mcp/handlers/coverage.ts
+++ b/src/mcp/handlers/coverage.ts
@@ -1,0 +1,224 @@
+/**
+ * Coverage analysis handler for MCP server
+ * Analyzes which dependencies need mocking for Jest tests
+ *
+ * Uses build/graph.json for transitive dependency analysis
+ */
+
+import fs from 'fs/promises'
+import path from 'path'
+import {discoverEntities, loadDependencyGraph} from './data-loader.js'
+
+export type CoverageQueryType = 'required' | 'missing' | 'all' | 'summary'
+
+export interface CoverageQueryArgs {
+  file: string
+  query: CoverageQueryType
+}
+
+interface MockCategory {
+  entities: Array<{name: string; path: string; mockHelper: string}>
+  vendors: Array<{name: string; path: string; exports?: string[]}>
+  external: Array<{name: string; suggestion: string}>
+  utilities: Array<{path: string; needsMock: boolean; reason?: string}>
+}
+
+/**
+ * Categorize a dependency for mocking purposes
+ */
+function categorizeDependency(dep: string, entityNames: string[]): {category: keyof MockCategory; name: string; details: Record<string, unknown>} | null {
+  // Entity files
+  const entityMatch = dep.match(/src\/entities\/(\w+)/)
+  if (entityMatch) {
+    const entityName = entityMatch[1]
+    if (entityNames.includes(entityName)) {
+      return {category: 'entities', name: entityName, details: {path: dep, mockHelper: 'createElectroDBEntityMock()'}}
+    }
+  }
+
+  // AWS Vendor wrappers
+  const awsVendorMatch = dep.match(/src\/lib\/vendor\/AWS\/(\w+)/)
+  if (awsVendorMatch) {
+    return {category: 'vendors', name: `AWS/${awsVendorMatch[1]}`, details: {path: dep}}
+  }
+
+  // Other vendor wrappers
+  const vendorMatch = dep.match(/src\/lib\/vendor\/(\w+)/)
+  if (vendorMatch && !dep.includes('/AWS/')) {
+    return {category: 'vendors', name: vendorMatch[1], details: {path: dep}}
+  }
+
+  // Utilities that typically need mocking
+  const utilsNeedingMocks = ['lambda-helpers', 'logging', 'errors', 'env-validation']
+  const utilMatch = dep.match(/src\/util\/(\w+[-\w]*)/)
+  if (utilMatch) {
+    const utilName = utilMatch[1]
+    const needsMock = utilsNeedingMocks.some((u) => utilName.includes(u))
+    return {
+      category: 'utilities',
+      name: utilName,
+      details: {path: dep, needsMock, reason: needsMock ? 'Contains external dependencies or environment access' : undefined}
+    }
+  }
+
+  return null
+}
+
+/**
+ * Analyze an existing test file for current mocks
+ */
+async function analyzeExistingTestMocks(testFilePath: string): Promise<string[]> {
+  try {
+    const content = await fs.readFile(testFilePath, 'utf-8')
+    const mocks: string[] = []
+
+    // Find jest.unstable_mockModule calls
+    const mockModulePattern = /jest\.unstable_mockModule\s*\(\s*['"]([^'"]+)['"]/g
+    let match
+    while ((match = mockModulePattern.exec(content)) !== null) {
+      mocks.push(match[1])
+    }
+
+    // Find jest.mock calls
+    const jestMockPattern = /jest\.mock\s*\(\s*['"]([^'"]+)['"]/g
+    while ((match = jestMockPattern.exec(content)) !== null) {
+      mocks.push(match[1])
+    }
+
+    return mocks
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Convert file path to test file path
+ */
+function getTestFilePath(filePath: string): string {
+  // src/lambdas/Name/src/index.ts -> src/lambdas/Name/test/index.test.ts
+  return filePath.replace('/src/', '/test/').replace(/\.ts$/, '.test.ts')
+}
+
+export async function handleCoverageQuery(args: CoverageQueryArgs) {
+  const {file, query} = args
+
+  if (!file) {
+    return {error: 'File path required', example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'required'}}
+  }
+
+  // Load dependency graph and entity names
+  const [depGraph, entityNames] = await Promise.all([loadDependencyGraph(), discoverEntities()])
+
+  // Get transitive dependencies for the file
+  const transitiveDeps = depGraph.transitiveDependencies[file] || []
+
+  if (transitiveDeps.length === 0) {
+    // Try to find the file in the graph with different path formats
+    const possiblePaths = Object.keys(depGraph.transitiveDependencies).filter((k) => k.includes(file) || file.includes(k))
+
+    if (possiblePaths.length > 0) {
+      return {error: `File not found exactly as '${file}'. Did you mean one of these?`, suggestions: possiblePaths.slice(0, 5)}
+    }
+
+    return {
+      error: `File '${file}' not found in dependency graph`,
+      hint: 'Make sure the file path is relative to project root (e.g., src/lambdas/ListFiles/src/index.ts)',
+      availableFiles: Object.keys(depGraph.transitiveDependencies).filter((k) => k.includes('lambdas')).slice(0, 10)
+    }
+  }
+
+  // Categorize all dependencies
+  const mockAnalysis: MockCategory = {entities: [], vendors: [], external: [], utilities: []}
+
+  for (const dep of transitiveDeps) {
+    const categorized = categorizeDependency(dep, entityNames)
+    if (categorized) {
+      const {category, name, details} = categorized
+      if (category === 'entities') {
+        mockAnalysis.entities.push({name, path: details.path as string, mockHelper: details.mockHelper as string})
+      } else if (category === 'vendors') {
+        mockAnalysis.vendors.push({name, path: details.path as string})
+      } else if (category === 'utilities') {
+        mockAnalysis.utilities.push({path: details.path as string, needsMock: details.needsMock as boolean, reason: details.reason as string | undefined})
+      }
+    }
+  }
+
+  switch (query) {
+    case 'required': {
+      // Return what needs to be mocked
+      return {
+        file,
+        transitiveDependencyCount: transitiveDeps.length,
+        mockingRequired: {entities: mockAnalysis.entities, vendors: mockAnalysis.vendors, utilities: mockAnalysis.utilities.filter((u) => u.needsMock)},
+        mockingOptional: {utilities: mockAnalysis.utilities.filter((u) => !u.needsMock)},
+        recommendation: `Mock ${mockAnalysis.entities.length} entities and ${mockAnalysis.vendors.length} vendors before importing the handler`
+      }
+    }
+
+    case 'missing': {
+      // Compare against existing test file
+      const testFile = getTestFilePath(file)
+      const existingMocks = await analyzeExistingTestMocks(path.join(process.cwd(), testFile))
+
+      // Find missing mocks
+      const requiredPaths = [...mockAnalysis.entities.map((e) => e.path), ...mockAnalysis.vendors.map((v) => v.path)]
+
+      const missingMocks = requiredPaths.filter((reqPath) => {
+        // Check if any existing mock matches this path
+        return !existingMocks.some((mock) => reqPath.includes(mock.replace('#', 'src/').replace(/\//g, '/')) || mock.includes(reqPath.split('/').pop()!))
+      })
+
+      return {
+        file,
+        testFile,
+        existingMocks,
+        missingMocks,
+        coverage: existingMocks.length > 0 ? `${Math.round((1 - missingMocks.length / requiredPaths.length) * 100)}%` : 'No test file found'
+      }
+    }
+
+    case 'all': {
+      // Full analysis
+      const testFile = getTestFilePath(file)
+      const existingMocks = await analyzeExistingTestMocks(path.join(process.cwd(), testFile))
+
+      return {
+        file,
+        testFile,
+        transitiveDependencies: transitiveDeps,
+        analysis: mockAnalysis,
+        existingMocks,
+        summary: {
+          totalDependencies: transitiveDeps.length,
+          entities: mockAnalysis.entities.length,
+          vendors: mockAnalysis.vendors.length,
+          utilitiesNeedingMocks: mockAnalysis.utilities.filter((u) => u.needsMock).length
+        }
+      }
+    }
+
+    case 'summary': {
+      return {
+        file,
+        dependencies: transitiveDeps.length,
+        entities: mockAnalysis.entities.map((e) => e.name),
+        vendors: mockAnalysis.vendors.map((v) => v.name),
+        recommendation: mockAnalysis.entities.length > 0
+          ? 'Use createElectroDBEntityMock() from test/helpers/electrodb-mock.ts for entity mocking'
+          : 'Standard jest.unstable_mockModule() for vendor mocks'
+      }
+    }
+
+    default:
+      return {
+        error: `Unknown query: ${query}`,
+        availableQueries: ['required', 'missing', 'all', 'summary'],
+        examples: [
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'required'},
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'missing'},
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'all'}
+        ]
+      }
+  }
+}

--- a/src/mcp/handlers/data-loader.test.ts
+++ b/src/mcp/handlers/data-loader.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Unit tests for data-loader module
+ * Tests shared data loading for MCP handlers
+ *
+ * Note: This module uses import.meta.url which makes mocking difficult.
+ * These tests run against the actual project files (integration-style).
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+
+// Module loaded via dynamic import
+let loadMetadata: typeof import('./data-loader').loadMetadata
+let loadDependencyGraph: typeof import('./data-loader').loadDependencyGraph
+let discoverLambdas: typeof import('./data-loader').discoverLambdas
+let discoverEntities: typeof import('./data-loader').discoverEntities
+let getLambdaConfigs: typeof import('./data-loader').getLambdaConfigs
+let getEntityInfo: typeof import('./data-loader').getEntityInfo
+let getLambdaInvocations: typeof import('./data-loader').getLambdaInvocations
+let getExternalServices: typeof import('./data-loader').getExternalServices
+let getAwsServices: typeof import('./data-loader').getAwsServices
+let loadConventions: typeof import('./data-loader').loadConventions
+let discoverWikiPages: typeof import('./data-loader').discoverWikiPages
+let searchWikiPages: typeof import('./data-loader').searchWikiPages
+let loadWikiPage: typeof import('./data-loader').loadWikiPage
+
+beforeAll(async () => {
+  const module = await import('./data-loader')
+  loadMetadata = module.loadMetadata
+  loadDependencyGraph = module.loadDependencyGraph
+  discoverLambdas = module.discoverLambdas
+  discoverEntities = module.discoverEntities
+  getLambdaConfigs = module.getLambdaConfigs
+  getEntityInfo = module.getEntityInfo
+  getLambdaInvocations = module.getLambdaInvocations
+  getExternalServices = module.getExternalServices
+  getAwsServices = module.getAwsServices
+  loadConventions = module.loadConventions
+  discoverWikiPages = module.discoverWikiPages
+  searchWikiPages = module.searchWikiPages
+  loadWikiPage = module.loadWikiPage
+})
+
+describe('loadMetadata', () => {
+  test('should load and parse metadata.json', async () => {
+    const metadata = await loadMetadata()
+
+    expect(metadata).toBeDefined()
+    expect(metadata.lambdas).toBeDefined()
+    expect(typeof metadata.lambdas).toBe('object')
+  })
+
+  test('should have lambdas with trigger and purpose', async () => {
+    const metadata = await loadMetadata()
+    const lambdaNames = Object.keys(metadata.lambdas)
+
+    expect(lambdaNames.length).toBeGreaterThan(0)
+
+    for (const name of lambdaNames) {
+      const lambda = metadata.lambdas[name]
+      expect(lambda).toHaveProperty('trigger')
+      expect(lambda).toHaveProperty('purpose')
+    }
+  })
+
+  test('should have external services', async () => {
+    const metadata = await loadMetadata()
+
+    expect(Array.isArray(metadata.externalServices)).toBe(true)
+    expect(metadata.externalServices.length).toBeGreaterThan(0)
+  })
+
+  test('should have AWS services', async () => {
+    const metadata = await loadMetadata()
+
+    expect(Array.isArray(metadata.awsServices)).toBe(true)
+    expect(metadata.awsServices.length).toBeGreaterThan(0)
+  })
+
+  test('should have entity relationships', async () => {
+    const metadata = await loadMetadata()
+
+    expect(Array.isArray(metadata.entityRelationships)).toBe(true)
+  })
+})
+
+describe('loadDependencyGraph', () => {
+  test('should load and parse graph.json', async () => {
+    const graph = await loadDependencyGraph()
+
+    expect(graph).toBeDefined()
+    expect(graph.metadata).toBeDefined()
+    expect(graph.transitiveDependencies).toBeDefined()
+  })
+
+  test('should have file entries', async () => {
+    const graph = await loadDependencyGraph()
+    const files = Object.keys(graph.files || graph.transitiveDependencies)
+
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  test('should have transitive dependencies', async () => {
+    const graph = await loadDependencyGraph()
+
+    expect(typeof graph.transitiveDependencies).toBe('object')
+    expect(Object.keys(graph.transitiveDependencies).length).toBeGreaterThan(0)
+  })
+})
+
+describe('discoverLambdas', () => {
+  test('should discover Lambda directories', async () => {
+    const lambdas = await discoverLambdas()
+
+    expect(Array.isArray(lambdas)).toBe(true)
+    expect(lambdas.length).toBeGreaterThan(0)
+  })
+
+  test('should include known Lambda names', async () => {
+    const lambdas = await discoverLambdas()
+
+    // Check for at least some expected Lambdas
+    const knownLambdas = ['ListFiles', 'LoginUser', 'RegisterDevice', 'FileCoordinator']
+    const found = knownLambdas.filter((l) => lambdas.includes(l))
+
+    expect(found.length).toBeGreaterThan(0)
+  })
+
+  test('should return sorted array', async () => {
+    const lambdas = await discoverLambdas()
+    const sorted = [...lambdas].sort()
+
+    expect(lambdas).toEqual(sorted)
+  })
+})
+
+describe('discoverEntities', () => {
+  test('should discover Entity files', async () => {
+    const entities = await discoverEntities()
+
+    expect(Array.isArray(entities)).toBe(true)
+    expect(entities.length).toBeGreaterThan(0)
+  })
+
+  test('should include known entities', async () => {
+    const entities = await discoverEntities()
+
+    // Check for expected entities
+    expect(entities).toContain('Users')
+    expect(entities).toContain('Files')
+  })
+
+  test('should exclude Collections.ts', async () => {
+    const entities = await discoverEntities()
+
+    expect(entities).not.toContain('Collections')
+  })
+
+  test('should return clean entity names without .ts', async () => {
+    const entities = await discoverEntities()
+
+    for (const entity of entities) {
+      expect(entity).not.toContain('.ts')
+    }
+  })
+})
+
+describe('getLambdaConfigs', () => {
+  test('should combine metadata with dependencies', async () => {
+    const configs = await getLambdaConfigs()
+
+    expect(typeof configs).toBe('object')
+    const names = Object.keys(configs)
+    expect(names.length).toBeGreaterThan(0)
+  })
+
+  test('should have required fields for each Lambda', async () => {
+    const configs = await getLambdaConfigs()
+
+    for (const [name, config] of Object.entries(configs)) {
+      expect(config).toHaveProperty('name', name)
+      expect(config).toHaveProperty('trigger')
+      expect(config).toHaveProperty('purpose')
+      expect(config).toHaveProperty('dependencies')
+      expect(config).toHaveProperty('entities')
+      expect(Array.isArray(config.dependencies)).toBe(true)
+      expect(Array.isArray(config.entities)).toBe(true)
+    }
+  })
+})
+
+describe('getEntityInfo', () => {
+  test('should return entities and relationships', async () => {
+    const info = await getEntityInfo()
+
+    expect(info).toHaveProperty('entities')
+    expect(info).toHaveProperty('relationships')
+    expect(Array.isArray(info.entities)).toBe(true)
+    expect(Array.isArray(info.relationships)).toBe(true)
+  })
+
+  test('should have entities matching discovery', async () => {
+    const info = await getEntityInfo()
+    const discovered = await discoverEntities()
+
+    expect(info.entities).toEqual(discovered)
+  })
+})
+
+describe('getLambdaInvocations', () => {
+  test('should return invocation chains', async () => {
+    const invocations = await getLambdaInvocations()
+
+    expect(Array.isArray(invocations)).toBe(true)
+  })
+
+  test('should have from/to/via structure', async () => {
+    const invocations = await getLambdaInvocations()
+
+    if (invocations.length > 0) {
+      expect(invocations[0]).toHaveProperty('from')
+      expect(invocations[0]).toHaveProperty('to')
+      expect(invocations[0]).toHaveProperty('via')
+    }
+  })
+})
+
+describe('getExternalServices', () => {
+  test('should return external services', async () => {
+    const services = await getExternalServices()
+
+    expect(Array.isArray(services)).toBe(true)
+    expect(services.length).toBeGreaterThan(0)
+  })
+
+  test('should have name and type', async () => {
+    const services = await getExternalServices()
+
+    for (const service of services) {
+      expect(service).toHaveProperty('name')
+      expect(service).toHaveProperty('type')
+    }
+  })
+})
+
+describe('getAwsServices', () => {
+  test('should return AWS services', async () => {
+    const services = await getAwsServices()
+
+    expect(Array.isArray(services)).toBe(true)
+    expect(services.length).toBeGreaterThan(0)
+  })
+
+  test('should have vendorPath for wrapper services', async () => {
+    const services = await getAwsServices()
+    const withVendor = services.filter((s) => s.vendorPath)
+
+    expect(withVendor.length).toBeGreaterThan(0)
+  })
+})
+
+describe('loadConventions', () => {
+  test('should load and parse conventions', async () => {
+    const conventions = await loadConventions()
+
+    expect(Array.isArray(conventions)).toBe(true)
+    expect(conventions.length).toBeGreaterThan(0)
+  })
+
+  test('should have required convention fields', async () => {
+    const conventions = await loadConventions()
+
+    for (const conv of conventions) {
+      expect(conv).toHaveProperty('name')
+      expect(conv).toHaveProperty('severity')
+      expect(conv).toHaveProperty('status')
+    }
+  })
+})
+
+describe('loadWikiPage', () => {
+  test('should load a wiki page', async () => {
+    const pages = await discoverWikiPages()
+    if (pages.length > 0) {
+      const content = await loadWikiPage(pages[0])
+
+      expect(typeof content).toBe('string')
+      expect(content.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('discoverWikiPages', () => {
+  test('should discover wiki pages', async () => {
+    const pages = await discoverWikiPages()
+
+    expect(Array.isArray(pages)).toBe(true)
+    expect(pages.length).toBeGreaterThan(0)
+  })
+
+  test('should return markdown files only', async () => {
+    const pages = await discoverWikiPages()
+
+    for (const page of pages) {
+      expect(page).toMatch(/\.md$/)
+    }
+  })
+
+  test('should return relative paths', async () => {
+    const pages = await discoverWikiPages()
+
+    for (const page of pages) {
+      expect(page.startsWith('docs/wiki/')).toBe(true)
+    }
+  })
+})
+
+describe('searchWikiPages', () => {
+  test('should search wiki pages', async () => {
+    const results = await searchWikiPages('AWS')
+
+    expect(Array.isArray(results)).toBe(true)
+  })
+
+  test('should return path and matches', async () => {
+    const results = await searchWikiPages('import')
+
+    if (results.length > 0) {
+      expect(results[0]).toHaveProperty('path')
+      expect(results[0]).toHaveProperty('matches')
+    }
+  })
+
+  test('should find pages matching filename', async () => {
+    const results = await searchWikiPages('SDK')
+
+    const hasMatch = results.some((r) => r.path.toLowerCase().includes('sdk'))
+    expect(hasMatch).toBe(true)
+  })
+})
+
+describe('function exports', () => {
+  test('should export all data loader functions', async () => {
+    expect(typeof loadMetadata).toBe('function')
+    expect(typeof loadDependencyGraph).toBe('function')
+    expect(typeof discoverLambdas).toBe('function')
+    expect(typeof discoverEntities).toBe('function')
+    expect(typeof getLambdaConfigs).toBe('function')
+    expect(typeof getEntityInfo).toBe('function')
+    expect(typeof getLambdaInvocations).toBe('function')
+    expect(typeof getExternalServices).toBe('function')
+    expect(typeof getAwsServices).toBe('function')
+    expect(typeof loadConventions).toBe('function')
+    expect(typeof loadWikiPage).toBe('function')
+    expect(typeof discoverWikiPages).toBe('function')
+    expect(typeof searchWikiPages).toBe('function')
+  })
+})

--- a/src/mcp/handlers/impact.ts
+++ b/src/mcp/handlers/impact.ts
@@ -1,0 +1,324 @@
+/**
+ * Impact analysis handler for MCP server
+ * Shows what's affected by changing a Lambda function or shared module
+ *
+ * Uses build/graph.json for dependency analysis and metadata for Lambda info
+ */
+
+import {getLambdaInvocations, loadDependencyGraph, loadMetadata} from './data-loader.js'
+
+export type ImpactQueryType = 'dependents' | 'cascade' | 'tests' | 'infrastructure' | 'all'
+
+export interface ImpactQueryArgs {
+  file: string
+  query: ImpactQueryType
+}
+
+/**
+ * Convert a file path to its corresponding test file path
+ */
+function getTestFilePath(filePath: string): string | null {
+  // Lambda handler: src/lambdas/Name/src/index.ts -> src/lambdas/Name/test/index.test.ts
+  if (filePath.includes('/lambdas/') && filePath.includes('/src/')) {
+    return filePath.replace('/src/', '/test/').replace(/\.ts$/, '.test.ts')
+  }
+
+  // Entity: src/entities/Name.ts -> could have tests in multiple places
+  if (filePath.includes('/entities/')) {
+    return null // Entities are tested via Lambda tests
+  }
+
+  // Utility: src/util/name.ts -> test/util/name.test.ts or src/util/name.test.ts
+  if (filePath.includes('/util/')) {
+    const testPath = filePath.replace('/util/', '/test/util/').replace(/\.ts$/, '.test.ts')
+    return testPath
+  }
+
+  return null
+}
+
+/**
+ * Extract Lambda name from a file path
+ */
+function extractLambdaName(filePath: string): string | null {
+  const match = filePath.match(/src\/lambdas\/([^/]+)/)
+  return match ? match[1] : null
+}
+
+/**
+ * Find all files that import a given file (reverse dependency lookup)
+ */
+function findDependents(filePath: string, graph: Record<string, {imports: string[]}>): string[] {
+  const dependents: string[] = []
+
+  for (const [file, data] of Object.entries(graph)) {
+    if (data.imports?.includes(filePath)) {
+      dependents.push(file)
+    }
+  }
+
+  return dependents.sort()
+}
+
+/**
+ * Recursively find all files affected by changing a file
+ */
+function findCascade(filePath: string, graph: Record<string, {imports: string[]}>): string[] {
+  const affected = new Set<string>()
+  const toProcess = [filePath]
+
+  while (toProcess.length > 0) {
+    const current = toProcess.pop()!
+    const dependents = findDependents(current, graph)
+
+    for (const dep of dependents) {
+      if (!affected.has(dep)) {
+        affected.add(dep)
+        toProcess.push(dep)
+      }
+    }
+  }
+
+  return Array.from(affected).sort()
+}
+
+export async function handleImpactQuery(args: ImpactQueryArgs) {
+  const {file, query} = args
+
+  if (!file) {
+    return {error: 'File path required', example: {file: 'src/entities/Files.ts', query: 'dependents'}}
+  }
+
+  // Load data
+  const [depGraph, metadata, invocations] = await Promise.all([loadDependencyGraph(), loadMetadata(), getLambdaInvocations()])
+
+  // Normalize file path
+  const normalizedFile = file.startsWith('src/') ? file : `src/${file}`
+
+  // Check if file exists in graph
+  const fileExists = Object.keys(depGraph.files).some((f) => f === normalizedFile || f.includes(file))
+  if (!fileExists) {
+    const suggestions = Object.keys(depGraph.files).filter((f) => f.includes(file.split('/').pop()!.replace('.ts', ''))).slice(0, 5)
+
+    return {
+      error: `File '${file}' not found in dependency graph`,
+      suggestions: suggestions.length > 0 ? suggestions : undefined,
+      hint: 'Use relative path from project root (e.g., src/entities/Files.ts)'
+    }
+  }
+
+  switch (query) {
+    case 'dependents': {
+      // Find direct dependents
+      const dependents = findDependents(normalizedFile, depGraph.files)
+
+      // Categorize dependents
+      const lambdaDependents = dependents.filter((d) => d.includes('/lambdas/'))
+      const entityDependents = dependents.filter((d) => d.includes('/entities/'))
+      const utilDependents = dependents.filter((d) => d.includes('/util/'))
+      const otherDependents = dependents.filter((d) => !lambdaDependents.includes(d) && !entityDependents.includes(d) && !utilDependents.includes(d))
+
+      return {
+        file: normalizedFile,
+        directDependents: {
+          lambdas: lambdaDependents.map((d) => ({file: d, name: extractLambdaName(d)})),
+          entities: entityDependents,
+          utilities: utilDependents,
+          other: otherDependents
+        },
+        totalCount: dependents.length
+      }
+    }
+
+    case 'cascade': {
+      // Find full cascade of affected files
+      const cascade = findCascade(normalizedFile, depGraph.files)
+
+      // Categorize by type
+      const affectedLambdas = new Set<string>()
+      const affectedTests: string[] = []
+      const affectedOther: string[] = []
+
+      for (const f of cascade) {
+        const lambdaName = extractLambdaName(f)
+        if (lambdaName) {
+          affectedLambdas.add(lambdaName)
+        }
+        if (f.includes('.test.') || f.includes('/test/')) {
+          affectedTests.push(f)
+        }
+        if (!f.includes('/lambdas/') && !f.includes('.test.')) {
+          affectedOther.push(f)
+        }
+      }
+
+      return {
+        file: normalizedFile,
+        cascade: {totalFiles: cascade.length, lambdas: Array.from(affectedLambdas).sort(), tests: affectedTests, other: affectedOther},
+        recommendation: affectedLambdas.size > 0
+          ? `Run tests for affected Lambdas: ${Array.from(affectedLambdas).join(', ')}`
+          : 'No Lambda functions directly affected'
+      }
+    }
+
+    case 'tests': {
+      // Find test files that need updating
+      const cascade = findCascade(normalizedFile, depGraph.files)
+
+      const testFiles: Array<{testFile: string; sourceFile: string; exists: boolean}> = []
+      const processedSources = new Set<string>()
+
+      // Add test for the changed file itself
+      const mainTestFile = getTestFilePath(normalizedFile)
+      if (mainTestFile) {
+        testFiles.push({testFile: mainTestFile, sourceFile: normalizedFile, exists: true})
+      }
+
+      // Add tests for affected files
+      for (const f of cascade) {
+        if (f.includes('.test.') || f.includes('/test/')) {
+          // This is already a test file
+          testFiles.push({testFile: f, sourceFile: f.replace('.test.ts', '.ts').replace('/test/', '/src/'), exists: true})
+        } else if (!processedSources.has(f)) {
+          const testPath = getTestFilePath(f)
+          if (testPath) {
+            testFiles.push({testFile: testPath, sourceFile: f, exists: true})
+            processedSources.add(f)
+          }
+        }
+      }
+
+      // Group by Lambda
+      const testsByLambda: Record<string, string[]> = {}
+      for (const t of testFiles) {
+        const lambdaName = extractLambdaName(t.testFile)
+        if (lambdaName) {
+          if (!testsByLambda[lambdaName]) {
+            testsByLambda[lambdaName] = []
+          }
+          if (!testsByLambda[lambdaName].includes(t.testFile)) {
+            testsByLambda[lambdaName].push(t.testFile)
+          }
+        }
+      }
+
+      return {
+        file: normalizedFile,
+        testsToUpdate: testFiles.map((t) => t.testFile),
+        byLambda: testsByLambda,
+        testCommand: Object.keys(testsByLambda).length > 0 ? `pnpm test -- --testPathPattern="${Object.keys(testsByLambda).join('|')}"` : 'pnpm test'
+      }
+    }
+
+    case 'infrastructure': {
+      // Find related Terraform files
+      const cascade = findCascade(normalizedFile, depGraph.files)
+
+      // Extract Lambda names from affected files
+      const affectedLambdas = new Set<string>()
+      const lambdaName = extractLambdaName(normalizedFile)
+      if (lambdaName) {
+        affectedLambdas.add(lambdaName)
+      }
+
+      for (const f of cascade) {
+        const name = extractLambdaName(f)
+        if (name) {
+          affectedLambdas.add(name)
+        }
+      }
+
+      // Map to Terraform files
+      const terraformFiles = Array.from(affectedLambdas).map((name) => ({
+        lambda: name,
+        terraformFile: `terraform/${name.toLowerCase()}.tf`,
+        trigger: metadata.lambdas[name]?.trigger || 'Unknown'
+      }))
+
+      // Check for Lambda invocations
+      const affectedInvocations = invocations.filter((inv) => affectedLambdas.has(inv.from) || affectedLambdas.has(inv.to))
+
+      return {
+        file: normalizedFile,
+        affectedLambdas: Array.from(affectedLambdas),
+        terraformFiles,
+        invocationChains: affectedInvocations,
+        recommendation: terraformFiles.length > 0
+          ? `Review Terraform files: ${terraformFiles.map((t) => t.terraformFile).join(', ')}`
+          : 'No infrastructure changes expected'
+      }
+    }
+
+    case 'all': {
+      // Comprehensive impact analysis
+      const cascade = findCascade(normalizedFile, depGraph.files)
+      const directDependents = findDependents(normalizedFile, depGraph.files)
+
+      // Extract affected Lambdas
+      const affectedLambdas = new Set<string>()
+      const lambdaName = extractLambdaName(normalizedFile)
+      if (lambdaName) {
+        affectedLambdas.add(lambdaName)
+      }
+
+      for (const f of [...cascade, ...directDependents]) {
+        const name = extractLambdaName(f)
+        if (name) {
+          affectedLambdas.add(name)
+        }
+      }
+
+      // Determine severity
+      let severity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL'
+      if (normalizedFile.includes('/entities/')) {
+        severity = 'HIGH' // Entity changes affect multiple Lambdas
+      } else if (normalizedFile.includes('/util/lambda-helpers') || normalizedFile.includes('/util/errors')) {
+        severity = 'CRITICAL' // Core utility changes
+      } else if (affectedLambdas.size > 3) {
+        severity = 'HIGH'
+      } else if (affectedLambdas.size > 0) {
+        severity = 'MEDIUM'
+      } else {
+        severity = 'LOW'
+      }
+
+      return {
+        file: normalizedFile,
+        severity,
+        impact: {
+          directDependents: directDependents.length,
+          cascadeFiles: cascade.length,
+          affectedLambdas: Array.from(affectedLambdas).sort(),
+          lambdaCount: affectedLambdas.size
+        },
+        tests: {
+          command: affectedLambdas.size > 0 ? `pnpm test -- --testPathPattern="${Array.from(affectedLambdas).join('|')}"` : 'pnpm test',
+          fullSuiteRecommended: severity === 'CRITICAL' || severity === 'HIGH'
+        },
+        infrastructure: {
+          terraformFiles: Array.from(affectedLambdas).map((name) => `terraform/${name.toLowerCase()}.tf`),
+          invocations: invocations.filter((inv) => affectedLambdas.has(inv.from) || affectedLambdas.has(inv.to))
+        },
+        recommendation: severity === 'CRITICAL'
+          ? 'CRITICAL change: Run full test suite and review all affected Lambdas'
+          : severity === 'HIGH'
+          ? 'HIGH impact: Run affected Lambda tests and verify functionality'
+          : severity === 'MEDIUM'
+          ? 'MEDIUM impact: Run targeted tests for affected Lambdas'
+          : 'LOW impact: Standard testing should suffice'
+      }
+    }
+
+    default:
+      return {
+        error: `Unknown query: ${query}`,
+        availableQueries: ['dependents', 'cascade', 'tests', 'infrastructure', 'all'],
+        examples: [
+          {file: 'src/entities/Files.ts', query: 'dependents'},
+          {file: 'src/entities/Files.ts', query: 'cascade'},
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'tests'},
+          {file: 'src/util/lambda-helpers.ts', query: 'all'}
+        ]
+      }
+  }
+}

--- a/src/mcp/handlers/test-scaffold.ts
+++ b/src/mcp/handlers/test-scaffold.ts
@@ -1,0 +1,396 @@
+/**
+ * Test scaffolding handler for MCP server
+ * Generates complete test file scaffolding with all required mocks
+ *
+ * Uses build/graph.json for dependency analysis and existing test patterns
+ */
+
+import {discoverEntities, loadDependencyGraph} from './data-loader.js'
+
+export type TestScaffoldQueryType = 'scaffold' | 'mocks' | 'fixtures' | 'structure'
+
+export interface TestScaffoldQueryArgs {
+  file: string
+  query: TestScaffoldQueryType
+}
+
+interface MockInfo {
+  type: 'entity' | 'vendor' | 'utility' | 'external'
+  name: string
+  path: string
+  importAlias: string
+  mockCode: string
+}
+
+/**
+ * Extract Lambda name from file path
+ */
+function extractLambdaName(filePath: string): string | null {
+  const match = filePath.match(/src\/lambdas\/([^/]+)/)
+  return match ? match[1] : null
+}
+
+/**
+ * Generate mock code for a dependency
+ */
+function generateMockCode(dep: string, entityNames: string[]): MockInfo | null {
+  // Entity mocks
+  const entityMatch = dep.match(/src\/entities\/(\w+)/)
+  if (entityMatch && entityNames.includes(entityMatch[1])) {
+    const entityName = entityMatch[1]
+    return {
+      type: 'entity',
+      name: entityName,
+      path: dep,
+      importAlias: `#entities/${entityName}`,
+      mockCode: `// ${entityName} entity mock
+const ${entityName.toLowerCase()}Mock = createElectroDBEntityMock({queryIndexes: ['byKey']})
+jest.unstable_mockModule('#entities/${entityName}', () => ({${entityName}: ${entityName.toLowerCase()}Mock.entity}))`
+    }
+  }
+
+  // AWS Vendor mocks
+  const awsVendorMatch = dep.match(/src\/lib\/vendor\/AWS\/(\w+)/)
+  if (awsVendorMatch) {
+    const serviceName = awsVendorMatch[1]
+    const mockFunctions = getAwsServiceMocks(serviceName)
+    return {
+      type: 'vendor',
+      name: `AWS/${serviceName}`,
+      path: dep,
+      importAlias: `#lib/vendor/AWS/${serviceName}`,
+      mockCode: `// AWS ${serviceName} mock
+jest.unstable_mockModule('#lib/vendor/AWS/${serviceName}', () => ({
+${mockFunctions.map((fn) => `  ${fn}: jest.fn()`).join(',\n')}
+}))`
+    }
+  }
+
+  // Other vendor mocks (YouTube, etc.)
+  const vendorMatch = dep.match(/src\/lib\/vendor\/(\w+)/)
+  if (vendorMatch && !dep.includes('/AWS/')) {
+    const vendorName = vendorMatch[1]
+    return {
+      type: 'vendor',
+      name: vendorName,
+      path: dep,
+      importAlias: `#lib/vendor/${vendorName}`,
+      mockCode: `// ${vendorName} vendor mock
+jest.unstable_mockModule('#lib/vendor/${vendorName}', () => ({
+  // Add mock functions as needed
+}))`
+    }
+  }
+
+  // X-Ray wrapper
+  if (dep.includes('XRay')) {
+    return {
+      type: 'vendor',
+      name: 'XRay',
+      path: dep,
+      importAlias: '#lib/vendor/AWS/XRay',
+      mockCode: `// X-Ray mock (passthrough)
+jest.unstable_mockModule('#lib/vendor/AWS/XRay', () => ({
+  withXRay: (handler: unknown) => handler
+}))`
+    }
+  }
+
+  return null
+}
+
+/**
+ * Get common mock functions for AWS services
+ */
+function getAwsServiceMocks(service: string): string[] {
+  const serviceMocks: Record<string, string[]> = {
+    DynamoDB: ['queryItems', 'getItem', 'putItem', 'deleteItem', 'batchGetItems', 'batchWriteItems'],
+    S3: ['uploadToS3', 'getObject', 'deleteObject', 'listObjects'],
+    Lambda: ['invokeFunction', 'invokeFunctionAsync'],
+    SNS: ['publishToSNS', 'sendPushNotification'],
+    SQS: ['sendMessage', 'receiveMessage', 'deleteMessage'],
+    SecretsManager: ['getSecret'],
+    CloudWatch: ['putMetric', 'putLogEvents']
+  }
+  return serviceMocks[service] || ['mockFunction']
+}
+
+/**
+ * Generate complete test file scaffold
+ */
+function generateTestScaffold(lambdaName: string, mocks: MockInfo[]): string {
+  const entityMocks = mocks.filter((m) => m.type === 'entity')
+  const vendorMocks = mocks.filter((m) => m.type === 'vendor')
+
+  const lines: string[] = []
+
+  // Imports
+  lines.push("import {beforeAll, beforeEach, describe, expect, jest, test} from '@jest/globals'")
+  lines.push("import type {APIGatewayProxyEvent, Context} from 'aws-lambda'")
+
+  if (entityMocks.length > 0) {
+    lines.push("import {createElectroDBEntityMock} from '../../../../test/helpers/electrodb-mock'")
+  }
+
+  lines.push('')
+
+  // Environment setup
+  lines.push('// Environment setup')
+  lines.push('beforeAll(() => {')
+  lines.push("  process.env.TableName = 'test-table'")
+  lines.push("  process.env.Region = 'us-east-1'")
+  lines.push('})')
+  lines.push('')
+
+  // Entity mocks (must be before other mocks)
+  if (entityMocks.length > 0) {
+    lines.push('// Entity mocks')
+    for (const mock of entityMocks) {
+      lines.push(mock.mockCode)
+      lines.push('')
+    }
+  }
+
+  // Vendor mocks
+  if (vendorMocks.length > 0) {
+    lines.push('// Vendor mocks')
+    for (const mock of vendorMocks) {
+      lines.push(mock.mockCode)
+      lines.push('')
+    }
+  }
+
+  // Import handler after mocks
+  lines.push('// Import handler after mocks')
+  lines.push("const {handler} = await import('../src')")
+  lines.push('')
+
+  // Test context helper
+  lines.push('// Test helpers')
+  lines.push('const testContext: Context = {')
+  lines.push("  functionName: 'test',")
+  lines.push("  functionVersion: '1',")
+  lines.push("  invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789:function:test',")
+  lines.push("  memoryLimitInMB: '128',")
+  lines.push("  awsRequestId: 'test-request-id',")
+  lines.push("  logGroupName: 'test-log-group',")
+  lines.push("  logStreamName: 'test-log-stream',")
+  lines.push('  getRemainingTimeInMillis: () => 30000,')
+  lines.push('  done: () => {},')
+  lines.push('  fail: () => {},')
+  lines.push('  succeed: () => {}')
+  lines.push('} as Context')
+  lines.push('')
+
+  // Test suite
+  lines.push(`describe('#${lambdaName}', () => {`)
+  lines.push('  beforeEach(() => {')
+  lines.push('    jest.clearAllMocks()')
+
+  // Reset entity mocks
+  for (const mock of entityMocks) {
+    const entityName = mock.name.toLowerCase()
+    lines.push(`    ${entityName}Mock.reset()`)
+  }
+
+  lines.push('  })')
+  lines.push('')
+
+  lines.push("  describe('success cases', () => {")
+  lines.push("    test('should handle valid request', async () => {")
+  lines.push('      // Arrange')
+  lines.push('      const event: Partial<APIGatewayProxyEvent> = {')
+  lines.push('        requestContext: {')
+  lines.push('          authorizer: {')
+  lines.push("            userId: 'test-user-id'")
+  lines.push('          }')
+  lines.push('        } as unknown as APIGatewayProxyEvent["requestContext"],')
+  lines.push('        body: JSON.stringify({})')
+  lines.push('      }')
+  lines.push('')
+
+  // Set up mock returns for entities
+  for (const mock of entityMocks) {
+    const entityName = mock.name.toLowerCase()
+    lines.push(`      ${entityName}Mock.query.go.mockResolvedValue({data: []})`)
+  }
+
+  lines.push('')
+  lines.push('      // Act')
+  lines.push('      const result = await handler(event as APIGatewayProxyEvent, testContext)')
+  lines.push('')
+  lines.push('      // Assert')
+  lines.push('      expect(result.statusCode).toBe(200)')
+  lines.push('    })')
+  lines.push('  })')
+  lines.push('')
+
+  lines.push("  describe('error cases', () => {")
+  lines.push("    test('should handle missing authorization', async () => {")
+  lines.push('      // Arrange')
+  lines.push('      const event: Partial<APIGatewayProxyEvent> = {')
+  lines.push('        requestContext: {} as unknown as APIGatewayProxyEvent["requestContext"]')
+  lines.push('      }')
+  lines.push('')
+  lines.push('      // Act')
+  lines.push('      const result = await handler(event as APIGatewayProxyEvent, testContext)')
+  lines.push('')
+  lines.push('      // Assert')
+  lines.push('      expect(result.statusCode).toBe(401)')
+  lines.push('    })')
+  lines.push('  })')
+
+  lines.push('})')
+
+  return lines.join('\n')
+}
+
+export async function handleTestScaffoldQuery(args: TestScaffoldQueryArgs) {
+  const {file, query} = args
+
+  if (!file) {
+    return {error: 'File path required', example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'scaffold'}}
+  }
+
+  // Load data
+  const [depGraph, entityNames] = await Promise.all([loadDependencyGraph(), discoverEntities()])
+
+  // Normalize file path
+  const normalizedFile = file.startsWith('src/') ? file : `src/${file}`
+
+  // Get transitive dependencies
+  const transitiveDeps = depGraph.transitiveDependencies[normalizedFile] || []
+
+  if (transitiveDeps.length === 0) {
+    const suggestions = Object.keys(depGraph.transitiveDependencies).filter((k) => k.includes(file.split('/').pop()!.replace('.ts', ''))).slice(0, 5)
+
+    return {error: `File '${file}' not found in dependency graph`, suggestions: suggestions.length > 0 ? suggestions : undefined}
+  }
+
+  // Extract Lambda name
+  const lambdaName = extractLambdaName(normalizedFile)
+
+  // Generate mocks
+  const mocks: MockInfo[] = []
+  for (const dep of transitiveDeps) {
+    const mockInfo = generateMockCode(dep, entityNames)
+    if (mockInfo) {
+      mocks.push(mockInfo)
+    }
+  }
+
+  // Calculate test file path
+  const testFilePath = normalizedFile.replace('/src/', '/test/').replace(/\.ts$/, '.test.ts')
+
+  switch (query) {
+    case 'scaffold': {
+      if (!lambdaName) {
+        return {
+          error: 'scaffold query only supports Lambda handler files',
+          hint: 'Provide a path like src/lambdas/ListFiles/src/index.ts',
+          file: normalizedFile
+        }
+      }
+
+      const scaffoldCode = generateTestScaffold(lambdaName, mocks)
+
+      return {
+        file: normalizedFile,
+        testPath: testFilePath,
+        lambdaName,
+        generatedCode: scaffoldCode,
+        mocksIncluded: mocks.map((m) => ({type: m.type, name: m.name})),
+        instructions: [
+          `1. Create file: ${testFilePath}`,
+          '2. Paste the generated code',
+          '3. Add specific test cases for your Lambda logic',
+          '4. Run: pnpm test -- --testPathPattern=' + lambdaName
+        ]
+      }
+    }
+
+    case 'mocks': {
+      // Return just the mock setup code
+      const entityMocks = mocks.filter((m) => m.type === 'entity')
+      const vendorMocks = mocks.filter((m) => m.type === 'vendor')
+
+      return {
+        file: normalizedFile,
+        mocks: {
+          entities: entityMocks.map((m) => ({name: m.name, importAlias: m.importAlias, code: m.mockCode})),
+          vendors: vendorMocks.map((m) => ({name: m.name, importAlias: m.importAlias, code: m.mockCode}))
+        },
+        mockOrder: [
+          '1. Entity mocks (createElectroDBEntityMock)',
+          '2. Vendor mocks (jest.unstable_mockModule)',
+          '3. Handler import (await import)'
+        ],
+        recommendation: entityMocks.length > 0
+          ? 'Remember: Entity mocks MUST be defined before jest.unstable_mockModule calls'
+          : 'Standard mock setup - define mocks before importing handler'
+      }
+    }
+
+    case 'fixtures': {
+      // Suggest fixture files based on dependencies
+      const fixtures: Array<{name: string; purpose: string; suggested: boolean}> = []
+
+      // API Gateway event fixture
+      fixtures.push({
+        name: 'APIGatewayEvent.json',
+        purpose: 'Sample API Gateway proxy event with authorization',
+        suggested: normalizedFile.includes('/lambdas/')
+      })
+
+      // Entity-specific fixtures
+      for (const mock of mocks.filter((m) => m.type === 'entity')) {
+        fixtures.push({name: `${mock.name}-query-response.json`, purpose: `Mock response for ${mock.name} queries`, suggested: true})
+      }
+
+      // Response fixtures
+      fixtures.push({name: 'success-response.json', purpose: 'Expected success response format', suggested: true})
+
+      fixtures.push({name: 'error-response.json', purpose: 'Expected error response format', suggested: true})
+
+      return {
+        file: normalizedFile,
+        suggestedFixtures: fixtures.filter((f) => f.suggested),
+        fixtureDirectory: testFilePath.replace('index.test.ts', 'fixtures/'),
+        recommendation: 'Create fixtures based on production data using logIncomingFixture/logOutgoingFixture'
+      }
+    }
+
+    case 'structure': {
+      // Return test file structure without full code
+      return {
+        file: normalizedFile,
+        testPath: testFilePath,
+        structure: {
+          imports: [
+            '@jest/globals (beforeAll, beforeEach, describe, expect, jest, test)',
+            'aws-lambda types',
+            entityNames.length > 0 ? 'createElectroDBEntityMock from test helpers' : null
+          ].filter(Boolean),
+          setup: {beforeAll: 'Environment variables', mocks: mocks.map((m) => `${m.type}: ${m.name}`), handlerImport: 'await import after mocks'},
+          testSuites: ['success cases', 'error cases', 'edge cases'],
+          helpers: ['testContext', 'createTestEvent']
+        },
+        dependencies: {
+          entities: mocks.filter((m) => m.type === 'entity').map((m) => m.name),
+          vendors: mocks.filter((m) => m.type === 'vendor').map((m) => m.name)
+        }
+      }
+    }
+
+    default:
+      return {
+        error: `Unknown query: ${query}`,
+        availableQueries: ['scaffold', 'mocks', 'fixtures', 'structure'],
+        examples: [
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'scaffold'},
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'mocks'},
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'fixtures'}
+        ]
+      }
+  }
+}

--- a/src/mcp/handlers/validation.ts
+++ b/src/mcp/handlers/validation.ts
@@ -1,0 +1,201 @@
+/**
+ * Validation handler for MCP server
+ * Provides AST-based pattern validation against project conventions
+ *
+ * Uses the shared validation core from src/mcp/validation/
+ */
+
+import path from 'path'
+import {fileURLToPath} from 'url'
+import {allRules, rulesByName, validateFile} from '../validation/index.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const projectRoot = path.resolve(__dirname, '../../..')
+
+export type ValidationQueryType = 'all' | 'aws-sdk' | 'electrodb' | 'imports' | 'response' | 'rules' | 'summary'
+
+export interface ValidationQueryArgs {
+  file?: string
+  query: ValidationQueryType
+}
+
+export async function handleValidationQuery(args: ValidationQueryArgs) {
+  const {file, query} = args
+
+  switch (query) {
+    case 'rules': {
+      // List all available validation rules
+      return {
+        rules: allRules.map((rule) => ({
+          name: rule.name,
+          description: rule.description,
+          severity: rule.severity,
+          appliesTo: rule.appliesTo,
+          excludes: rule.excludes
+        })),
+        aliases: Object.entries(rulesByName).filter(([alias, rule]) => alias !== rule.name).map(([alias, rule]) => ({alias, rule: rule.name}))
+      }
+    }
+
+    case 'all': {
+      if (!file) {
+        return {error: 'File path required for validation', example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'all'}}
+      }
+
+      const filePath = path.isAbsolute(file) ? file : path.join(projectRoot, file)
+      const result = await validateFile(filePath, {projectRoot})
+
+      return {
+        file: result.file,
+        valid: result.valid,
+        violations: result.violations,
+        passed: result.passed,
+        skipped: result.skipped,
+        summary: result.valid ? 'All applicable rules passed' : `${result.violations.length} violation(s) found`
+      }
+    }
+
+    case 'aws-sdk': {
+      if (!file) {
+        return {
+          error: 'File path required',
+          description: 'Validates AWS SDK encapsulation (CRITICAL rule)',
+          example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'aws-sdk'}
+        }
+      }
+
+      const filePath = path.isAbsolute(file) ? file : path.join(projectRoot, file)
+      const result = await validateFile(filePath, {projectRoot, rules: ['aws-sdk-encapsulation']})
+
+      return {
+        file: result.file,
+        rule: 'aws-sdk-encapsulation',
+        severity: 'CRITICAL',
+        valid: result.valid,
+        violations: result.violations,
+        message: result.valid
+          ? 'No direct AWS SDK imports found. File follows encapsulation policy.'
+          : 'CRITICAL: Direct AWS SDK imports detected. Use lib/vendor/AWS/ wrappers.'
+      }
+    }
+
+    case 'electrodb': {
+      if (!file) {
+        return {
+          error: 'File path required',
+          description: 'Validates ElectroDB mocking patterns in test files (CRITICAL rule)',
+          example: {file: 'src/lambdas/ListFiles/test/index.test.ts', query: 'electrodb'}
+        }
+      }
+
+      const filePath = path.isAbsolute(file) ? file : path.join(projectRoot, file)
+      const result = await validateFile(filePath, {projectRoot, rules: ['electrodb-mocking']})
+
+      return {
+        file: result.file,
+        rule: 'electrodb-mocking',
+        severity: 'CRITICAL',
+        valid: result.valid,
+        violations: result.violations,
+        skipped: result.skipped.includes('electrodb-mocking') ? 'Rule skipped: Not a test file or no entity mocks' : undefined,
+        message: result.valid
+          ? 'ElectroDB entities are mocked correctly using createElectroDBEntityMock().'
+          : 'CRITICAL: Manual entity mocks detected. Use createElectroDBEntityMock() helper.'
+      }
+    }
+
+    case 'imports': {
+      if (!file) {
+        return {
+          error: 'File path required',
+          description: 'Validates import ordering in Lambda handlers (MEDIUM rule)',
+          example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'imports'}
+        }
+      }
+
+      const filePath = path.isAbsolute(file) ? file : path.join(projectRoot, file)
+      const result = await validateFile(filePath, {projectRoot, rules: ['import-order']})
+
+      return {
+        file: result.file,
+        rule: 'import-order',
+        severity: 'MEDIUM',
+        valid: result.valid,
+        violations: result.violations,
+        skipped: result.skipped.includes('import-order') ? 'Rule skipped: Not a Lambda handler file' : undefined,
+        expectedOrder: ['node-builtins', 'aws-lambda-types', 'external-packages', 'entities', 'vendor', 'types', 'utilities', 'relative']
+      }
+    }
+
+    case 'response': {
+      if (!file) {
+        return {
+          error: 'File path required',
+          description: 'Validates response helper usage in Lambda handlers (HIGH rule)',
+          example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'response'}
+        }
+      }
+
+      const filePath = path.isAbsolute(file) ? file : path.join(projectRoot, file)
+      const result = await validateFile(filePath, {projectRoot, rules: ['response-helpers']})
+
+      return {
+        file: result.file,
+        rule: 'response-helpers',
+        severity: 'HIGH',
+        valid: result.valid,
+        violations: result.violations,
+        skipped: result.skipped.includes('response-helpers') ? 'Rule skipped: Not a Lambda handler file' : undefined,
+        message: result.valid
+          ? 'Lambda uses response() and lambdaErrorResponse() helpers correctly.'
+          : 'Raw response objects detected. Use helper functions for consistent formatting.'
+      }
+    }
+
+    case 'summary': {
+      // Validate a file and return a concise summary
+      if (!file) {
+        return {error: 'File path required', example: {file: 'src/lambdas/ListFiles/src/index.ts', query: 'summary'}}
+      }
+
+      const filePath = path.isAbsolute(file) ? file : path.join(projectRoot, file)
+      const result = await validateFile(filePath, {projectRoot})
+
+      const criticalViolations = result.violations.filter((v) => v.severity === 'CRITICAL')
+      const highViolations = result.violations.filter((v) => v.severity === 'HIGH')
+      const mediumViolations = result.violations.filter((v) => v.severity === 'MEDIUM')
+
+      return {
+        file: result.file,
+        valid: result.valid,
+        summary: {
+          critical: criticalViolations.length,
+          high: highViolations.length,
+          medium: mediumViolations.length,
+          passed: result.passed.length,
+          skipped: result.skipped.length
+        },
+        criticalIssues: criticalViolations.map((v) => ({rule: v.rule, line: v.line, message: v.message})),
+        recommendation: criticalViolations.length > 0
+          ? 'CRITICAL issues must be fixed before committing'
+          : highViolations.length > 0
+          ? 'HIGH priority issues should be addressed'
+          : result.valid
+          ? 'File passes all convention checks'
+          : 'Minor issues detected'
+      }
+    }
+
+    default:
+      return {
+        error: `Unknown query: ${query}`,
+        availableQueries: ['all', 'aws-sdk', 'electrodb', 'imports', 'response', 'rules', 'summary'],
+        examples: [
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'all'},
+          {file: 'src/lambdas/ListFiles/src/index.ts', query: 'aws-sdk'},
+          {query: 'rules'}
+        ]
+      }
+  }
+}

--- a/src/mcp/parsers/convention-parser.test.ts
+++ b/src/mcp/parsers/convention-parser.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for convention-parser.ts
+ * Tests the pure functions for parsing conventions-tracking.md
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {readFileSync} from 'fs'
+import {join} from 'path'
+import type {Convention} from './convention-parser'
+
+// Load fixture from project root (Jest runs from rootDir)
+const fixtureContent = readFileSync(join(process.cwd(), 'src/mcp/test/fixtures/conventions-sample.md'), 'utf-8')
+
+// Module functions loaded via dynamic import
+let parseConventions: typeof import('./convention-parser').parseConventions
+let searchConventions: typeof import('./convention-parser').searchConventions
+let filterByCategory: typeof import('./convention-parser').filterByCategory
+let filterBySeverity: typeof import('./convention-parser').filterBySeverity
+let filterByStatus: typeof import('./convention-parser').filterByStatus
+
+beforeAll(async () => {
+  const module = await import('./convention-parser')
+  parseConventions = module.parseConventions
+  searchConventions = module.searchConventions
+  filterByCategory = module.filterByCategory
+  filterBySeverity = module.filterBySeverity
+  filterByStatus = module.filterByStatus
+})
+
+describe('convention-parser', () => {
+  describe('parseConventions', () => {
+    test('should parse all conventions from fixture', () => {
+      const result = parseConventions(fixtureContent)
+
+      expect(result.conventions.length).toBe(6)
+    })
+
+    test('should parse metadata correctly', () => {
+      const result = parseConventions(fixtureContent)
+
+      expect(result.metadata.lastUpdated).toBe('2024-01-15')
+      expect(result.metadata.totalCount).toBe(6)
+      expect(result.metadata.documentedCount).toBe(4)
+      expect(result.metadata.pendingCount).toBe(2)
+    })
+
+    test('should extract convention name and type', () => {
+      const result = parseConventions(fixtureContent)
+      const firstConvention = result.conventions.find((c) => c.name === 'Test Convention One')
+
+      expect(firstConvention).toBeDefined()
+      expect(firstConvention!.type).toBe('Testing Pattern')
+    })
+
+    test('should extract what and why fields', () => {
+      const result = parseConventions(fixtureContent)
+      const convention = result.conventions.find((c) => c.name === 'Test Convention One')
+
+      expect(convention!.what).toContain('mock helpers')
+      expect(convention!.why).toContain('maintainability')
+    })
+
+    test('should parse severity from priority field', () => {
+      const result = parseConventions(fixtureContent)
+
+      const criticalConv = result.conventions.find((c) => c.name === 'Test Convention Two')
+      const highConv = result.conventions.find((c) => c.name === 'Test Convention One')
+      const mediumConv = result.conventions.find((c) => c.name === 'Documented Convention Two')
+      const lowConv = result.conventions.find((c) => c.name === 'Low Priority Convention')
+
+      expect(criticalConv!.severity).toBe('CRITICAL')
+      expect(highConv!.severity).toBe('HIGH')
+      expect(mediumConv!.severity).toBe('MEDIUM')
+      expect(lowConv!.severity).toBe('LOW')
+    })
+
+    test('should parse status from section and status field', () => {
+      const result = parseConventions(fixtureContent)
+
+      const pendingConv = result.conventions.find((c) => c.name === 'Test Convention One')
+      const documentedConv = result.conventions.find((c) => c.name === 'Documented Convention One')
+
+      expect(pendingConv!.status).toBe('pending')
+      expect(documentedConv!.status).toBe('documented')
+    })
+
+    test('should infer category from type', () => {
+      const result = parseConventions(fixtureContent)
+
+      const testingConv = result.conventions.find((c) => c.name === 'Test Convention One')
+      const awsConv = result.conventions.find((c) => c.name === 'Test Convention Two')
+      const gitConv = result.conventions.find((c) => c.name === 'Documented Convention One')
+      const securityConv = result.conventions.find((c) => c.name === 'Documented Convention Three')
+
+      expect(testingConv!.category).toBe('testing')
+      expect(awsConv!.category).toBe('aws')
+      expect(gitConv!.category).toBe('git')
+      expect(securityConv!.category).toBe('security')
+    })
+
+    test('should extract wiki path from target/documented field', () => {
+      const result = parseConventions(fixtureContent)
+      const convention = result.conventions.find((c) => c.name === 'Test Convention One')
+
+      expect(convention!.wikiPath).toBe('docs/wiki/Testing/Mock-Patterns.md')
+    })
+
+    test('should extract enforcement field', () => {
+      const result = parseConventions(fixtureContent)
+      const convention = result.conventions.find((c) => c.name === 'Test Convention Two')
+
+      expect(convention!.enforcement).toBe('Zero-tolerance')
+    })
+
+    test('should handle empty content', () => {
+      const result = parseConventions('')
+
+      expect(result.conventions).toEqual([])
+      expect(result.metadata.totalCount).toBe(0)
+    })
+
+    test('should handle content with no conventions', () => {
+      const content = '# Conventions Tracking\n\n## 🟡 Pending Documentation\n\n(None)\n'
+      const result = parseConventions(content)
+
+      expect(result.conventions).toEqual([])
+    })
+  })
+
+  describe('searchConventions', () => {
+    let conventions: Convention[]
+
+    test('should search by name', () => {
+      const result = parseConventions(fixtureContent)
+      conventions = result.conventions
+
+      const matches = searchConventions(conventions, 'Test Convention One')
+      expect(matches.length).toBe(1)
+      expect(matches[0].name).toBe('Test Convention One')
+    })
+
+    test('should search by what field', () => {
+      const result = parseConventions(fixtureContent)
+      conventions = result.conventions
+
+      const matches = searchConventions(conventions, 'mock helpers')
+      expect(matches.length).toBeGreaterThan(0)
+      expect(matches[0].what).toContain('mock helpers')
+    })
+
+    test('should search by why field', () => {
+      const result = parseConventions(fixtureContent)
+      conventions = result.conventions
+
+      const matches = searchConventions(conventions, 'maintainability')
+      expect(matches.length).toBeGreaterThan(0)
+    })
+
+    test('should be case-insensitive', () => {
+      const result = parseConventions(fixtureContent)
+      conventions = result.conventions
+
+      const matches = searchConventions(conventions, 'MOCK HELPERS')
+      expect(matches.length).toBeGreaterThan(0)
+    })
+
+    test('should return empty array for no matches', () => {
+      const result = parseConventions(fixtureContent)
+      conventions = result.conventions
+
+      const matches = searchConventions(conventions, 'nonexistent term xyz123')
+      expect(matches).toEqual([])
+    })
+  })
+
+  describe('filterByCategory', () => {
+    test('should filter by testing category', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterByCategory(result.conventions, 'testing')
+
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(filtered.every((c) => c.category === 'testing')).toBe(true)
+    })
+
+    test('should filter by aws category', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterByCategory(result.conventions, 'aws')
+
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(filtered.every((c) => c.category === 'aws')).toBe(true)
+    })
+
+    test('should return empty array for category with no matches', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterByCategory(result.conventions, 'patterns')
+
+      // May be empty depending on fixture
+      expect(Array.isArray(filtered)).toBe(true)
+    })
+  })
+
+  describe('filterBySeverity', () => {
+    test('should filter by CRITICAL severity', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterBySeverity(result.conventions, 'CRITICAL')
+
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(filtered.every((c) => c.severity === 'CRITICAL')).toBe(true)
+    })
+
+    test('should filter by HIGH severity', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterBySeverity(result.conventions, 'HIGH')
+
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(filtered.every((c) => c.severity === 'HIGH')).toBe(true)
+    })
+
+    test('should filter by MEDIUM severity', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterBySeverity(result.conventions, 'MEDIUM')
+
+      expect(filtered.every((c) => c.severity === 'MEDIUM')).toBe(true)
+    })
+
+    test('should filter by LOW severity', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterBySeverity(result.conventions, 'LOW')
+
+      expect(filtered.every((c) => c.severity === 'LOW')).toBe(true)
+    })
+  })
+
+  describe('filterByStatus', () => {
+    test('should filter by pending status', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterByStatus(result.conventions, 'pending')
+
+      expect(filtered.length).toBe(2)
+      expect(filtered.every((c) => c.status === 'pending')).toBe(true)
+    })
+
+    test('should filter by documented status', () => {
+      const result = parseConventions(fixtureContent)
+      const filtered = filterByStatus(result.conventions, 'documented')
+
+      expect(filtered.length).toBe(4)
+      expect(filtered.every((c) => c.status === 'documented')).toBe(true)
+    })
+  })
+})

--- a/src/mcp/parsers/convention-parser.ts
+++ b/src/mcp/parsers/convention-parser.ts
@@ -1,0 +1,214 @@
+/**
+ * Parser for conventions-tracking.md
+ * Extracts structured convention data from markdown format
+ */
+
+export type ConventionCategory = 'testing' | 'aws' | 'typescript' | 'git' | 'infrastructure' | 'security' | 'meta' | 'patterns' | 'unknown'
+export type ConventionSeverity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+export type ConventionStatus = 'pending' | 'documented' | 'proposed' | 'archived'
+
+export interface Convention {
+  name: string
+  type: string
+  category: ConventionCategory
+  severity: ConventionSeverity
+  status: ConventionStatus
+  what: string
+  why: string
+  wikiPath?: string
+  enforcement?: string
+  detectedDate?: string
+}
+
+interface ParsedConventions {
+  conventions: Convention[]
+  metadata: {totalCount: number; documentedCount: number; pendingCount: number; lastUpdated?: string}
+}
+
+/**
+ * Infer category from convention type or wiki path
+ */
+function inferCategory(type: string, wikiPath?: string): ConventionCategory {
+  const typeLower = type.toLowerCase()
+  const pathLower = (wikiPath || '').toLowerCase()
+
+  if (typeLower.includes('test') || pathLower.includes('testing')) {
+    return 'testing'
+  }
+  if (typeLower.includes('security') || typeLower.includes('pnpm') || typeLower.includes('supply chain')) {
+    return 'security'
+  }
+  if (pathLower.includes('aws') || typeLower.includes('aws') || typeLower.includes('sdk')) {
+    return 'aws'
+  }
+  if (pathLower.includes('typescript') || typeLower.includes('typescript')) {
+    return 'typescript'
+  }
+  if (pathLower.includes('git') || typeLower.includes('git') || typeLower.includes('commit')) {
+    return 'git'
+  }
+  if (pathLower.includes('infrastructure') || typeLower.includes('script')) {
+    return 'infrastructure'
+  }
+  if (pathLower.includes('meta') || typeLower.includes('convention') || typeLower.includes('standard')) {
+    return 'meta'
+  }
+  if (typeLower.includes('pattern') || typeLower.includes('methodology')) {
+    return 'patterns'
+  }
+
+  return 'unknown'
+}
+
+/**
+ * Parse severity from priority string
+ */
+function parseSeverity(priority?: string): ConventionSeverity {
+  if (!priority) {
+    return 'MEDIUM'
+  }
+  const upper = priority.toUpperCase()
+  if (upper.includes('CRITICAL')) {
+    return 'CRITICAL'
+  }
+  if (upper.includes('HIGH')) {
+    return 'HIGH'
+  }
+  if (upper.includes('LOW')) {
+    return 'LOW'
+  }
+  return 'MEDIUM'
+}
+
+/**
+ * Parse a single convention block from markdown
+ */
+function parseConventionBlock(block: string, defaultStatus: ConventionStatus): Convention | null {
+  // Match convention header: "1. **Name** (Type)" or "### Name"
+  const headerMatch = block.match(/^\d+\.\s+\*\*(.+?)\*\*\s*\((.+?)\)/m) || block.match(/^###\s+(.+?)$/m)
+
+  if (!headerMatch) {
+    return null
+  }
+
+  const name = headerMatch[1].trim()
+  const type = headerMatch[2]?.trim() || 'Convention'
+
+  // Extract fields using regex
+  const whatMatch = block.match(/\*\*What\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+  const whyMatch = block.match(/\*\*Why\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+  const targetMatch = block.match(/\*\*(?:Target|Documented)\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+  const priorityMatch = block.match(/\*\*Priority\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+  const statusMatch = block.match(/\*\*Status\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+  const enforcementMatch = block.match(/\*\*Enforcement\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+  const detectedMatch = block.match(/\*\*Detected\*\*:\s*(.+?)(?=\n\s*-|\n\s*\*\*|$)/s)
+
+  const what = whatMatch?.[1]?.trim() || ''
+  const why = whyMatch?.[1]?.trim() || ''
+  const wikiPath = targetMatch?.[1]?.trim()
+
+  // Determine actual status from status field or section default
+  let status = defaultStatus
+  if (statusMatch) {
+    const statusText = statusMatch[1].toLowerCase()
+    if (statusText.includes('documented') || statusText.includes('✅')) {
+      status = 'documented'
+    } else if (statusText.includes('pending') || statusText.includes('⏳')) {
+      status = 'pending'
+    } else if (statusText.includes('proposed')) {
+      status = 'proposed'
+    }
+  }
+
+  return {
+    name,
+    type,
+    category: inferCategory(type, wikiPath),
+    severity: parseSeverity(priorityMatch?.[1]),
+    status,
+    what,
+    why,
+    wikiPath,
+    enforcement: enforcementMatch?.[1]?.trim(),
+    detectedDate: detectedMatch?.[1]?.trim()
+  }
+}
+
+/**
+ * Parse conventions-tracking.md content into structured data
+ */
+export function parseConventions(content: string): ParsedConventions {
+  const conventions: Convention[] = []
+
+  // Extract metadata
+  const lastUpdatedMatch = content.match(/\*\*Last Updated\*\*:\s*(\d{4}-\d{2}-\d{2})/)
+  const totalMatch = content.match(/\*\*Total Conventions\*\*:\s*(\d+)\s*detected,\s*(\d+)\s*documented,\s*(\d+)\s*pending/)
+
+  // Split by sections
+  const sections: Array<{pattern: RegExp; status: ConventionStatus}> = [
+    {pattern: /## 🟡 Pending Documentation([\s\S]*?)(?=## ✅|## 💭|## 🗄️|## Usage|$)/, status: 'pending'},
+    {pattern: /## ✅ Recently Documented([\s\S]*?)(?=## 🟡|## 💭|## 🗄️|## Usage|$)/, status: 'documented'},
+    {pattern: /## 💭 Proposed Conventions([\s\S]*?)(?=## 🟡|## ✅|## 🗄️|## Usage|$)/, status: 'proposed'},
+    {pattern: /## 🗄️ Archived Conventions([\s\S]*?)(?=## 🟡|## ✅|## 💭|## Usage|$)/, status: 'archived'}
+  ]
+
+  for (const {pattern, status} of sections) {
+    const sectionMatch = content.match(pattern)
+    if (!sectionMatch) {
+      continue
+    }
+
+    const sectionContent = sectionMatch[1]
+
+    // Split section into convention blocks (numbered items or ### headers)
+    const blocks = sectionContent.split(/(?=^\d+\.\s+\*\*|^###\s+)/m).filter((b) => b.trim())
+
+    for (const block of blocks) {
+      const convention = parseConventionBlock(block, status)
+      if (convention && convention.what) {
+        conventions.push(convention)
+      }
+    }
+  }
+
+  return {
+    conventions,
+    metadata: {
+      totalCount: totalMatch ? parseInt(totalMatch[1], 10) : conventions.length,
+      documentedCount: totalMatch ? parseInt(totalMatch[2], 10) : conventions.filter((c) => c.status === 'documented').length,
+      pendingCount: totalMatch ? parseInt(totalMatch[3], 10) : conventions.filter((c) => c.status === 'pending').length,
+      lastUpdated: lastUpdatedMatch?.[1]
+    }
+  }
+}
+
+/**
+ * Search conventions by term (searches name, what, why fields)
+ */
+export function searchConventions(conventions: Convention[], term: string): Convention[] {
+  const termLower = term.toLowerCase()
+  return conventions.filter((c) =>
+    c.name.toLowerCase().includes(termLower) || c.what.toLowerCase().includes(termLower) || c.why.toLowerCase().includes(termLower)
+  )
+}
+
+/**
+ * Filter conventions by category
+ */
+export function filterByCategory(conventions: Convention[], category: ConventionCategory): Convention[] {
+  return conventions.filter((c) => c.category === category)
+}
+
+/**
+ * Filter conventions by severity
+ */
+export function filterBySeverity(conventions: Convention[], severity: ConventionSeverity): Convention[] {
+  return conventions.filter((c) => c.severity === severity)
+}
+
+/**
+ * Filter conventions by status
+ */
+export function filterByStatus(conventions: Convention[], status: ConventionStatus): Convention[] {
+  return conventions.filter((c) => c.status === status)
+}

--- a/src/mcp/test/fixtures/conventions-sample.md
+++ b/src/mcp/test/fixtures/conventions-sample.md
@@ -1,0 +1,76 @@
+# Conventions Tracking
+
+Test fixture for convention parser unit tests.
+
+**Last Updated**: 2024-01-15
+**Total Conventions**: 6 detected, 4 documented, 2 pending
+
+## 🟡 Pending Documentation
+
+1. **Test Convention One** (Testing Pattern)
+   - **What**: Use mock helpers for all entity mocking
+   - **Why**: Consistent mocking patterns improve test maintainability
+   - **Detected**: During test implementation
+   - **Target**: docs/wiki/Testing/Mock-Patterns.md
+   - **Priority**: HIGH
+   - **Status**: ⏳ Pending
+   - **Enforcement**: Code review
+
+2. **Test Convention Two** (AWS SDK usage)
+   - **What**: Never import AWS SDK directly
+   - **Why**: Encapsulation and testability
+   - **Detected**: During SDK migration
+   - **Target**: docs/wiki/AWS/SDK-Policy.md
+   - **Priority**: CRITICAL
+   - **Status**: ⏳ Pending
+   - **Enforcement**: Zero-tolerance
+
+## ✅ Recently Documented
+
+1. **Documented Convention One** (Git Rule)
+   - **What**: No AI references in commits
+   - **Why**: Professional commits only
+   - **Detected**: From project setup
+   - **Documented**: docs/wiki/Conventions/Git-Workflow.md
+   - **Priority**: CRITICAL
+   - **Status**: ✅ Documented
+   - **Enforcement**: Zero-tolerance
+
+2. **Documented Convention Two** (TypeScript Pattern)
+   - **What**: Use strict TypeScript configuration
+   - **Why**: Catch errors at compile time
+   - **Detected**: From initial setup
+   - **Documented**: docs/wiki/TypeScript/Config.md
+   - **Priority**: MEDIUM
+   - **Status**: ✅ Documented
+   - **Enforcement**: tsconfig.json
+
+3. **Documented Convention Three** (Security Rule)
+   - **What**: Lifecycle scripts disabled by default
+   - **Why**: Supply chain attack prevention
+   - **Detected**: During pnpm migration
+   - **Documented**: docs/wiki/Meta/pnpm-Migration.md
+   - **Priority**: CRITICAL
+   - **Status**: ✅ Documented
+   - **Enforcement**: .npmrc configuration
+
+4. **Low Priority Convention** (Infrastructure Script)
+   - **What**: Use consistent script naming
+   - **Why**: Developer experience
+   - **Detected**: During script cleanup
+   - **Documented**: docs/wiki/Infrastructure/Scripts.md
+   - **Priority**: LOW
+   - **Status**: ✅ Documented
+   - **Enforcement**: Code review
+
+## 💭 Proposed Conventions
+
+(None currently)
+
+## 🗄️ Archived Conventions
+
+(None currently)
+
+## Usage
+
+This file serves as test data for the convention parser tests.

--- a/src/mcp/test/fixtures/graph-sample.json
+++ b/src/mcp/test/fixtures/graph-sample.json
@@ -1,0 +1,75 @@
+{
+  "metadata": {
+    "generated": "2024-01-15T12:00:00.000Z",
+    "projectRoot": "/test/project",
+    "totalFiles": 10
+  },
+  "files": {
+    "src/lambdas/TestLambda/src/index.ts": {
+      "file": "src/lambdas/TestLambda/src/index.ts",
+      "imports": [
+        "src/entities/Files",
+        "src/entities/Users",
+        "src/lib/vendor/AWS/DynamoDB",
+        "src/util/lambda-helpers"
+      ]
+    },
+    "src/lambdas/AnotherLambda/src/index.ts": {
+      "file": "src/lambdas/AnotherLambda/src/index.ts",
+      "imports": [
+        "src/entities/Files",
+        "src/util/lambda-helpers"
+      ]
+    },
+    "src/entities/Files.ts": {
+      "file": "src/entities/Files.ts",
+      "imports": [
+        "src/lib/vendor/ElectroDB/config"
+      ]
+    },
+    "src/entities/Users.ts": {
+      "file": "src/entities/Users.ts",
+      "imports": [
+        "src/lib/vendor/ElectroDB/config"
+      ]
+    },
+    "src/util/lambda-helpers.ts": {
+      "file": "src/util/lambda-helpers.ts",
+      "imports": []
+    },
+    "src/lib/vendor/AWS/DynamoDB.ts": {
+      "file": "src/lib/vendor/AWS/DynamoDB.ts",
+      "imports": []
+    },
+    "src/lib/vendor/ElectroDB/config.ts": {
+      "file": "src/lib/vendor/ElectroDB/config.ts",
+      "imports": [
+        "src/lib/vendor/AWS/DynamoDB"
+      ]
+    }
+  },
+  "transitiveDependencies": {
+    "src/lambdas/TestLambda/src/index.ts": [
+      "src/entities/Files",
+      "src/entities/Users",
+      "src/lib/vendor/AWS/DynamoDB",
+      "src/lib/vendor/ElectroDB/config",
+      "src/util/lambda-helpers"
+    ],
+    "src/lambdas/AnotherLambda/src/index.ts": [
+      "src/entities/Files",
+      "src/lib/vendor/AWS/DynamoDB",
+      "src/lib/vendor/ElectroDB/config",
+      "src/util/lambda-helpers"
+    ],
+    "src/entities/Files.ts": [
+      "src/lib/vendor/AWS/DynamoDB",
+      "src/lib/vendor/ElectroDB/config"
+    ],
+    "src/entities/Users.ts": [
+      "src/lib/vendor/AWS/DynamoDB",
+      "src/lib/vendor/ElectroDB/config"
+    ]
+  },
+  "circularDependencies": []
+}

--- a/src/mcp/test/fixtures/metadata-sample.json
+++ b/src/mcp/test/fixtures/metadata-sample.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "./metadata.schema.json",
+  "description": "Test fixture for MCP handler tests",
+  "lambdas": {
+    "TestLambda": {
+      "trigger": "API Gateway",
+      "purpose": "Test Lambda for unit tests"
+    },
+    "AnotherLambda": {
+      "trigger": "CloudWatch Events",
+      "purpose": "Another test Lambda"
+    },
+    "ScheduledLambda": {
+      "trigger": "CloudWatch Events",
+      "purpose": "Scheduled background job"
+    }
+  },
+  "externalServices": [
+    { "name": "TestService", "type": "api", "description": "Test external service" },
+    { "name": "APNS", "type": "notification", "description": "Apple Push Notification Service" }
+  ],
+  "awsServices": [
+    { "name": "DynamoDB", "type": "database", "vendorPath": "AWS/DynamoDB" },
+    { "name": "S3", "type": "storage", "vendorPath": "AWS/S3" },
+    { "name": "Lambda", "type": "compute", "vendorPath": "AWS/Lambda" }
+  ],
+  "entityRelationships": [
+    { "from": "Users", "to": "Files", "via": "UserFiles", "type": "many-to-many" },
+    { "from": "Users", "to": "Devices", "via": "UserDevices", "type": "many-to-many" }
+  ],
+  "lambdaInvocations": [
+    { "from": "ScheduledLambda", "to": "TestLambda", "via": "Lambda.invokeFunction" }
+  ]
+}

--- a/src/mcp/test/fixtures/validation/invalid-aws-sdk.ts
+++ b/src/mcp/test/fixtures/validation/invalid-aws-sdk.ts
@@ -1,0 +1,14 @@
+/**
+ * Invalid Lambda handler fixture - AWS SDK violation
+ * This file directly imports AWS SDK (forbidden)
+ */
+
+import type {APIGatewayProxyEvent} from 'aws-lambda'
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
+import {response} from '#util/lambda-helpers'
+
+const client = new DynamoDBClient({})
+
+export async function handler(event: APIGatewayProxyEvent) {
+  return response(200, {message: 'hello'})
+}

--- a/src/mcp/test/fixtures/validation/valid-handler.ts
+++ b/src/mcp/test/fixtures/validation/valid-handler.ts
@@ -1,0 +1,20 @@
+/**
+ * Valid Lambda handler fixture
+ * This file follows all conventions
+ */
+
+import type {APIGatewayProxyEvent} from 'aws-lambda'
+import {v4 as uuid} from 'uuid'
+import {Users} from '#entities/Users'
+import {queryItems} from '#lib/vendor/AWS/DynamoDB'
+import {response} from '#util/lambda-helpers'
+
+export async function handler(event: APIGatewayProxyEvent) {
+  const userId = event.pathParameters?.userId
+  if (!userId) {
+    return response(400, {error: 'Missing userId'})
+  }
+
+  const user = await Users.get({userId}).go()
+  return response(200, {user})
+}

--- a/src/mcp/validation/index.test.ts
+++ b/src/mcp/validation/index.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for validation index module
+ * Tests the unified validation interface
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {join} from 'path'
+
+// Module loaded via dynamic import
+let validateFile: typeof import('./index').validateFile
+let validateFiles: typeof import('./index').validateFiles
+let getValidationSummary: typeof import('./index').getValidationSummary
+let allRules: typeof import('./index').allRules
+let rulesByName: typeof import('./index').rulesByName
+let awsSdkEncapsulationRule: typeof import('./index').awsSdkEncapsulationRule
+
+const fixturesDir = join(process.cwd(), 'src/mcp/test/fixtures/validation')
+
+beforeAll(async () => {
+  const module = await import('./index')
+  validateFile = module.validateFile
+  validateFiles = module.validateFiles
+  getValidationSummary = module.getValidationSummary
+  allRules = module.allRules
+  rulesByName = module.rulesByName
+  awsSdkEncapsulationRule = module.awsSdkEncapsulationRule
+})
+
+describe('validation exports', () => {
+  describe('allRules', () => {
+    test('should export array of rules', () => {
+      expect(Array.isArray(allRules)).toBe(true)
+      expect(allRules.length).toBe(4)
+    })
+
+    test('should contain all expected rules', () => {
+      const ruleNames = allRules.map((r) => r.name)
+      expect(ruleNames).toContain('aws-sdk-encapsulation')
+      expect(ruleNames).toContain('electrodb-mocking')
+      expect(ruleNames).toContain('import-order')
+      expect(ruleNames).toContain('response-helpers')
+    })
+  })
+
+  describe('rulesByName', () => {
+    test('should have all rules by name', () => {
+      expect(rulesByName['aws-sdk-encapsulation']).toBeDefined()
+      expect(rulesByName['electrodb-mocking']).toBeDefined()
+      expect(rulesByName['import-order']).toBeDefined()
+      expect(rulesByName['response-helpers']).toBeDefined()
+    })
+
+    test('should have aliases', () => {
+      expect(rulesByName['aws-sdk']).toBe(rulesByName['aws-sdk-encapsulation'])
+      expect(rulesByName['electrodb']).toBe(rulesByName['electrodb-mocking'])
+      expect(rulesByName['imports']).toBe(rulesByName['import-order'])
+      expect(rulesByName['response']).toBe(rulesByName['response-helpers'])
+    })
+  })
+
+  describe('individual rule exports', () => {
+    test('should export awsSdkEncapsulationRule', () => {
+      expect(awsSdkEncapsulationRule).toBeDefined()
+      expect(awsSdkEncapsulationRule.name).toBe('aws-sdk-encapsulation')
+    })
+  })
+})
+
+describe('validateFile', () => {
+  test('should validate a valid handler file', async () => {
+    const result = await validateFile(join(fixturesDir, 'valid-handler.ts'), {projectRoot: process.cwd()})
+
+    // File path should be relative
+    expect(result.file).toContain('valid-handler.ts')
+    // Should have no critical violations for valid code
+    // Note: Some rules may skip this file if it's not in the right location
+    expect(result.skipped.length + result.passed.length).toBeGreaterThan(0)
+  })
+
+  test('should detect AWS SDK violation', async () => {
+    const result = await validateFile(join(fixturesDir, 'invalid-aws-sdk.ts'), {projectRoot: process.cwd()})
+
+    // Should find the AWS SDK violation
+    const awsViolations = result.violations.filter((v) => v.rule === 'aws-sdk-encapsulation')
+    expect(awsViolations.length).toBeGreaterThan(0)
+    expect(awsViolations[0].severity).toBe('CRITICAL')
+    expect(result.valid).toBe(false)
+  })
+
+  test('should handle non-existent file gracefully', async () => {
+    const result = await validateFile('/path/to/nonexistent.ts')
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toHaveLength(1)
+    expect(result.violations[0].rule).toBe('file-parse')
+  })
+
+  test('should run specific rules when specified', async () => {
+    const result = await validateFile(join(fixturesDir, 'invalid-aws-sdk.ts'), {projectRoot: process.cwd(), rules: ['aws-sdk-encapsulation']})
+
+    // Only the specified rule should run (others skipped)
+    const nonAwsViolations = result.violations.filter((v) => v.rule !== 'aws-sdk-encapsulation' && v.rule !== 'file-parse')
+    expect(nonAwsViolations).toHaveLength(0)
+  })
+
+  test('should skip rules that dont apply', async () => {
+    const result = await validateFile(join(fixturesDir, 'valid-handler.ts'), {projectRoot: process.cwd()})
+
+    // Some rules should be skipped (file not in right location)
+    expect(result.skipped.length).toBeGreaterThan(0)
+  })
+
+  test('should track passed rules', async () => {
+    const result = await validateFile(join(fixturesDir, 'valid-handler.ts'), {projectRoot: process.cwd()})
+
+    // Some rules should pass
+    expect(result.passed.length + result.skipped.length).toBeGreaterThan(0)
+  })
+})
+
+describe('validateFiles', () => {
+  test('should validate multiple files', async () => {
+    const results = await validateFiles([join(fixturesDir, 'valid-handler.ts'), join(fixturesDir, 'invalid-aws-sdk.ts')], {projectRoot: process.cwd()})
+
+    expect(results).toHaveLength(2)
+    expect(results.every((r) => r.file)).toBe(true)
+  })
+
+  test('should return results in same order as input', async () => {
+    const results = await validateFiles([join(fixturesDir, 'invalid-aws-sdk.ts'), join(fixturesDir, 'valid-handler.ts')], {projectRoot: process.cwd()})
+
+    expect(results[0].file).toContain('invalid-aws-sdk.ts')
+    expect(results[1].file).toContain('valid-handler.ts')
+  })
+
+  test('should handle empty array', async () => {
+    const results = await validateFiles([])
+
+    expect(results).toHaveLength(0)
+  })
+})
+
+describe('getValidationSummary', () => {
+  test('should compute correct totals', async () => {
+    const results = await validateFiles([join(fixturesDir, 'valid-handler.ts'), join(fixturesDir, 'invalid-aws-sdk.ts')], {projectRoot: process.cwd()})
+
+    const summary = getValidationSummary(results)
+
+    expect(summary.totalFiles).toBe(2)
+    expect(summary.validFiles + summary.invalidFiles).toBe(2)
+    // Invalid file should have at least one violation
+    expect(summary.invalidFiles).toBeGreaterThanOrEqual(1)
+  })
+
+  test('should count violations by severity', async () => {
+    const results = await validateFiles([join(fixturesDir, 'invalid-aws-sdk.ts')], {projectRoot: process.cwd()})
+
+    const summary = getValidationSummary(results)
+
+    expect(summary.violationsBySeverity).toBeDefined()
+    // AWS SDK violation is CRITICAL
+    expect(summary.violationsBySeverity['CRITICAL']).toBeGreaterThan(0)
+  })
+
+  test('should count violations by rule', async () => {
+    const results = await validateFiles([join(fixturesDir, 'invalid-aws-sdk.ts')], {projectRoot: process.cwd()})
+
+    const summary = getValidationSummary(results)
+
+    expect(summary.violationsByRule).toBeDefined()
+    expect(summary.violationsByRule['aws-sdk-encapsulation']).toBeGreaterThan(0)
+  })
+
+  test('should handle empty results', () => {
+    const summary = getValidationSummary([])
+
+    expect(summary.totalFiles).toBe(0)
+    expect(summary.validFiles).toBe(0)
+    expect(summary.invalidFiles).toBe(0)
+    expect(summary.totalViolations).toBe(0)
+  })
+
+  test('should handle results with no violations', async () => {
+    // Create a mock valid result
+    const mockResults = [
+      {file: 'test.ts', valid: true, violations: [], passed: ['rule1'], skipped: []}
+    ]
+
+    const summary = getValidationSummary(mockResults)
+
+    expect(summary.totalFiles).toBe(1)
+    expect(summary.validFiles).toBe(1)
+    expect(summary.invalidFiles).toBe(0)
+    expect(summary.totalViolations).toBe(0)
+  })
+})
+
+describe('rule applicability', () => {
+  test('should apply aws-sdk rule to src/**/*.ts files', async () => {
+    // The invalid-aws-sdk fixture is in a non-standard path but still a .ts file
+    const result = await validateFile(join(fixturesDir, 'invalid-aws-sdk.ts'), {projectRoot: process.cwd(), rules: ['aws-sdk-encapsulation']})
+
+    // Rule should apply (not skipped) for .ts files in src/
+    const applied = !result.skipped.includes('aws-sdk-encapsulation')
+    expect(applied).toBe(true)
+  })
+
+  test('should skip rules for excluded paths', async () => {
+    // Test file should be skipped by response-helpers rule
+    const result = await validateFile(join(fixturesDir, 'valid-handler.ts'), {projectRoot: process.cwd(), rules: ['response-helpers']})
+
+    // response-helpers only applies to src/lambdas/**/src/index.ts
+    expect(result.skipped).toContain('response-helpers')
+  })
+})
+
+describe('edge cases', () => {
+  test('should handle relative file paths', async () => {
+    const relativePath = 'src/mcp/test/fixtures/validation/valid-handler.ts'
+    const result = await validateFile(relativePath, {projectRoot: process.cwd()})
+
+    expect(result.file).toBe(relativePath)
+  })
+
+  test('should handle unknown rule names gracefully', async () => {
+    const result = await validateFile(join(fixturesDir, 'valid-handler.ts'), {projectRoot: process.cwd(), rules: ['nonexistent-rule']})
+
+    // Should not crash, just no rules run
+    expect(result).toBeDefined()
+    expect(result.violations).toHaveLength(0)
+  })
+})

--- a/src/mcp/validation/index.ts
+++ b/src/mcp/validation/index.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared validation core for MCP convention checking
+ * Exports all validation rules and provides a unified validation interface
+ *
+ * This module can be consumed by:
+ * - MCP validate_pattern tool
+ * - CI validation scripts
+ * - Future tooling
+ */
+
+import {Project, SourceFile} from 'ts-morph'
+import * as path from 'node:path'
+import {ValidationResult, ValidationRule, Violation} from './types'
+import {awsSdkEncapsulationRule} from './rules/aws-sdk-encapsulation'
+import {electrodbMockingRule} from './rules/electrodb-mocking'
+import {importOrderRule} from './rules/import-order'
+import {responseHelpersRule} from './rules/response-helpers'
+
+// Export all rules
+export const allRules: ValidationRule[] = [awsSdkEncapsulationRule, electrodbMockingRule, importOrderRule, responseHelpersRule]
+
+// Export rules by name for selective validation
+export const rulesByName: Record<string, ValidationRule> = {
+  'aws-sdk-encapsulation': awsSdkEncapsulationRule,
+  'aws-sdk': awsSdkEncapsulationRule, // alias
+  'electrodb-mocking': electrodbMockingRule,
+  electrodb: electrodbMockingRule, // alias
+  'import-order': importOrderRule,
+  imports: importOrderRule, // alias
+  'response-helpers': responseHelpersRule,
+  response: responseHelpersRule // alias
+}
+
+// Export individual rules
+export { awsSdkEncapsulationRule, electrodbMockingRule, importOrderRule, responseHelpersRule }
+
+// Export types
+export * from './types'
+
+/**
+ * Check if a file path matches a glob-like pattern
+ */
+function matchesPattern(filePath: string, pattern: string): boolean {
+  // Simple glob matching: ** matches any path segment, * matches within segment
+  const regexPattern = pattern.replace(/\*\*/g, '{{DOUBLE_STAR}}').replace(/\*/g, '[^/]*').replace(/{{DOUBLE_STAR}}/g, '.*').replace(/\//g, '\\/')
+
+  const regex = new RegExp(`^${regexPattern}$`)
+  return regex.test(filePath)
+}
+
+/**
+ * Check if a rule applies to a given file
+ */
+function ruleApplies(rule: ValidationRule, filePath: string): boolean {
+  // Check if file matches any of the appliesTo patterns
+  const applies = rule.appliesTo.some((pattern) => matchesPattern(filePath, pattern))
+
+  if (!applies) {
+    return false
+  }
+
+  // Check if file matches any exclude patterns
+  if (rule.excludes) {
+    const excluded = rule.excludes.some((pattern) => matchesPattern(filePath, pattern))
+    if (excluded) {
+      return false
+    }
+  }
+
+  return true
+}
+
+interface ValidateFileOptions {
+  /** Specific rules to run (by name). If not provided, runs all applicable rules */
+  rules?: string[]
+  /** Project root for context */
+  projectRoot?: string
+}
+
+/**
+ * Validate a single file against convention rules
+ */
+export async function validateFile(filePath: string, options: ValidateFileOptions = {}): Promise<ValidationResult> {
+  const projectRoot = options.projectRoot || process.cwd()
+  const relativePath = filePath.startsWith(projectRoot) ? path.relative(projectRoot, filePath) : filePath
+
+  // Create ts-morph project and load the file
+  const project = new Project({skipFileDependencyResolution: true})
+
+  let sourceFile: SourceFile
+  try {
+    sourceFile = project.addSourceFileAtPath(path.isAbsolute(filePath) ? filePath : path.join(projectRoot, filePath))
+  } catch (error) {
+    return {
+      file: relativePath,
+      valid: false,
+      violations: [
+        {rule: 'file-parse', severity: 'CRITICAL', line: 0, message: `Failed to parse file: ${error instanceof Error ? error.message : String(error)}`}
+      ],
+      passed: [],
+      skipped: []
+    }
+  }
+
+  const violations: Violation[] = []
+  const passed: string[] = []
+  const skipped: string[] = []
+
+  // Determine which rules to run
+  const rulesToRun = options.rules ? options.rules.map((name) => rulesByName[name]).filter(Boolean) : allRules
+
+  for (const rule of rulesToRun) {
+    if (!ruleApplies(rule, relativePath)) {
+      skipped.push(rule.name)
+      continue
+    }
+
+    try {
+      const ruleViolations = rule.validate(sourceFile, relativePath)
+      if (ruleViolations.length > 0) {
+        violations.push(...ruleViolations)
+      } else {
+        passed.push(rule.name)
+      }
+    } catch (error) {
+      violations.push({
+        rule: rule.name,
+        severity: 'HIGH',
+        line: 0,
+        message: `Rule execution failed: ${error instanceof Error ? error.message : String(error)}`
+      })
+    }
+  }
+
+  return {file: relativePath, valid: violations.length === 0, violations, passed, skipped}
+}
+
+/**
+ * Validate multiple files
+ */
+export async function validateFiles(filePaths: string[], options: ValidateFileOptions = {}): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = []
+
+  for (const filePath of filePaths) {
+    const result = await validateFile(filePath, options)
+    results.push(result)
+  }
+
+  return results
+}
+
+/**
+ * Get validation summary for multiple results
+ */
+export function getValidationSummary(
+  results: ValidationResult[]
+): {
+  totalFiles: number
+  validFiles: number
+  invalidFiles: number
+  totalViolations: number
+  violationsBySeverity: Record<string, number>
+  violationsByRule: Record<string, number>
+} {
+  const violationsBySeverity: Record<string, number> = {}
+  const violationsByRule: Record<string, number> = {}
+  let totalViolations = 0
+
+  for (const result of results) {
+    for (const violation of result.violations) {
+      totalViolations++
+      violationsBySeverity[violation.severity] = (violationsBySeverity[violation.severity] || 0) + 1
+      violationsByRule[violation.rule] = (violationsByRule[violation.rule] || 0) + 1
+    }
+  }
+
+  return {
+    totalFiles: results.length,
+    validFiles: results.filter((r) => r.valid).length,
+    invalidFiles: results.filter((r) => !r.valid).length,
+    totalViolations,
+    violationsBySeverity,
+    violationsByRule
+  }
+}

--- a/src/mcp/validation/rules/aws-sdk-encapsulation.test.ts
+++ b/src/mcp/validation/rules/aws-sdk-encapsulation.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for aws-sdk-encapsulation rule
+ * CRITICAL: No direct AWS SDK imports outside lib/vendor/AWS/
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {Project} from 'ts-morph'
+
+// Module loaded via dynamic import
+let awsSdkEncapsulationRule: typeof import('./aws-sdk-encapsulation').awsSdkEncapsulationRule
+
+// Create ts-morph project for in-memory source files
+const project = new Project({skipFileDependencyResolution: true, skipAddingFilesFromTsConfig: true})
+
+beforeAll(async () => {
+  const module = await import('./aws-sdk-encapsulation')
+  awsSdkEncapsulationRule = module.awsSdkEncapsulationRule
+})
+
+describe('aws-sdk-encapsulation rule', () => {
+  describe('rule metadata', () => {
+    test('should have correct name', () => {
+      expect(awsSdkEncapsulationRule.name).toBe('aws-sdk-encapsulation')
+    })
+
+    test('should have CRITICAL severity', () => {
+      expect(awsSdkEncapsulationRule.severity).toBe('CRITICAL')
+    })
+
+    test('should apply to src/**/*.ts files', () => {
+      expect(awsSdkEncapsulationRule.appliesTo).toContain('src/**/*.ts')
+    })
+
+    test('should exclude vendor files', () => {
+      expect(awsSdkEncapsulationRule.excludes).toContain('src/lib/vendor/AWS/**/*.ts')
+    })
+  })
+
+  describe('detects direct AWS SDK imports', () => {
+    test('should detect @aws-sdk/client-dynamodb import', () => {
+      const sourceFile = project.createSourceFile('test-dynamodb.ts', 'import {DynamoDBClient} from \'@aws-sdk/client-dynamodb\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].severity).toBe('CRITICAL')
+      expect(violations[0].message).toContain('@aws-sdk/client-dynamodb')
+    })
+
+    test('should detect @aws-sdk/client-s3 import', () => {
+      const sourceFile = project.createSourceFile('test-s3.ts', 'import {S3Client, PutObjectCommand} from \'@aws-sdk/client-s3\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('@aws-sdk/client-s3')
+    })
+
+    test('should detect @aws-sdk/lib-dynamodb import', () => {
+      const sourceFile = project.createSourceFile('test-lib.ts', 'import {DynamoDBDocumentClient} from \'@aws-sdk/lib-dynamodb\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('@aws-sdk/lib-dynamodb')
+    })
+
+    test('should detect @aws-sdk/client-sns import', () => {
+      const sourceFile = project.createSourceFile('test-sns.ts', 'import {SNSClient} from \'@aws-sdk/client-sns\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should detect @aws-sdk/client-lambda import', () => {
+      const sourceFile = project.createSourceFile('test-lambda.ts', 'import {LambdaClient} from \'@aws-sdk/client-lambda\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should detect multiple AWS SDK imports', () => {
+      const sourceFile = project.createSourceFile('test-multiple.ts', `import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
+import {S3Client} from '@aws-sdk/client-s3'
+import {SNSClient} from '@aws-sdk/client-sns'`, {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(3)
+    })
+  })
+
+  describe('detects dynamic AWS SDK imports', () => {
+    test('should detect dynamic import of AWS SDK', () => {
+      const sourceFile = project.createSourceFile('test-dynamic.ts', 'const sdk = await import(\'@aws-sdk/client-dynamodb\')', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('Dynamic AWS SDK import forbidden')
+    })
+  })
+
+  describe('allows valid patterns', () => {
+    test('should allow vendor wrapper imports', () => {
+      const sourceFile = project.createSourceFile('test-vendor.ts', `import {queryItems} from '#lib/vendor/AWS/DynamoDB'
+import {uploadToS3} from '#lib/vendor/AWS/S3'`, {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow other package imports', () => {
+      const sourceFile = project.createSourceFile('test-other.ts', `import {v4 as uuidv4} from 'uuid'
+import {APIGatewayProxyEvent} from 'aws-lambda'`, {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow entity imports', () => {
+      const sourceFile = project.createSourceFile('test-entities.ts', `import {Files} from '#entities/Files'
+import {Users} from '#entities/Users'`, {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('skips vendor files', () => {
+    test('should skip files in lib/vendor/AWS/', () => {
+      const sourceFile = project.createSourceFile('test-vendor-internal.ts', 'import {DynamoDBClient} from \'@aws-sdk/client-dynamodb\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lib/vendor/AWS/DynamoDB.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should skip files in lib/vendor/', () => {
+      const sourceFile = project.createSourceFile('test-vendor-root.ts', 'import {S3Client} from \'@aws-sdk/client-s3\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lib/vendor/AWS/S3.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('provides helpful suggestions', () => {
+    test('should suggest DynamoDB vendor wrapper', () => {
+      const sourceFile = project.createSourceFile('test-suggestion-dynamodb.ts', 'import {DynamoDBClient} from \'@aws-sdk/client-dynamodb\'', {
+        overwrite: true
+      })
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].suggestion).toContain('lib/vendor/AWS/DynamoDB')
+    })
+
+    test('should suggest S3 vendor wrapper', () => {
+      const sourceFile = project.createSourceFile('test-suggestion-s3.ts', 'import {S3Client} from \'@aws-sdk/client-s3\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].suggestion).toContain('lib/vendor/AWS/S3')
+    })
+  })
+
+  describe('includes code context', () => {
+    test('should include code snippet in violation', () => {
+      const sourceFile = project.createSourceFile('test-snippet.ts', 'import {DynamoDBClient} from \'@aws-sdk/client-dynamodb\'', {overwrite: true})
+
+      const violations = awsSdkEncapsulationRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].codeSnippet).toBeDefined()
+      expect(violations[0].codeSnippet).toContain('@aws-sdk/client-dynamodb')
+    })
+  })
+})

--- a/src/mcp/validation/rules/aws-sdk-encapsulation.ts
+++ b/src/mcp/validation/rules/aws-sdk-encapsulation.ts
@@ -1,0 +1,107 @@
+/**
+ * AWS SDK Encapsulation Rule
+ * CRITICAL: Never import AWS SDK directly - use lib/vendor/AWS/ wrappers
+ *
+ * This is a zero-tolerance rule per project conventions.
+ */
+
+import type {SourceFile} from 'ts-morph'
+import {SyntaxKind} from 'ts-morph'
+import {createViolation, ValidationRule, Violation} from '../types'
+
+const RULE_NAME = 'aws-sdk-encapsulation'
+const SEVERITY = 'CRITICAL' as const
+
+/**
+ * AWS SDK packages that should never be imported directly
+ */
+const FORBIDDEN_PACKAGES = [
+  '@aws-sdk/client-',
+  '@aws-sdk/lib-',
+  '@aws-sdk/util-',
+  '@aws-sdk/credential-',
+  '@aws-sdk/middleware-',
+  'aws-sdk' // v2
+]
+
+/**
+ * Suggested vendor wrapper mappings
+ */
+const VENDOR_SUGGESTIONS: Record<string, string> = {
+  '@aws-sdk/client-dynamodb': 'lib/vendor/AWS/DynamoDB',
+  '@aws-sdk/lib-dynamodb': 'lib/vendor/AWS/DynamoDB',
+  '@aws-sdk/client-s3': 'lib/vendor/AWS/S3',
+  '@aws-sdk/client-lambda': 'lib/vendor/AWS/Lambda',
+  '@aws-sdk/client-sns': 'lib/vendor/AWS/SNS',
+  '@aws-sdk/client-sqs': 'lib/vendor/AWS/SQS',
+  '@aws-sdk/client-cloudwatch-logs': 'lib/vendor/AWS/CloudWatch',
+  '@aws-sdk/client-secrets-manager': 'lib/vendor/AWS/SecretsManager'
+}
+
+function getSuggestion(moduleSpecifier: string): string {
+  for (const [pattern, vendor] of Object.entries(VENDOR_SUGGESTIONS)) {
+    if (moduleSpecifier.startsWith(pattern) || moduleSpecifier === pattern) {
+      return `Import from '${vendor}' instead`
+    }
+  }
+  return 'Create a vendor wrapper in lib/vendor/AWS/ for this service'
+}
+
+export const awsSdkEncapsulationRule: ValidationRule = {
+  name: RULE_NAME,
+  description: 'Never import AWS SDK packages directly. Use lib/vendor/AWS/ wrappers for encapsulation, type safety, and testability.',
+  severity: SEVERITY,
+  appliesTo: ['src/**/*.ts'],
+  excludes: ['src/lib/vendor/AWS/**/*.ts', 'src/**/*.test.ts', 'test/**/*.ts'],
+
+  validate(sourceFile: SourceFile, filePath: string): Violation[] {
+    const violations: Violation[] = []
+
+    // Skip vendor directory - that's where direct imports are allowed
+    if (filePath.includes('lib/vendor/AWS')) {
+      return violations
+    }
+
+    // Check all import declarations
+    const imports = sourceFile.getImportDeclarations()
+
+    for (const importDecl of imports) {
+      const moduleSpecifier = importDecl.getModuleSpecifierValue()
+
+      // Check if this is a forbidden AWS SDK import
+      const isForbidden = FORBIDDEN_PACKAGES.some((pkg) => moduleSpecifier.startsWith(pkg))
+
+      if (isForbidden) {
+        const line = importDecl.getStartLineNumber()
+        const importText = importDecl.getText()
+
+        violations.push(
+          createViolation(RULE_NAME, SEVERITY, line, `Direct AWS SDK import forbidden: '${moduleSpecifier}'`, {
+            suggestion: getSuggestion(moduleSpecifier),
+            codeSnippet: importText.substring(0, 100)
+          })
+        )
+      }
+    }
+
+    // Also check dynamic imports
+    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)
+    for (const call of callExpressions) {
+      const expression = call.getExpression()
+      if (expression.getText() === 'import') {
+        const args = call.getArguments()
+        if (args.length > 0) {
+          const arg = args[0].getText().replace(/['"]/g, '')
+          const isForbidden = FORBIDDEN_PACKAGES.some((pkg) => arg.startsWith(pkg))
+          if (isForbidden) {
+            violations.push(
+              createViolation(RULE_NAME, SEVERITY, call.getStartLineNumber(), `Dynamic AWS SDK import forbidden: '${arg}'`, {suggestion: getSuggestion(arg)})
+            )
+          }
+        }
+      }
+    }
+
+    return violations
+  }
+}

--- a/src/mcp/validation/rules/electrodb-mocking.test.ts
+++ b/src/mcp/validation/rules/electrodb-mocking.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for electrodb-mocking rule
+ * CRITICAL: Test files must use createElectroDBEntityMock() helper
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {Project} from 'ts-morph'
+
+// Module loaded via dynamic import
+let electrodbMockingRule: typeof import('./electrodb-mocking').electrodbMockingRule
+
+// Create ts-morph project for in-memory source files
+const project = new Project({skipFileDependencyResolution: true, skipAddingFilesFromTsConfig: true})
+
+beforeAll(async () => {
+  const module = await import('./electrodb-mocking')
+  electrodbMockingRule = module.electrodbMockingRule
+})
+
+describe('electrodb-mocking rule', () => {
+  describe('rule metadata', () => {
+    test('should have correct name', () => {
+      expect(electrodbMockingRule.name).toBe('electrodb-mocking')
+    })
+
+    test('should have CRITICAL severity', () => {
+      expect(electrodbMockingRule.severity).toBe('CRITICAL')
+    })
+
+    test('should apply to test files', () => {
+      expect(electrodbMockingRule.appliesTo).toContain('src/**/*.test.ts')
+      expect(electrodbMockingRule.appliesTo).toContain('test/**/*.ts')
+    })
+
+    test('should exclude helper files', () => {
+      expect(electrodbMockingRule.excludes).toContain('test/helpers/**/*.ts')
+    })
+  })
+
+  describe('skips non-test files', () => {
+    test('should skip files not in test directories', () => {
+      const sourceFile = project.createSourceFile('test-non-test.ts', `import {Users} from '#entities/Users'
+jest.unstable_mockModule('#entities/Users', () => ({
+  Users: { get: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should skip helper files', () => {
+      const sourceFile = project.createSourceFile('test-helper.ts', `import {Users} from '#entities/Users'
+jest.unstable_mockModule('#entities/Users', () => ({
+  Users: { get: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'test/helpers/electrodb-mock.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('detects manual entity mocking', () => {
+    test('should detect jest.unstable_mockModule without helper', () => {
+      const sourceFile = project.createSourceFile('test-mock-users.ts', `import {beforeAll, describe, test} from '@jest/globals'
+import {Users} from '#entities/Users'
+
+jest.unstable_mockModule('#entities/Users', () => ({
+  Users: {
+    get: jest.fn(),
+    create: jest.fn()
+  }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].severity).toBe('CRITICAL')
+      expect(violations[0].message).toContain('#entities/Users')
+      expect(violations[0].message).toContain('createElectroDBEntityMock')
+    })
+
+    test('should detect jest.mock without helper', () => {
+      const sourceFile = project.createSourceFile('test-mock-files.ts', `import {beforeAll, describe, test} from '@jest/globals'
+import {Files} from '#entities/Files'
+
+jest.mock('#entities/Files', () => ({
+  Files: {
+    get: jest.fn(),
+    put: jest.fn()
+  }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('#entities/Files')
+    })
+
+    test('should detect mocking of UserFiles entity', () => {
+      const sourceFile = project.createSourceFile('test-mock-userfiles.ts', `jest.unstable_mockModule('#entities/UserFiles', () => ({
+  UserFiles: { query: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'test/integration/user.test.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should detect mocking of Devices entity', () => {
+      const sourceFile = project.createSourceFile('test-mock-devices.ts', `jest.unstable_mockModule('#entities/Devices', () => ({
+  Devices: { scan: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'test/unit/devices.test.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+  })
+
+  describe('allows correct mocking patterns', () => {
+    test('should allow createElectroDBEntityMock usage', () => {
+      const sourceFile = project.createSourceFile('test-correct-mock.ts', `import {createElectroDBEntityMock} from '../../../../test/helpers/electrodb-mock'
+import {Users} from '#entities/Users'
+
+const UsersMock = createElectroDBEntityMock({
+  get: jest.fn(),
+  create: jest.fn()
+})
+
+jest.unstable_mockModule('#entities/Users', () => ({
+  Users: createElectroDBEntityMock({get: jest.fn()})
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow test files without entity imports', () => {
+      const sourceFile = project.createSourceFile('test-no-entities.ts', `import {describe, expect, test} from '@jest/globals'
+
+describe('utility function', () => {
+  test('should work', () => {
+    expect(true).toBe(true)
+  })
+})`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/util/test/helpers.test.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow non-entity mocks', () => {
+      const sourceFile = project.createSourceFile('test-other-mocks.ts', `import {describe, test} from '@jest/globals'
+
+jest.unstable_mockModule('#lib/vendor/AWS/S3', () => ({
+  uploadToS3: jest.fn()
+}))
+
+jest.unstable_mockModule('#util/lambda-helpers', () => ({
+  response: jest.fn()
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('detects entity usage without helper import', () => {
+    test('should warn when mocking entities without helper', () => {
+      const sourceFile = project.createSourceFile('test-missing-import.ts', `import {describe, test} from '@jest/globals'
+
+// File references entities but doesn't use helper
+const mockUsers = {
+  get: jest.fn()
+}
+
+jest.unstable_mockModule('#entities/Users', () => ({
+  Users: mockUsers
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations.length).toBeGreaterThan(0)
+      expect(violations[0].suggestion).toContain('createElectroDBEntityMock')
+    })
+  })
+
+  describe('provides helpful suggestions', () => {
+    test('should suggest proper import path', () => {
+      const sourceFile = project.createSourceFile('test-suggestion.ts', `jest.unstable_mockModule('#entities/Users', () => ({
+  Users: { get: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations[0].suggestion).toBeDefined()
+      expect(violations[0].suggestion).toContain('createElectroDBEntityMock')
+    })
+
+    test('should include code snippet', () => {
+      const sourceFile = project.createSourceFile('test-snippet.ts', `jest.unstable_mockModule('#entities/Files', () => ({
+  Files: { query: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'test/lambdas/files.test.ts')
+
+      expect(violations[0].codeSnippet).toBeDefined()
+      expect(violations[0].codeSnippet).toContain('#entities/Files')
+    })
+  })
+
+  describe('handles multiple entities', () => {
+    test('should detect multiple manual entity mocks', () => {
+      const sourceFile = project.createSourceFile('test-multiple-entities.ts', `jest.unstable_mockModule('#entities/Users', () => ({
+  Users: { get: jest.fn() }
+}))
+
+jest.unstable_mockModule('#entities/Files', () => ({
+  Files: { query: jest.fn() }
+}))
+
+jest.unstable_mockModule('#entities/Devices', () => ({
+  Devices: { scan: jest.fn() }
+}))`, {overwrite: true})
+
+      const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+      expect(violations.length).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('all known entities', () => {
+    const entities = ['Users', 'Files', 'Devices', 'UserFiles', 'UserDevices', 'Sessions', 'Accounts', 'Verifications']
+
+    entities.forEach((entity) => {
+      test(`should detect manual mock of ${entity}`, () => {
+        const sourceFile = project.createSourceFile(`test-${entity.toLowerCase()}.ts`, `jest.unstable_mockModule('#entities/${entity}', () => ({
+  ${entity}: { get: jest.fn() }
+}))`, {overwrite: true})
+
+        const violations = electrodbMockingRule.validate(sourceFile, 'src/lambdas/Test/test/index.test.ts')
+
+        expect(violations).toHaveLength(1)
+        expect(violations[0].message).toContain(entity)
+      })
+    })
+  })
+})

--- a/src/mcp/validation/rules/electrodb-mocking.ts
+++ b/src/mcp/validation/rules/electrodb-mocking.ts
@@ -1,0 +1,116 @@
+/**
+ * ElectroDB Mocking Rule
+ * CRITICAL: Test files must use createElectroDBEntityMock() helper
+ *
+ * This ensures consistent mocking patterns and proper type safety.
+ */
+
+import type {SourceFile} from 'ts-morph'
+import {SyntaxKind} from 'ts-morph'
+import {createViolation, ValidationRule, Violation} from '../types'
+
+const RULE_NAME = 'electrodb-mocking'
+const SEVERITY = 'CRITICAL' as const
+
+/**
+ * Entity names that should be mocked with the helper
+ */
+const ENTITY_NAMES = ['Users', 'Files', 'Devices', 'UserFiles', 'UserDevices', 'Sessions', 'Accounts', 'Verifications']
+
+export const electrodbMockingRule: ValidationRule = {
+  name: RULE_NAME,
+  description: 'Test files must use createElectroDBEntityMock() from test/helpers/electrodb-mock.ts for mocking ElectroDB entities.',
+  severity: SEVERITY,
+  appliesTo: ['src/**/*.test.ts', 'test/**/*.ts'],
+  excludes: ['test/helpers/**/*.ts'],
+
+  validate(sourceFile: SourceFile, filePath: string): Violation[] {
+    const violations: Violation[] = []
+
+    // Only check test files
+    if (!filePath.includes('.test.') && !filePath.includes('/test/')) {
+      return violations
+    }
+
+    // Skip the helper file itself
+    if (filePath.includes('electrodb-mock')) {
+      return violations
+    }
+
+    const content = sourceFile.getFullText()
+
+    // Check if file imports any entities
+    const imports = sourceFile.getImportDeclarations()
+    const importsEntities = imports.some((imp) => {
+      const moduleSpec = imp.getModuleSpecifierValue()
+      return moduleSpec.includes('entities/') || ENTITY_NAMES.some((e) => moduleSpec.includes(e))
+    })
+
+    // Check if file mocks entities
+    const mocksEntities = ENTITY_NAMES.some((entity) => content.includes(`#entities/${entity}`) || content.includes(`entities/${entity}`))
+
+    if (!importsEntities && !mocksEntities) {
+      return violations // No entity usage, rule doesn't apply
+    }
+
+    // Check if createElectroDBEntityMock is imported
+    const hasCorrectImport = imports.some((imp) => {
+      const moduleSpec = imp.getModuleSpecifierValue()
+      const namedImports = imp.getNamedImports().map((n) => n.getName())
+      return (moduleSpec.includes('electrodb-mock') || moduleSpec.includes('test/helpers')) && namedImports.includes('createElectroDBEntityMock')
+    })
+
+    // Check for manual entity mocking patterns
+    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)
+
+    for (const call of callExpressions) {
+      const expression = call.getExpression()
+      const expressionText = expression.getText()
+
+      // Check for jest.unstable_mockModule with entity paths
+      if (expressionText === 'jest.unstable_mockModule' || expressionText === 'jest.mock') {
+        const args = call.getArguments()
+        if (args.length > 0) {
+          const modulePath = args[0].getText().replace(/['"]/g, '')
+
+          // Check if mocking an entity
+          const isEntityMock = modulePath.includes('entities/') || ENTITY_NAMES.some((e) => modulePath.includes(e))
+
+          if (isEntityMock && args.length > 1) {
+            // Check if the mock implementation uses createElectroDBEntityMock
+            const mockImpl = args[1].getText()
+
+            if (!mockImpl.includes('createElectroDBEntityMock')) {
+              violations.push(
+                createViolation(RULE_NAME, SEVERITY, call.getStartLineNumber(),
+                  `Manual entity mock detected for '${modulePath}'. Use createElectroDBEntityMock() instead.`, {
+                  suggestion: `const ${
+                    modulePath.split('/').pop()
+                  }Mock = createElectroDBEntityMock({...})\njest.unstable_mockModule('${modulePath}', () => ({${modulePath.split('/').pop()}: ${
+                    modulePath.split('/').pop()
+                  }Mock.entity}))`,
+                  codeSnippet: call.getText().substring(0, 150)
+                })
+              )
+            }
+          }
+        }
+      }
+    }
+
+    // If file mocks entities but doesn't import the helper
+    if (mocksEntities && !hasCorrectImport && violations.length === 0) {
+      // Check if they're using the mock helper correctly
+      const usesHelper = content.includes('createElectroDBEntityMock')
+      if (!usesHelper) {
+        violations.push(
+          createViolation(RULE_NAME, SEVERITY, 1, 'File mocks ElectroDB entities but does not use createElectroDBEntityMock() helper', {
+            suggestion: "import {createElectroDBEntityMock} from '../../../../test/helpers/electrodb-mock'"
+          })
+        )
+      }
+    }
+
+    return violations
+  }
+}

--- a/src/mcp/validation/rules/import-order.test.ts
+++ b/src/mcp/validation/rules/import-order.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for import-order rule
+ * MEDIUM: Imports should be grouped and ordered consistently
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {Project} from 'ts-morph'
+
+// Module loaded via dynamic import
+let importOrderRule: typeof import('./import-order').importOrderRule
+
+// Create ts-morph project for in-memory source files
+const project = new Project({skipFileDependencyResolution: true, skipAddingFilesFromTsConfig: true})
+
+beforeAll(async () => {
+  const module = await import('./import-order')
+  importOrderRule = module.importOrderRule
+})
+
+describe('import-order rule', () => {
+  describe('rule metadata', () => {
+    test('should have correct name', () => {
+      expect(importOrderRule.name).toBe('import-order')
+    })
+
+    test('should have MEDIUM severity', () => {
+      expect(importOrderRule.severity).toBe('MEDIUM')
+    })
+
+    test('should apply to Lambda handler files', () => {
+      expect(importOrderRule.appliesTo).toContain('src/lambdas/**/src/*.ts')
+    })
+
+    test('should exclude test files', () => {
+      expect(importOrderRule.excludes).toContain('**/*.test.ts')
+    })
+  })
+
+  describe('skips non-handler files', () => {
+    test('should skip files not in lambdas directory', () => {
+      const sourceFile = project.createSourceFile('test-util.ts', `import {v4} from 'uuid'
+import {Users} from '#entities/Users'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/util/helpers.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should skip non-index.ts files', () => {
+      const sourceFile = project.createSourceFile('test-helper.ts', `import {Users} from '#entities/Users'
+import type {APIGatewayProxyEvent} from 'aws-lambda'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/helper.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should skip files with less than 2 imports', () => {
+      const sourceFile = project.createSourceFile('test-single.ts', 'import {Users} from \'#entities/Users\'', {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('validates correct import order', () => {
+    test('should allow correct order: aws-lambda → external → entities', () => {
+      const sourceFile = project.createSourceFile('test-correct-order.ts', `import type {APIGatewayProxyEvent} from 'aws-lambda'
+import {v4} from 'uuid'
+import {Users} from '#entities/Users'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow correct order: node builtins → external → vendor → utilities', () => {
+      const sourceFile = project.createSourceFile('test-full-order.ts', `import {readFile} from 'node:fs'
+import {v4} from 'uuid'
+import {queryItems} from '#lib/vendor/AWS/DynamoDB'
+import {response} from '#util/lambda-helpers'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow correct full order', () => {
+      const sourceFile = project.createSourceFile('test-complete-order.ts', `import {join} from 'node:path'
+import type {APIGatewayProxyEvent} from 'aws-lambda'
+import {v4} from 'uuid'
+import {Users} from '#entities/Users'
+import {queryItems} from '#lib/vendor/AWS/DynamoDB'
+import type {UserRecord} from '#types/User'
+import {response} from '#util/lambda-helpers'
+import {helper} from './helper'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('detects incorrect import order', () => {
+    test('should detect entities before external packages', () => {
+      const sourceFile = project.createSourceFile('test-wrong-order-1.ts', `import {Users} from '#entities/Users'
+import {v4} from 'uuid'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].severity).toBe('MEDIUM')
+    })
+
+    test('should detect utilities before vendor', () => {
+      const sourceFile = project.createSourceFile('test-wrong-order-2.ts', `import {response} from '#util/lambda-helpers'
+import {queryItems} from '#lib/vendor/AWS/DynamoDB'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should detect aws-lambda after external packages', () => {
+      const sourceFile = project.createSourceFile('test-wrong-order-3.ts', `import {v4} from 'uuid'
+import type {APIGatewayProxyEvent} from 'aws-lambda'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('aws-lambda')
+    })
+  })
+
+  describe('detects non-grouped imports', () => {
+    test('should detect entities appearing non-consecutively', () => {
+      const sourceFile = project.createSourceFile('test-non-grouped.ts', `import {Users} from '#entities/Users'
+import {response} from '#util/lambda-helpers'
+import {Files} from '#entities/Files'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      // Should detect both out-of-order and non-grouped
+      expect(violations.length).toBeGreaterThan(0)
+    })
+
+    test('should detect vendor imports split apart', () => {
+      const sourceFile = project.createSourceFile('test-split-vendor.ts', `import {queryItems} from '#lib/vendor/AWS/DynamoDB'
+import {response} from '#util/lambda-helpers'
+import {uploadToS3} from '#lib/vendor/AWS/S3'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations.length).toBeGreaterThan(0)
+      expect(violations.some((v) => v.message.includes('grouped'))).toBe(true)
+    })
+  })
+
+  describe('categorizes imports correctly', () => {
+    test('should recognize node: prefix as builtin', () => {
+      const sourceFile = project.createSourceFile('test-node-prefix.ts', `import {Users} from '#entities/Users'
+import {readFile} from 'node:fs'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('node-builtins')
+    })
+
+    test('should recognize @scope packages as external', () => {
+      const sourceFile = project.createSourceFile('test-scoped.ts', `import {Users} from '#entities/Users'
+import {something} from '@scope/package'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should recognize #types as types category', () => {
+      const sourceFile = project.createSourceFile('test-types.ts', `import {response} from '#util/lambda-helpers'
+import type {UserRecord} from '#types/User'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should recognize relative imports', () => {
+      const sourceFile = project.createSourceFile('test-relative.ts', `import {helper} from './helper'
+import {response} from '#util/lambda-helpers'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+  })
+
+  describe('provides helpful suggestions', () => {
+    test('should suggest moving import to correct section', () => {
+      const sourceFile = project.createSourceFile('test-suggestion.ts', `import {Users} from '#entities/Users'
+import type {APIGatewayProxyEvent} from 'aws-lambda'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].suggestion).toBeDefined()
+      expect(violations[0].suggestion).toContain('Move')
+    })
+
+    test('should include code snippet', () => {
+      const sourceFile = project.createSourceFile('test-snippet.ts', `import {queryItems} from '#lib/vendor/AWS/DynamoDB'
+import {v4} from 'uuid'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].codeSnippet).toBeDefined()
+    })
+  })
+
+  describe('handles edge cases', () => {
+    test('should handle same category imports correctly', () => {
+      const sourceFile = project.createSourceFile('test-same-category.ts', `import {Users} from '#entities/Users'
+import {Files} from '#entities/Files'
+import {Devices} from '#entities/Devices'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should handle multiple external packages', () => {
+      const sourceFile = project.createSourceFile('test-multi-external.ts', `import {v4} from 'uuid'
+import axios from 'axios'
+import {format} from 'date-fns'`, {overwrite: true})
+
+      const violations = importOrderRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+})

--- a/src/mcp/validation/rules/import-order.ts
+++ b/src/mcp/validation/rules/import-order.ts
@@ -1,0 +1,102 @@
+/**
+ * Import Order Rule
+ * MEDIUM: Imports should be grouped and ordered consistently
+ *
+ * Order: aws-lambda types → entities → vendor → types → utilities
+ */
+
+import type {SourceFile} from 'ts-morph'
+import {createViolation, ValidationRule, Violation} from '../types'
+
+const RULE_NAME = 'import-order'
+const SEVERITY = 'MEDIUM' as const
+
+/**
+ * Import categories in expected order
+ */
+const IMPORT_CATEGORIES = [
+  {name: 'node-builtins', patterns: [/^node:/, /^fs$/, /^path$/, /^url$/]},
+  {name: 'aws-lambda-types', patterns: [/^aws-lambda$/]},
+  {name: 'external-packages', patterns: [/^[^#./]/, /^@[^/]+\//]},
+  {name: 'entities', patterns: [/#entities\//, /src\/entities\//]},
+  {name: 'vendor', patterns: [/#lib\/vendor\//, /src\/lib\/vendor\//]},
+  {name: 'types', patterns: [/#types\//, /src\/types\//]},
+  {name: 'utilities', patterns: [/#util\//, /src\/util\//]},
+  {name: 'relative', patterns: [/^\.\//]}
+]
+
+function categorizeImport(moduleSpecifier: string): string {
+  for (const category of IMPORT_CATEGORIES) {
+    if (category.patterns.some((p) => p.test(moduleSpecifier))) {
+      return category.name
+    }
+  }
+  return 'unknown'
+}
+
+function getCategoryIndex(category: string): number {
+  const index = IMPORT_CATEGORIES.findIndex((c) => c.name === category)
+  return index === -1 ? IMPORT_CATEGORIES.length : index
+}
+
+export const importOrderRule: ValidationRule = {
+  name: RULE_NAME,
+  description: 'Imports should be grouped in order: node builtins → aws-lambda types → external packages → entities → vendor → types → utilities → relative',
+  severity: SEVERITY,
+  appliesTo: ['src/lambdas/**/src/*.ts'],
+  excludes: ['**/*.test.ts', 'test/**/*.ts'],
+
+  validate(sourceFile: SourceFile, filePath: string): Violation[] {
+    const violations: Violation[] = []
+
+    // Only check Lambda handler files
+    if (!filePath.includes('/lambdas/') || !filePath.endsWith('/src/index.ts')) {
+      return violations
+    }
+
+    const imports = sourceFile.getImportDeclarations()
+
+    if (imports.length < 2) {
+      return violations // Not enough imports to check order
+    }
+
+    // Analyze import order
+    let lastCategory = ''
+    let lastCategoryIndex = -1
+    const seenCategories: string[] = []
+
+    for (const importDecl of imports) {
+      const moduleSpecifier = importDecl.getModuleSpecifierValue()
+      const category = categorizeImport(moduleSpecifier)
+      const categoryIndex = getCategoryIndex(category)
+
+      // Check if this category comes before a previously seen category
+      if (categoryIndex < lastCategoryIndex && lastCategory !== category) {
+        violations.push(
+          createViolation(RULE_NAME, SEVERITY, importDecl.getStartLineNumber(),
+            `Import '${moduleSpecifier}' (${category}) should come before ${lastCategory} imports`, {
+            suggestion: `Move this import to the ${category} section at the top`,
+            codeSnippet: importDecl.getText().substring(0, 80)
+          })
+        )
+      }
+
+      // Check for mixed categories (same category appearing non-consecutively)
+      if (seenCategories.includes(category) && lastCategory !== category) {
+        violations.push(
+          createViolation(RULE_NAME, SEVERITY, importDecl.getStartLineNumber(), `${category} imports should be grouped together`, {
+            suggestion: `Group all ${category} imports consecutively`
+          })
+        )
+      }
+
+      if (lastCategory !== category) {
+        seenCategories.push(category)
+      }
+      lastCategory = category
+      lastCategoryIndex = categoryIndex
+    }
+
+    return violations
+  }
+}

--- a/src/mcp/validation/rules/response-helpers.test.ts
+++ b/src/mcp/validation/rules/response-helpers.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for response-helpers rule
+ * HIGH: Lambda handlers must use response() helper, not raw objects
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {Project} from 'ts-morph'
+
+// Module loaded via dynamic import
+let responseHelpersRule: typeof import('./response-helpers').responseHelpersRule
+
+// Create ts-morph project for in-memory source files
+const project = new Project({skipFileDependencyResolution: true, skipAddingFilesFromTsConfig: true})
+
+beforeAll(async () => {
+  const module = await import('./response-helpers')
+  responseHelpersRule = module.responseHelpersRule
+})
+
+describe('response-helpers rule', () => {
+  describe('rule metadata', () => {
+    test('should have correct name', () => {
+      expect(responseHelpersRule.name).toBe('response-helpers')
+    })
+
+    test('should have HIGH severity', () => {
+      expect(responseHelpersRule.severity).toBe('HIGH')
+    })
+
+    test('should apply to Lambda handler files', () => {
+      expect(responseHelpersRule.appliesTo).toContain('src/lambdas/**/src/*.ts')
+    })
+
+    test('should exclude test files', () => {
+      expect(responseHelpersRule.excludes).toContain('**/*.test.ts')
+    })
+  })
+
+  describe('skips non-handler files', () => {
+    test('should skip files not in lambdas directory', () => {
+      const sourceFile = project.createSourceFile('test-non-lambda.ts', `export function handler() {
+  return { statusCode: 200, body: JSON.stringify({success: true}) }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/util/helpers.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should skip non-index.ts files', () => {
+      const sourceFile = project.createSourceFile('test-helper.ts', `export function buildResponse() {
+  return { statusCode: 200, body: '{}' }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/helper.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('detects raw response objects', () => {
+    test('should detect raw statusCode + body return', () => {
+      const sourceFile = project.createSourceFile('test-raw-response.ts', `export async function handler(event: APIGatewayProxyEvent) {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({success: true})
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      // May have 2 violations: raw response + missing import warning
+      expect(violations.length).toBeGreaterThanOrEqual(1)
+      const rawResponseViolation = violations.find((v) => v.message.includes('Raw response object'))
+      expect(rawResponseViolation).toBeDefined()
+      expect(rawResponseViolation!.severity).toBe('HIGH')
+    })
+
+    test('should detect raw statusCode + headers return', () => {
+      const sourceFile = project.createSourceFile('test-raw-headers.ts', `export async function handler(event: APIGatewayProxyEvent) {
+  return {
+    statusCode: 302,
+    headers: { Location: 'https://example.com' }
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      // May have 2 violations: raw response + missing import warning
+      expect(violations.length).toBeGreaterThanOrEqual(1)
+      expect(violations.some((v) => v.message.includes('Raw response object'))).toBe(true)
+    })
+
+    test('should detect raw response with all properties', () => {
+      const sourceFile = project.createSourceFile('test-raw-full.ts', `export async function handler() {
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({data: []})
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+
+    test('should detect error response without helper', () => {
+      const sourceFile = project.createSourceFile('test-error-raw.ts', `export async function handler() {
+  try {
+    throw new Error('test')
+  } catch (e) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({error: 'Internal error'})
+    }
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+    })
+  })
+
+  describe('detects Promise.resolve patterns', () => {
+    test('should detect Promise.resolve with raw response', () => {
+      const sourceFile = project.createSourceFile('test-promise-resolve.ts', `export async function handler() {
+  return Promise.resolve({
+    statusCode: 200,
+    body: JSON.stringify({})
+  })
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('allows proper response helper usage', () => {
+    test('should allow response() helper', () => {
+      const sourceFile = project.createSourceFile('test-response-helper.ts', `import {response} from '#util/lambda-helpers'
+
+export async function handler() {
+  return response(200, {success: true})
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow lambdaErrorResponse() helper', () => {
+      const sourceFile = project.createSourceFile('test-error-helper.ts', `import {lambdaErrorResponse, response} from '#util/lambda-helpers'
+
+export async function handler() {
+  try {
+    return response(200, {})
+  } catch (error) {
+    return lambdaErrorResponse(500, error, 'Failed')
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow returning helper result', () => {
+      const sourceFile = project.createSourceFile('test-helper-result.ts', `import {response} from '#util/lambda-helpers'
+
+export async function handler() {
+  const result = await processData()
+  return response(200, result)
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('detects missing helper imports', () => {
+    test('should warn when APIGateway handler lacks helper import', () => {
+      const sourceFile = project.createSourceFile('test-missing-import.ts', `import type {APIGatewayProxyEvent} from 'aws-lambda'
+
+export const handler = async (event: APIGatewayProxyEvent) => {
+  const statusCode = 200
+  return { statusCode, body: '{}' }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('provides helpful suggestions', () => {
+    test('should suggest response helper when detected', () => {
+      const sourceFile = project.createSourceFile('test-suggestion.ts', `import {response} from '#util/lambda-helpers'
+
+export async function handler() {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({})
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].suggestion).toContain('response')
+    })
+
+    test('should suggest importing helper when missing', () => {
+      const sourceFile = project.createSourceFile('test-suggest-import.ts', `import type {APIGatewayProxyEvent} from 'aws-lambda'
+
+export const handler = async (event: APIGatewayProxyEvent) => {
+  return { statusCode: 200, body: '{}' }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      const hasImportSuggestion = violations.some((v) => v.suggestion && v.suggestion.includes('import'))
+      expect(hasImportSuggestion).toBe(true)
+    })
+  })
+
+  describe('handles multiple return statements', () => {
+    test('should detect multiple raw responses', () => {
+      const sourceFile = project.createSourceFile('test-multiple-returns.ts', `export async function handler(event) {
+  if (!event.body) {
+    return { statusCode: 400, body: 'Missing body' }
+  }
+
+  try {
+    return { statusCode: 200, body: JSON.stringify({}) }
+  } catch (e) {
+    return { statusCode: 500, body: 'Error' }
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(3)
+    })
+  })
+
+  describe('code snippets', () => {
+    test('should include code snippet in violation', () => {
+      const sourceFile = project.createSourceFile('test-snippet.ts', `export async function handler() {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({message: 'hello'})
+  }
+}`, {overwrite: true})
+
+      const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].codeSnippet).toBeDefined()
+      expect(violations[0].codeSnippet).toContain('statusCode')
+    })
+  })
+})

--- a/src/mcp/validation/rules/response-helpers.ts
+++ b/src/mcp/validation/rules/response-helpers.ts
@@ -1,0 +1,117 @@
+/**
+ * Response Helpers Rule
+ * HIGH: Lambda handlers must use response() helper, not raw objects
+ *
+ * Ensures consistent response formatting across all Lambda functions.
+ */
+
+import type {SourceFile} from 'ts-morph'
+import {SyntaxKind} from 'ts-morph'
+import {createViolation, ValidationRule, Violation} from '../types'
+
+const RULE_NAME = 'response-helpers'
+const SEVERITY = 'HIGH' as const
+
+export const responseHelpersRule: ValidationRule = {
+  name: RULE_NAME,
+  description: 'Lambda handlers must use response() and lambdaErrorResponse() helpers from lambda-helpers.ts instead of raw response objects.',
+  severity: SEVERITY,
+  appliesTo: ['src/lambdas/**/src/*.ts'],
+  excludes: ['**/*.test.ts', 'test/**/*.ts'],
+
+  validate(sourceFile: SourceFile, filePath: string): Violation[] {
+    const violations: Violation[] = []
+
+    // Only check Lambda handler files
+    if (!filePath.includes('/lambdas/') || !filePath.endsWith('/src/index.ts')) {
+      return violations
+    }
+
+    // Check if response helper is imported
+    const imports = sourceFile.getImportDeclarations()
+    const hasResponseImport = imports.some((imp) => {
+      const moduleSpec = imp.getModuleSpecifierValue()
+      if (moduleSpec.includes('lambda-helpers')) {
+        const namedImports = imp.getNamedImports().map((n) => n.getName())
+        return namedImports.includes('response') || namedImports.includes('lambdaErrorResponse')
+      }
+      return false
+    })
+
+    // Find return statements
+    const returnStatements = sourceFile.getDescendantsOfKind(SyntaxKind.ReturnStatement)
+
+    for (const returnStmt of returnStatements) {
+      const expression = returnStmt.getExpression()
+      if (!expression) {
+        continue
+      }
+
+      const returnText = expression.getText()
+
+      // Check for raw response objects: { statusCode: ..., body: ... }
+      if (expression.getKind() === SyntaxKind.ObjectLiteralExpression) {
+        const objLiteral = expression.asKind(SyntaxKind.ObjectLiteralExpression)
+        if (!objLiteral) {
+          continue
+        }
+
+        const properties = objLiteral.getProperties()
+        const propertyNames = properties.map((p) => {
+          if (p.getKind() === SyntaxKind.PropertyAssignment) {
+            return p.asKind(SyntaxKind.PropertyAssignment)?.getName()
+          }
+          if (p.getKind() === SyntaxKind.ShorthandPropertyAssignment) {
+            return p.asKind(SyntaxKind.ShorthandPropertyAssignment)?.getName()
+          }
+          return undefined
+        }).filter(Boolean)
+
+        // Detect raw response pattern
+        const hasStatusCode = propertyNames.includes('statusCode')
+        const hasBody = propertyNames.includes('body')
+        const hasHeaders = propertyNames.includes('headers')
+
+        if (hasStatusCode && (hasBody || hasHeaders)) {
+          // This looks like a raw Lambda response object
+          violations.push(
+            createViolation(RULE_NAME, SEVERITY, returnStmt.getStartLineNumber(),
+              'Raw response object detected. Use response() or lambdaErrorResponse() helper instead.', {
+              suggestion: hasResponseImport
+                ? 'Replace with: return response(statusCode, data) or return lambdaErrorResponse(statusCode, error, message)'
+                : "Import {response, lambdaErrorResponse} from '#util/lambda-helpers' and use those helpers",
+              codeSnippet: returnText.substring(0, 100)
+            })
+          )
+        }
+      }
+
+      // Check for Promise.resolve with raw objects
+      if (returnText.includes('Promise.resolve') && returnText.includes('statusCode')) {
+        violations.push(
+          createViolation(RULE_NAME, SEVERITY, returnStmt.getStartLineNumber(), 'Promise.resolve with raw response object. Use response() helper directly.',
+            {suggestion: 'The response() helper already returns a proper object, no need for Promise.resolve'})
+        )
+      }
+    }
+
+    // If no response helper is imported but file has return statements with API responses
+    if (!hasResponseImport) {
+      // Check if this Lambda returns API Gateway responses
+      const handlerFunction = sourceFile.getFunction('handler') || sourceFile.getVariableDeclaration('handler')
+
+      if (handlerFunction) {
+        const functionText = sourceFile.getFullText()
+        if (functionText.includes('APIGateway') && functionText.includes('statusCode')) {
+          violations.push(
+            createViolation(RULE_NAME, SEVERITY, 1, 'Lambda handler does not import response helpers but appears to return API Gateway responses', {
+              suggestion: "import {response, lambdaErrorResponse} from '#util/lambda-helpers'"
+            })
+          )
+        }
+      }
+    }
+
+    return violations
+  }
+}

--- a/src/mcp/validation/types.ts
+++ b/src/mcp/validation/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared validation types for MCP convention checking
+ * These types can be reused by CI scripts and future tooling
+ */
+
+import type {SourceFile} from 'ts-morph'
+
+export type ValidationSeverity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+
+export interface Violation {
+  rule: string
+  severity: ValidationSeverity
+  line: number
+  column?: number
+  message: string
+  suggestion?: string
+  codeSnippet?: string
+}
+
+export interface ValidationResult {
+  file: string
+  valid: boolean
+  violations: Violation[]
+  passed: string[]
+  skipped: string[]
+}
+
+export interface ValidationRule {
+  /** Unique identifier for the rule */
+  name: string
+
+  /** Human-readable description */
+  description: string
+
+  /** Severity level if violated */
+  severity: ValidationSeverity
+
+  /** File patterns this rule applies to (glob-like) */
+  appliesTo: string[]
+
+  /** File patterns to exclude from this rule */
+  excludes?: string[]
+
+  /** Validate a source file and return violations */
+  validate(sourceFile: SourceFile, filePath: string): Violation[]
+}
+
+export interface ValidationContext {
+  /** Project root directory */
+  projectRoot: string
+
+  /** File being validated */
+  filePath: string
+
+  /** Whether this is a test file */
+  isTestFile: boolean
+
+  /** Whether this is a Lambda handler */
+  isLambdaHandler: boolean
+
+  /** Whether this is in the vendor directory */
+  isVendorFile: boolean
+}
+
+/**
+ * Helper to create a violation object
+ */
+export function createViolation(
+  rule: string,
+  severity: ValidationSeverity,
+  line: number,
+  message: string,
+  options?: {column?: number; suggestion?: string; codeSnippet?: string}
+): Violation {
+  return {rule, severity, line, message, ...options}
+}
+
+/**
+ * Determine validation context from file path
+ */
+export function getValidationContext(filePath: string, projectRoot: string): ValidationContext {
+  return {
+    projectRoot,
+    filePath,
+    isTestFile: filePath.includes('.test.') || filePath.includes('/test/'),
+    isLambdaHandler: filePath.includes('/lambdas/') && filePath.includes('/src/index.ts'),
+    isVendorFile: filePath.includes('/lib/vendor/')
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "node_modules",
     "**/*.spec.ts",
     "test/**/*",
-    "./src/types/terraform.d.ts"
+    "./src/types/terraform.d.ts",
+    "src/mcp/test/fixtures/**/*"
   ],
   "ts-node": {
     "compilerOptions": { "module": "esnext" },


### PR DESCRIPTION
## Summary
- **query_conventions**: Semantic search across conventions-tracking.md with category/severity filtering
- **validate_pattern**: AST-based validation of code against established project patterns (AWS SDK encapsulation, ElectroDB mocking, import order, response helpers)
- **check_coverage**: Analyze which dependencies need mocking using build/graph.json
- **lambda_impact**: Show affected dependents, tests, and infrastructure when changing a file
- **suggest_tests**: Generate test file scaffolding with all required mocks pre-configured

## Implementation Details
- Full test coverage for parsers, validators, and handlers
- Wiki documentation added at `docs/wiki/MCP/Convention-Tools.md`
- Validation rules use TypeScript AST analysis for accuracy
- Integration with existing `build/graph.json` dependency graph

## Test Plan
- [x] All unit tests passing (423 tests)
- [x] All integration tests passing
- [x] Type checking passes
- [x] Linting passes
- [x] GraphRAG validation passes

Closes #143