### PR TITLE
feat: add centralized auth wrappers for Lambda handlers

### DIFF
--- a/docs/conventions-tracking.md
+++ b/docs/conventions-tracking.md
@@ -8,7 +8,7 @@ This document tracks all conventions, patterns, rules, and methodologies detecte
 
 | Method | Count | Conventions |
 |--------|-------|-------------|
-| **MCP Rules** | 13 | aws-sdk-encapsulation, electrodb-mocking, config-enforcement, env-validation, cascade-safety, response-helpers, types-location, batch-retry, scan-pagination, import-order, response-enum, mock-formatting, doc-sync |
+| **MCP Rules** | 15 | aws-sdk-encapsulation, electrodb-mocking, config-enforcement, env-validation, cascade-safety, response-helpers, types-location, batch-retry, scan-pagination, import-order, response-enum, mock-formatting, doc-sync, naming-conventions, authenticated-handler-enforcement |
 | **Git Hooks** | 2 | AI attribution (commit-msg), direct master push (pre-push) |
 | **ESLint** | 3 | naming conventions, import order, unused vars |
 | **CI Workflows** | 2 | script validation, type checking |
@@ -32,12 +32,25 @@ This document tracks all conventions, patterns, rules, and methodologies detecte
 | response-enum | enum | MEDIUM | Magic status strings |
 | mock-formatting | mock | MEDIUM | Chained mock returns |
 | doc-sync | docs | HIGH | Documentation drift detection |
+| naming-conventions | naming | HIGH | Type and enum naming patterns |
+| authenticated-handler-enforcement | auth | HIGH | Manual auth checks in handlers |
 
 ---
 
 ## 🟡 Pending Documentation
 
 _No pending conventions - all conventions are documented._
+
+### Detected: 2025-12-18
+
+1. **Centralized Auth Handler Wrappers** (Security Pattern)
+   - **What**: Use `wrapAuthenticatedHandler` for endpoints requiring authentication (rejects Unauthenticated + Anonymous) or `wrapOptionalAuthHandler` for endpoints allowing anonymous access (rejects only Unauthenticated)
+   - **Why**: Eliminates boilerplate `getUserDetailsFromEvent()` + `UserStatus` checks; provides type-safe `userId` (guaranteed string in authenticated wrapper); fixes security vulnerabilities from missing auth checks
+   - **Detected**: During security audit of Lambda handlers
+   - **Target**: docs/wiki/TypeScript/Lambda-Function-Patterns.md
+   - **Priority**: HIGH
+   - **Status**: ✅ Documented
+   - **Enforcement**: MCP `authenticated-handler-enforcement` rule, ESLint `local-rules/authenticated-handler-enforcement`
 
 ### Detected: 2025-11-28
 

--- a/eslint-local-rules/index.cjs
+++ b/eslint-local-rules/index.cjs
@@ -12,6 +12,7 @@
  * Phase 2 (HIGH):
  *   - response-helpers: Enforce response() helper usage
  *   - env-validation: Enforce getRequiredEnv() usage
+ *   - authenticated-handler-enforcement: Enforce centralized auth wrappers
  */
 
 const noDirectAwsSdkImport = require('./rules/no-direct-aws-sdk-import.cjs')
@@ -19,6 +20,7 @@ const cascadeDeleteOrder = require('./rules/cascade-delete-order.cjs')
 const useElectrodbMockHelper = require('./rules/use-electrodb-mock-helper.cjs')
 const responseHelpers = require('./rules/response-helpers.cjs')
 const envValidation = require('./rules/env-validation.cjs')
+const authenticatedHandlerEnforcement = require('./rules/authenticated-handler-enforcement.cjs')
 
 module.exports = {
   rules: {
@@ -28,6 +30,7 @@ module.exports = {
     'use-electrodb-mock-helper': useElectrodbMockHelper,
     // Phase 2: HIGH
     'response-helpers': responseHelpers,
-    'env-validation': envValidation
+    'env-validation': envValidation,
+    'authenticated-handler-enforcement': authenticatedHandlerEnforcement
   }
 }

--- a/eslint-local-rules/rules/authenticated-handler-enforcement.cjs
+++ b/eslint-local-rules/rules/authenticated-handler-enforcement.cjs
@@ -1,0 +1,103 @@
+/**
+ * authenticated-handler-enforcement
+ * HIGH: Detects manual getUserDetailsFromEvent + UserStatus checks in Lambda handlers
+ * Suggests using wrapAuthenticatedHandler or wrapOptionalAuthHandler instead
+ *
+ * Mirrors: src/mcp/validation/rules/authenticated-handler-enforcement.ts
+ */
+
+function getSuggestion(hasAnonymousCheck, hasUnauthenticatedCheck) {
+  if (hasAnonymousCheck && hasUnauthenticatedCheck) {
+    return "Use 'wrapAuthenticatedHandler' - it rejects both Unauthenticated and Anonymous users automatically."
+  } else if (hasUnauthenticatedCheck && !hasAnonymousCheck) {
+    return "Use 'wrapOptionalAuthHandler' - it rejects Unauthenticated users but allows Anonymous."
+  } else if (hasAnonymousCheck) {
+    return "Use 'wrapAuthenticatedHandler' if you need both checks, or 'wrapOptionalAuthHandler' if Anonymous should be allowed."
+  }
+  return "Use 'wrapAuthenticatedHandler' for authenticated-only endpoints or 'wrapOptionalAuthHandler' for endpoints that allow anonymous access."
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Enforce use of wrapAuthenticatedHandler/wrapOptionalAuthHandler instead of manual getUserDetailsFromEvent + UserStatus checks',
+      category: 'Best Practices',
+      recommended: true
+    },
+    messages: {
+      manualAuth: "Manual auth handling detected: '{{function}}'. {{suggestion}}",
+      redundantCall: 'Redundant getUserDetailsFromEvent call - wrapper already handles auth. Use userId/userStatus from wrapper params.'
+    },
+    schema: []
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename()
+
+    // Only apply to Lambda handler files
+    if (!filename.includes('/lambdas/') || !filename.includes('/src/index.ts')) {
+      return {}
+    }
+
+    // Skip test files
+    if (filename.includes('.test.') || filename.includes('/test/')) {
+      return {}
+    }
+
+    let usesNewWrapper = false
+    let hasAnonymousCheck = false
+    let hasUnauthenticatedCheck = false
+
+    return {
+      // Track if new wrappers are used
+      ImportDeclaration(node) {
+        const source = node.source.value
+        if (source.includes('lambda-helpers')) {
+          for (const specifier of node.specifiers) {
+            if (specifier.type === 'ImportSpecifier') {
+              const name = specifier.imported.name
+              if (name === 'wrapAuthenticatedHandler' || name === 'wrapOptionalAuthHandler') {
+                usesNewWrapper = true
+              }
+            }
+          }
+        }
+      },
+
+      // Track UserStatus checks in the file
+      BinaryExpression(node) {
+        const code = context.sourceCode.getText(node)
+        if (code.includes('UserStatus.Anonymous')) {
+          hasAnonymousCheck = true
+        }
+        if (code.includes('UserStatus.Unauthenticated') || code.includes('!userId') || code.includes('userId ===')) {
+          hasUnauthenticatedCheck = true
+        }
+      },
+
+      // Detect getUserDetailsFromEvent calls
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'getUserDetailsFromEvent') {
+          if (usesNewWrapper) {
+            // Redundant call - wrapper already handles this
+            context.report({
+              node,
+              messageId: 'redundantCall'
+            })
+          } else {
+            // Manual auth handling - suggest using new wrapper
+            context.report({
+              node,
+              messageId: 'manualAuth',
+              data: {
+                function: 'getUserDetailsFromEvent',
+                suggestion: getSuggestion(hasAnonymousCheck, hasUnauthenticatedCheck)
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,7 +64,8 @@ export default [
       'local-rules/use-electrodb-mock-helper': 'error',
       // Phase 2: HIGH
       'local-rules/response-helpers': 'warn',
-      'local-rules/env-validation': 'error'
+      'local-rules/env-validation': 'error',
+      'local-rules/authenticated-handler-enforcement': 'warn'
     }
   }
 ]

--- a/src/lambdas/RegisterDevice/test/index.test.ts
+++ b/src/lambdas/RegisterDevice/test/index.test.ts
@@ -77,11 +77,17 @@ describe('#RegisterDevice', () => {
     expect(body.body).toHaveProperty('endpointArn')
   })
   test('should return a valid response if APNS is not configured', async () => {
+    // Set up as anonymous user (not unauthenticated) to test APNS config check
+    delete event.headers['Authorization']
+    event.requestContext.authorizer!.principalId = 'unknown'
     process.env.PlatformApplicationArn = ''
     const output = await handler(event, context)
     expect(output.statusCode).toEqual(503)
   })
   test('should handle an invalid request (no token)', async () => {
+    // Set up as anonymous user to test validation
+    delete event.headers['Authorization']
+    event.requestContext.authorizer!.principalId = 'unknown'
     event.body = '{}'
     const output = await handler(event, context)
     expect(output.statusCode).toEqual(400)
@@ -91,6 +97,9 @@ describe('#RegisterDevice', () => {
   })
   describe('#AWSFailure', () => {
     test('AWS.SNS.createPlatformEndpoint', async () => {
+      // Set up as anonymous user to test AWS failure
+      delete event.headers['Authorization']
+      event.requestContext.authorizer!.principalId = 'unknown'
       createPlatformEndpointMock.mockReturnValue(undefined)
       const output = await handler(event, context)
       expect(output.statusCode).toEqual(500)

--- a/src/lambdas/UserDelete/src/index.ts
+++ b/src/lambdas/UserDelete/src/index.ts
@@ -3,8 +3,8 @@ import {Users} from '#entities/Users'
 import {UserFiles} from '#entities/UserFiles'
 import {UserDevices} from '#entities/UserDevices'
 import {Devices} from '#entities/Devices'
-import type {ApiHandlerParams} from '#types/lambda-wrappers'
-import {getUserDetailsFromEvent, logDebug, logError, response, wrapApiHandler} from '#util/lambda-helpers'
+import type {AuthenticatedApiParams} from '#types/lambda-wrappers'
+import {logDebug, logError, response, wrapAuthenticatedHandler} from '#util/lambda-helpers'
 import {deleteDevice, getUserDevices} from '#util/shared'
 import {providerFailureErrorMessage, UnexpectedError} from '#util/errors'
 import type {Device} from '#types/domain-models'
@@ -51,12 +51,7 @@ async function deleteUserDevices(userId: string): Promise<void> {
  * @param event - An AWS ScheduledEvent; happening daily
  * @param context - An AWS Context object
  */
-export const handler = withXRay(wrapApiHandler(async ({event, context}: ApiHandlerParams): Promise<APIGatewayProxyResult> => {
-  const {userId} = getUserDetailsFromEvent(event)
-  if (!userId) {
-    // This should never happen; enforced by the API Gateway Authorizer
-    throw new UnexpectedError('No userId found')
-  }
+export const handler = withXRay(wrapAuthenticatedHandler(async ({context, userId}: AuthenticatedApiParams): Promise<APIGatewayProxyResult> => {
   const deletableDevices: Device[] = []
 
   const userDevices = await getUserDevices(userId)

--- a/src/lambdas/UserDelete/test/index.test.ts
+++ b/src/lambdas/UserDelete/test/index.test.ts
@@ -104,10 +104,18 @@ describe('#UserDelete', () => {
       const output = await handler(event, context)
       expect(output.statusCode).toEqual(500)
     })
-    test('should return 500 error when user ID is missing', async () => {
+    test('should return 401 error when user ID is missing (unauthenticated)', async () => {
+      // With Authorization header but unknown principalId = Unauthenticated
       event.requestContext.authorizer!.principalId = 'unknown'
       const output = await handler(event, context)
-      expect(output.statusCode).toEqual(500)
+      expect(output.statusCode).toEqual(401)
+    })
+    test('should return 401 error for anonymous users (no auth header)', async () => {
+      // Without Authorization header = Anonymous
+      delete event.headers.Authorization
+      event.requestContext.authorizer!.principalId = 'unknown'
+      const output = await handler(event, context)
+      expect(output.statusCode).toEqual(401)
     })
   })
 })

--- a/src/lambdas/UserSubscribe/src/index.ts
+++ b/src/lambdas/UserSubscribe/src/index.ts
@@ -1,21 +1,22 @@
 import type {APIGatewayProxyResult} from 'aws-lambda'
 import type {UserSubscribeInput} from '#types/request-types'
-import type {ApiHandlerParams} from '#types/lambda-wrappers'
+import type {AuthenticatedApiParams} from '#types/lambda-wrappers'
 import {getPayloadFromEvent, validateRequest} from '#util/apigateway-helpers'
 import {userSubscribeSchema} from '#util/constraints'
-import {response, verifyPlatformConfiguration, wrapApiHandler} from '#util/lambda-helpers'
+import {response, verifyPlatformConfiguration, wrapAuthenticatedHandler} from '#util/lambda-helpers'
 import {subscribeEndpointToTopic} from '#util/shared'
 import {withXRay} from '#lib/vendor/AWS/XRay'
 
 /**
  * Subscribes an endpoint (a client device) to an SNS topic
  *
+ * - Requires authentication (rejects Unauthenticated and Anonymous users)
  * - Requires that the platformApplicationArn environment variable is set
  * - Requires the endpointArn and topicArn are in the payload
  *
  * @notExported
  */
-export const handler = withXRay(wrapApiHandler(async ({event, context}: ApiHandlerParams): Promise<APIGatewayProxyResult> => {
+export const handler = withXRay(wrapAuthenticatedHandler(async ({event, context}: AuthenticatedApiParams): Promise<APIGatewayProxyResult> => {
   verifyPlatformConfiguration()
   const requestBody = getPayloadFromEvent(event) as UserSubscribeInput
   validateRequest(requestBody, userSubscribeSchema)

--- a/src/lambdas/UserSubscribe/test/index.test.ts
+++ b/src/lambdas/UserSubscribe/test/index.test.ts
@@ -1,6 +1,8 @@
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {testContext} from '#util/jest-setup'
+import {v4 as uuidv4} from 'uuid'
 import type {CustomAPIGatewayRequestAuthorizerEvent} from '#types/infrastructure-types'
+const fakeUserId = uuidv4()
 
 const subscribeMock = jest.fn()
 jest.unstable_mockModule('#lib/vendor/AWS/SNS', () => ({
@@ -16,6 +18,8 @@ describe('#UserSubscribe', () => {
   let event: CustomAPIGatewayRequestAuthorizerEvent
   beforeEach(() => {
     event = JSON.parse(JSON.stringify(eventMock))
+    event.headers.Authorization = 'Bearer test-token'
+    event.requestContext.authorizer!.principalId = fakeUserId
     process.env.PlatformApplicationArn = 'arn:aws:sns:region:account_id:topic:uuid'
   })
   test('should create a new remote endpoint (for the mobile phone)', async () => {
@@ -44,5 +48,18 @@ describe('#UserSubscribe', () => {
     expect(output.statusCode).toEqual(400)
     const body = JSON.parse(output.body)
     expect(body.error.message).toHaveProperty('topicArn')
+  })
+  test('should return 401 when user ID is missing (unauthenticated)', async () => {
+    // With Authorization header but unknown principalId = Unauthenticated
+    event.requestContext.authorizer!.principalId = 'unknown'
+    const output = await handler(event, context)
+    expect(output.statusCode).toEqual(401)
+  })
+  test('should return 401 for anonymous users (no auth header)', async () => {
+    // Without Authorization header = Anonymous
+    delete event.headers.Authorization
+    event.requestContext.authorizer!.principalId = 'unknown'
+    const output = await handler(event, context)
+    expect(output.statusCode).toEqual(401)
   })
 })

--- a/src/mcp/validation/index.test.ts
+++ b/src/mcp/validation/index.test.ts
@@ -30,7 +30,7 @@ describe('validation exports', () => {
   describe('allRules', () => {
     test('should export array of rules', () => {
       expect(Array.isArray(allRules)).toBe(true)
-      expect(allRules.length).toBe(14)
+      expect(allRules.length).toBe(15)
     })
 
     test('should contain all expected rules', () => {
@@ -53,6 +53,8 @@ describe('validation exports', () => {
       expect(ruleNames).toContain('mock-formatting')
       // HIGH (naming) rules
       expect(ruleNames).toContain('naming-conventions')
+      // HIGH (auth) rules
+      expect(ruleNames).toContain('authenticated-handler-enforcement')
     })
   })
 
@@ -71,6 +73,7 @@ describe('validation exports', () => {
       expect(rulesByName['scan-pagination']).toBeDefined()
       expect(rulesByName['doc-sync']).toBeDefined()
       expect(rulesByName['naming-conventions']).toBeDefined()
+      expect(rulesByName['authenticated-handler-enforcement']).toBeDefined()
       // MEDIUM rules
       expect(rulesByName['import-order']).toBeDefined()
       expect(rulesByName['response-enum']).toBeDefined()
@@ -96,6 +99,8 @@ describe('validation exports', () => {
       expect(rulesByName['mock']).toBe(rulesByName['mock-formatting'])
       // HIGH (naming) aliases
       expect(rulesByName['naming']).toBe(rulesByName['naming-conventions'])
+      // HIGH (auth) aliases
+      expect(rulesByName['auth']).toBe(rulesByName['authenticated-handler-enforcement'])
     })
   })
 

--- a/src/mcp/validation/index.ts
+++ b/src/mcp/validation/index.ts
@@ -26,8 +26,9 @@ import {responseEnumRule} from './rules/response-enum'
 import {mockFormattingRule} from './rules/mock-formatting'
 import {docSyncRule} from './rules/doc-sync'
 import {namingConventionsRule} from './rules/naming-conventions'
+import {authenticatedHandlerEnforcementRule} from './rules/authenticated-handler-enforcement'
 
-// Export all rules (14 total: 6 CRITICAL + 5 HIGH + 3 MEDIUM)
+// Export all rules (15 total: 6 CRITICAL + 6 HIGH + 3 MEDIUM)
 export const allRules: ValidationRule[] = [
   // CRITICAL
   awsSdkEncapsulationRule,
@@ -47,7 +48,9 @@ export const allRules: ValidationRule[] = [
   // HIGH (documentation)
   docSyncRule,
   // HIGH (naming)
-  namingConventionsRule
+  namingConventionsRule,
+  // HIGH (auth)
+  authenticatedHandlerEnforcementRule
 ]
 
 // Export rules by name for selective validation
@@ -84,11 +87,15 @@ export const rulesByName: Record<string, ValidationRule> = {
   docs: docSyncRule, // alias
   // HIGH (naming) rules
   'naming-conventions': namingConventionsRule,
-  naming: namingConventionsRule // alias
+  naming: namingConventionsRule, // alias
+  // HIGH (auth) rules
+  'authenticated-handler-enforcement': authenticatedHandlerEnforcementRule,
+  auth: authenticatedHandlerEnforcementRule // alias
 }
 
 // Export individual rules
 export {
+  authenticatedHandlerEnforcementRule,
   awsSdkEncapsulationRule,
   batchRetryRule,
   cascadeSafetyRule,

--- a/src/mcp/validation/rules/authenticated-handler-enforcement.test.ts
+++ b/src/mcp/validation/rules/authenticated-handler-enforcement.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for authenticated-handler-enforcement rule
+ * HIGH: Use wrapAuthenticatedHandler/wrapOptionalAuthHandler instead of manual auth checks
+ */
+
+import {beforeAll, describe, expect, test} from '@jest/globals'
+import {Project} from 'ts-morph'
+
+// Module loaded via dynamic import
+let authenticatedHandlerEnforcementRule: typeof import('./authenticated-handler-enforcement').authenticatedHandlerEnforcementRule
+
+// Create ts-morph project for in-memory source files
+const project = new Project({skipFileDependencyResolution: true, skipAddingFilesFromTsConfig: true})
+
+beforeAll(async () => {
+  const module = await import('./authenticated-handler-enforcement')
+  authenticatedHandlerEnforcementRule = module.authenticatedHandlerEnforcementRule
+})
+
+describe('authenticated-handler-enforcement rule', () => {
+  describe('rule metadata', () => {
+    test('should have correct name', () => {
+      expect(authenticatedHandlerEnforcementRule.name).toBe('authenticated-handler-enforcement')
+    })
+
+    test('should have HIGH severity', () => {
+      expect(authenticatedHandlerEnforcementRule.severity).toBe('HIGH')
+    })
+
+    test('should apply to Lambda handler files', () => {
+      expect(authenticatedHandlerEnforcementRule.appliesTo).toContain('src/lambdas/**/src/index.ts')
+    })
+
+    test('should exclude test files', () => {
+      expect(authenticatedHandlerEnforcementRule.excludes).toContain('src/**/*.test.ts')
+    })
+  })
+
+  describe('detects manual auth handling', () => {
+    test('should detect getUserDetailsFromEvent call', () => {
+      const sourceFile = project.createSourceFile(
+        'test-manual-auth.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+import {wrapApiHandler} from '#util/lambda-helpers'
+
+export const handler = wrapApiHandler(async ({event, context}) => {
+  const {userId, userStatus} = getUserDetailsFromEvent(event)
+  if (!userId) {
+    throw new Error('Unauthorized')
+  }
+  return response(context, 200, {})
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].severity).toBe('HIGH')
+      expect(violations[0].message).toContain('Manual auth handling detected')
+    })
+
+    test('should detect getUserDetailsFromEvent with UserStatus.Unauthenticated check', () => {
+      const sourceFile = project.createSourceFile(
+        'test-unauthenticated-check.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+import {UserStatus} from '#types/enums'
+
+export const handler = wrapApiHandler(async ({event}) => {
+  const {userId, userStatus} = getUserDetailsFromEvent(event)
+  if (userStatus === UserStatus.Unauthenticated) {
+    throw new UnauthorizedError()
+  }
+  return response(context, 200, {})
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].suggestion).toContain('wrapOptionalAuthHandler')
+    })
+
+    test('should detect getUserDetailsFromEvent with both Anonymous and Unauthenticated checks', () => {
+      const sourceFile = project.createSourceFile(
+        'test-both-checks.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+import {UserStatus} from '#types/enums'
+
+export const handler = wrapApiHandler(async ({event}) => {
+  const {userId, userStatus} = getUserDetailsFromEvent(event)
+  if (userStatus === UserStatus.Unauthenticated) {
+    throw new UnauthorizedError()
+  }
+  if (userStatus === UserStatus.Anonymous) {
+    throw new UnauthorizedError()
+  }
+  return response(context, 200, {})
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].suggestion).toContain('wrapAuthenticatedHandler')
+    })
+  })
+
+  describe('allows valid patterns', () => {
+    test('should allow wrapAuthenticatedHandler usage', () => {
+      const sourceFile = project.createSourceFile(
+        'test-authenticated-wrapper.ts',
+        `
+import {wrapAuthenticatedHandler} from '#util/lambda-helpers'
+import type {AuthenticatedApiParams} from '#types/lambda-wrappers'
+
+export const handler = wrapAuthenticatedHandler(async ({context, userId}: AuthenticatedApiParams) => {
+  // userId is guaranteed to be a string
+  await deleteUser(userId)
+  return response(context, 204)
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow wrapOptionalAuthHandler usage', () => {
+      const sourceFile = project.createSourceFile(
+        'test-optional-wrapper.ts',
+        `
+import {wrapOptionalAuthHandler} from '#util/lambda-helpers'
+import type {OptionalAuthApiParams} from '#types/lambda-wrappers'
+import {UserStatus} from '#types/enums'
+
+export const handler = wrapOptionalAuthHandler(async ({context, userId, userStatus}: OptionalAuthApiParams) => {
+  if (userStatus === UserStatus.Anonymous) {
+    return response(context, 200, {demo: true})
+  }
+  return response(context, 200, {userId})
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should allow public endpoints without auth', () => {
+      const sourceFile = project.createSourceFile(
+        'test-public.ts',
+        `
+import {wrapApiHandler} from '#util/lambda-helpers'
+
+export const handler = wrapApiHandler(async ({event, context}) => {
+  // Public endpoint - no auth needed
+  return response(context, 200, {status: 'ok'})
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('detects redundant getUserDetailsFromEvent', () => {
+    test('should flag redundant getUserDetailsFromEvent when using new wrapper', () => {
+      const sourceFile = project.createSourceFile(
+        'test-redundant.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+import {wrapAuthenticatedHandler} from '#util/lambda-helpers'
+
+export const handler = wrapAuthenticatedHandler(async ({event, context, userId}) => {
+  // This is redundant - userId is already in params
+  const {userId: uid} = getUserDetailsFromEvent(event)
+  return response(context, 200, {userId: uid})
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0].message).toContain('Redundant getUserDetailsFromEvent')
+    })
+  })
+
+  describe('skips non-Lambda files', () => {
+    test('should skip utility files', () => {
+      const sourceFile = project.createSourceFile(
+        'test-util.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+// This is allowed in utility files
+export function helper(event) {
+  return getUserDetailsFromEvent(event)
+}
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/util/helpers.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+
+    test('should skip files not matching Lambda pattern', () => {
+      const sourceFile = project.createSourceFile(
+        'test-other.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+const x = getUserDetailsFromEvent(event)
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lib/auth.ts')
+
+      expect(violations).toHaveLength(0)
+    })
+  })
+
+  describe('provides helpful suggestions', () => {
+    test('should suggest wrapAuthenticatedHandler for full auth', () => {
+      const sourceFile = project.createSourceFile(
+        'test-suggest-auth.ts',
+        `
+import {getUserDetailsFromEvent} from '#util/apigateway-helpers'
+import {UserStatus} from '#types/enums'
+
+export const handler = wrapApiHandler(async ({event}) => {
+  const {userStatus} = getUserDetailsFromEvent(event)
+  if (userStatus === UserStatus.Unauthenticated || userStatus === UserStatus.Anonymous) {
+    throw new Error('Unauthorized')
+  }
+})
+`,
+        {overwrite: true}
+      )
+
+      const violations = authenticatedHandlerEnforcementRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
+
+      expect(violations[0].suggestion).toContain('wrapAuthenticatedHandler')
+    })
+  })
+})

--- a/src/mcp/validation/rules/authenticated-handler-enforcement.ts
+++ b/src/mcp/validation/rules/authenticated-handler-enforcement.ts
@@ -1,0 +1,117 @@
+/**
+ * Authenticated Handler Enforcement Rule
+ * HIGH: Detects manual getUserDetailsFromEvent() + UserStatus checks and suggests using
+ * wrapAuthenticatedHandler or wrapOptionalAuthHandler instead
+ *
+ * This rule promotes centralized auth handling for consistency and type safety.
+ */
+
+import type {SourceFile} from 'ts-morph'
+import {SyntaxKind} from 'ts-morph'
+import {createViolation} from '../types'
+import type {ValidationRule, Violation} from '../types'
+
+const RULE_NAME = 'authenticated-handler-enforcement'
+const SEVERITY = 'HIGH' as const
+
+/**
+ * Patterns that indicate manual auth handling (anti-patterns)
+ */
+const AUTH_PATTERNS = {
+  getUserDetailsFromEvent: 'getUserDetailsFromEvent',
+  userStatusCheck: /userStatus\s*===?\s*UserStatus\.(Unauthenticated|Anonymous)/,
+  userIdCheck: /!userId|userId\s*===?\s*(undefined|null)|typeof\s+userId\s*===?\s*'undefined'/
+}
+
+/**
+ * Determine which wrapper to suggest based on context
+ */
+function getSuggestion(hasAnonymousCheck: boolean, hasUnauthenticatedCheck: boolean): string {
+  if (hasAnonymousCheck && hasUnauthenticatedCheck) {
+    return "Use 'wrapAuthenticatedHandler' - it rejects both Unauthenticated and Anonymous users automatically"
+  } else if (hasUnauthenticatedCheck && !hasAnonymousCheck) {
+    return "Use 'wrapOptionalAuthHandler' - it rejects Unauthenticated users but allows Anonymous"
+  } else if (hasAnonymousCheck) {
+    return "Use 'wrapAuthenticatedHandler' if you need both checks, or 'wrapOptionalAuthHandler' if Anonymous should be allowed"
+  }
+  return "Use 'wrapAuthenticatedHandler' for authenticated-only endpoints or 'wrapOptionalAuthHandler' for endpoints that allow anonymous access"
+}
+
+export const authenticatedHandlerEnforcementRule: ValidationRule = {
+  name: RULE_NAME,
+  description:
+    'Use wrapAuthenticatedHandler or wrapOptionalAuthHandler instead of manual getUserDetailsFromEvent + UserStatus checks for consistent, type-safe auth handling.',
+  severity: SEVERITY,
+  appliesTo: ['src/lambdas/**/src/index.ts'],
+  excludes: ['src/**/*.test.ts', 'test/**/*.ts'],
+
+  validate(sourceFile: SourceFile, filePath: string): Violation[] {
+    const violations: Violation[] = []
+
+    // Skip if file doesn't appear to be a Lambda handler
+    if (!filePath.includes('/lambdas/') || !filePath.includes('/src/index.ts')) {
+      return violations
+    }
+
+    const fileText = sourceFile.getFullText()
+
+    // Check for getUserDetailsFromEvent import or call
+    const hasGetUserDetails = fileText.includes(AUTH_PATTERNS.getUserDetailsFromEvent)
+
+    if (!hasGetUserDetails) {
+      return violations // No manual auth handling detected
+    }
+
+    // Find the location of getUserDetailsFromEvent
+    let getUserDetailsLine = 1
+    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)
+    for (const call of callExpressions) {
+      const callText = call.getText()
+      if (callText.includes(AUTH_PATTERNS.getUserDetailsFromEvent)) {
+        getUserDetailsLine = call.getStartLineNumber()
+        break
+      }
+    }
+
+    // Check for UserStatus checks
+    const hasAnonymousCheck = AUTH_PATTERNS.userStatusCheck.test(fileText) && fileText.includes('Anonymous')
+    const hasUnauthenticatedCheck =
+      AUTH_PATTERNS.userStatusCheck.test(fileText) && (fileText.includes('Unauthenticated') || AUTH_PATTERNS.userIdCheck.test(fileText))
+
+    // Check if already using the new wrappers
+    const usesAuthenticatedWrapper = fileText.includes('wrapAuthenticatedHandler')
+    const usesOptionalAuthWrapper = fileText.includes('wrapOptionalAuthHandler')
+
+    if (usesAuthenticatedWrapper || usesOptionalAuthWrapper) {
+      // Already using new wrappers - check if getUserDetailsFromEvent is still present (shouldn't be)
+      if (hasGetUserDetails) {
+        violations.push(
+          createViolation(
+            RULE_NAME,
+            SEVERITY,
+            getUserDetailsLine,
+            'Redundant getUserDetailsFromEvent call - wrapAuthenticatedHandler/wrapOptionalAuthHandler already handles this',
+            {
+              suggestion: 'Remove getUserDetailsFromEvent call and use userId/userStatus from wrapper params'
+            }
+          )
+        )
+      }
+      return violations
+    }
+
+    // Using getUserDetailsFromEvent without new wrappers - this is the anti-pattern
+    if (hasGetUserDetails) {
+      const suggestion = getSuggestion(hasAnonymousCheck, hasUnauthenticatedCheck)
+
+      violations.push(
+        createViolation(RULE_NAME, SEVERITY, getUserDetailsLine, 'Manual auth handling detected - use centralized wrapper instead', {
+          suggestion,
+          codeSnippet: `const {userId, userStatus} = getUserDetailsFromEvent(event)`
+        })
+      )
+    }
+
+    return violations
+  }
+}

--- a/src/types/lambda-wrappers.ts
+++ b/src/types/lambda-wrappers.ts
@@ -11,6 +11,7 @@
 
 import type {APIGatewayRequestAuthorizerEvent, Context, ScheduledEvent} from 'aws-lambda'
 import type {CustomAPIGatewayRequestAuthorizerEvent} from './infrastructure-types'
+import type {UserStatus} from './enums'
 
 /** Metadata passed to all wrapped handlers */
 export type WrapperMetadata = {traceId: string}
@@ -26,3 +27,28 @@ export type EventHandlerParams<TRecord> = {record: TRecord; context: Context; me
 
 /** Parameters passed to wrapped scheduled handlers */
 export type ScheduledHandlerParams = {event: ScheduledEvent; context: Context; metadata: WrapperMetadata}
+
+/**
+ * Parameters passed to authenticated API handlers.
+ * userId is guaranteed to be a string (not optional) - the wrapper enforces this
+ * by rejecting Unauthenticated and Anonymous users before the handler runs.
+ */
+export type AuthenticatedApiParams<TEvent = CustomAPIGatewayRequestAuthorizerEvent> = {
+  event: TEvent
+  context: Context
+  metadata: WrapperMetadata
+  userId: string
+}
+
+/**
+ * Parameters passed to optional-auth API handlers.
+ * Allows both Anonymous and Authenticated users (rejects only Unauthenticated).
+ * Handler receives userStatus to differentiate behavior.
+ */
+export type OptionalAuthApiParams<TEvent = CustomAPIGatewayRequestAuthorizerEvent> = {
+  event: TEvent
+  context: Context
+  metadata: WrapperMetadata
+  userId: string | undefined
+  userStatus: UserStatus
+}

--- a/src/util/lambda-helpers.test.ts
+++ b/src/util/lambda-helpers.test.ts
@@ -255,6 +255,226 @@ describe('lambda-helpers', () => {
     })
   })
 
+  describe('wrapAuthenticatedHandler', () => {
+    const mockContext = {awsRequestId: 'test-request-id'} as Context
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type TestEvent = any
+
+    // Event with valid Authorization header and userId from authorizer
+    const authenticatedEvent: TestEvent = {
+      httpMethod: 'GET',
+      headers: {Authorization: 'Bearer valid-token'},
+      requestContext: {authorizer: {principalId: 'user-123'}}
+    }
+
+    // Event with Authorization header but no valid userId (Unauthenticated)
+    const unauthenticatedEvent: TestEvent = {
+      httpMethod: 'GET',
+      headers: {Authorization: 'Bearer invalid-token'},
+      requestContext: {authorizer: {principalId: 'unknown'}}
+    }
+
+    // Event with no Authorization header (Anonymous)
+    const anonymousEvent: TestEvent = {
+      httpMethod: 'GET',
+      headers: {},
+      requestContext: {authorizer: {principalId: 'unknown'}}
+    }
+
+    it('should return handler result for authenticated user', async () => {
+      const {wrapAuthenticatedHandler, response} = await import('./lambda-helpers')
+      const handler = wrapAuthenticatedHandler<TestEvent>(async ({context, userId}) => response(context, 200, {userId}))
+
+      const result = await handler(authenticatedEvent, mockContext)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body)
+      expect(body.body.userId).toBe('user-123')
+    })
+
+    it('should provide guaranteed userId to handler', async () => {
+      const {wrapAuthenticatedHandler, response} = await import('./lambda-helpers')
+      let receivedUserId: string | undefined
+      const handler = wrapAuthenticatedHandler<TestEvent>(async ({context, userId}) => {
+        receivedUserId = userId
+        return response(context, 200, {})
+      })
+
+      await handler(authenticatedEvent, mockContext)
+
+      expect(receivedUserId).toBe('user-123')
+      expect(typeof receivedUserId).toBe('string')
+    })
+
+    it('should return 401 for unauthenticated user (invalid token)', async () => {
+      const {wrapAuthenticatedHandler, response} = await import('./lambda-helpers')
+      const handler = wrapAuthenticatedHandler<TestEvent>(async ({context}) => response(context, 200, {}))
+
+      const result = await handler(unauthenticatedEvent, mockContext)
+
+      expect(result.statusCode).toBe(401)
+    })
+
+    it('should return 401 for anonymous user (no token)', async () => {
+      const {wrapAuthenticatedHandler, response} = await import('./lambda-helpers')
+      const handler = wrapAuthenticatedHandler<TestEvent>(async ({context}) => response(context, 200, {}))
+
+      const result = await handler(anonymousEvent, mockContext)
+
+      expect(result.statusCode).toBe(401)
+    })
+
+    it('should pass metadata with traceId to handler', async () => {
+      const {wrapAuthenticatedHandler, response} = await import('./lambda-helpers')
+      let receivedMetadata: {traceId: string} | undefined
+      const handler = wrapAuthenticatedHandler<TestEvent>(async ({context, metadata}) => {
+        receivedMetadata = metadata
+        return response(context, 200, {})
+      })
+
+      await handler(authenticatedEvent, mockContext)
+
+      expect(receivedMetadata?.traceId).toBe('test-request-id')
+    })
+
+    it('should return 500 when handler throws', async () => {
+      const {wrapAuthenticatedHandler} = await import('./lambda-helpers')
+      const handler = wrapAuthenticatedHandler<TestEvent>(async () => {
+        throw new Error('Internal error')
+      })
+
+      const result = await handler(authenticatedEvent, mockContext)
+
+      expect(result.statusCode).toBe(500)
+      expect(JSON.parse(result.body).error.message).toBe('Internal error')
+    })
+  })
+
+  describe('wrapOptionalAuthHandler', () => {
+    const mockContext = {awsRequestId: 'test-request-id'} as Context
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type TestEvent = any
+
+    // Event with valid Authorization header and userId from authorizer
+    const authenticatedEvent: TestEvent = {
+      httpMethod: 'GET',
+      headers: {Authorization: 'Bearer valid-token'},
+      requestContext: {authorizer: {principalId: 'user-123'}}
+    }
+
+    // Event with Authorization header but no valid userId (Unauthenticated)
+    const unauthenticatedEvent: TestEvent = {
+      httpMethod: 'GET',
+      headers: {Authorization: 'Bearer invalid-token'},
+      requestContext: {authorizer: {principalId: 'unknown'}}
+    }
+
+    // Event with no Authorization header (Anonymous)
+    const anonymousEvent: TestEvent = {
+      httpMethod: 'GET',
+      headers: {},
+      requestContext: {authorizer: {principalId: 'unknown'}}
+    }
+
+    it('should return handler result for authenticated user', async () => {
+      const {wrapOptionalAuthHandler, response} = await import('./lambda-helpers')
+      const handler = wrapOptionalAuthHandler<TestEvent>(async ({context, userId}) => response(context, 200, {userId}))
+
+      const result = await handler(authenticatedEvent, mockContext)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body)
+      expect(body.body.userId).toBe('user-123')
+    })
+
+    it('should return handler result for anonymous user', async () => {
+      const {wrapOptionalAuthHandler, response} = await import('./lambda-helpers')
+      const {UserStatus} = await import('#types/enums')
+      const handler = wrapOptionalAuthHandler<TestEvent>(async ({context, userStatus}) => {
+        if (userStatus === UserStatus.Anonymous) {
+          return response(context, 200, {demo: true})
+        }
+        return response(context, 200, {demo: false})
+      })
+
+      const result = await handler(anonymousEvent, mockContext)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body)
+      expect(body.body.demo).toBe(true)
+    })
+
+    it('should return 401 for unauthenticated user (invalid token)', async () => {
+      const {wrapOptionalAuthHandler, response} = await import('./lambda-helpers')
+      const handler = wrapOptionalAuthHandler<TestEvent>(async ({context}) => response(context, 200, {}))
+
+      const result = await handler(unauthenticatedEvent, mockContext)
+
+      expect(result.statusCode).toBe(401)
+    })
+
+    it('should provide userId and userStatus to handler', async () => {
+      const {wrapOptionalAuthHandler, response} = await import('./lambda-helpers')
+      const {UserStatus} = await import('#types/enums')
+      let receivedUserId: string | undefined
+      let receivedUserStatus: typeof UserStatus[keyof typeof UserStatus] | undefined
+      const handler = wrapOptionalAuthHandler<TestEvent>(async ({context, userId, userStatus}) => {
+        receivedUserId = userId
+        receivedUserStatus = userStatus
+        return response(context, 200, {})
+      })
+
+      await handler(authenticatedEvent, mockContext)
+
+      expect(receivedUserId).toBe('user-123')
+      expect(receivedUserStatus).toBe(UserStatus.Authenticated)
+    })
+
+    it('should provide undefined userId for anonymous user', async () => {
+      const {wrapOptionalAuthHandler, response} = await import('./lambda-helpers')
+      const {UserStatus} = await import('#types/enums')
+      let receivedUserId: string | undefined
+      let receivedUserStatus: typeof UserStatus[keyof typeof UserStatus] | undefined
+      const handler = wrapOptionalAuthHandler<TestEvent>(async ({context, userId, userStatus}) => {
+        receivedUserId = userId
+        receivedUserStatus = userStatus
+        return response(context, 200, {})
+      })
+
+      await handler(anonymousEvent, mockContext)
+
+      expect(receivedUserId).toBeUndefined()
+      expect(receivedUserStatus).toBe(UserStatus.Anonymous)
+    })
+
+    it('should pass metadata with traceId to handler', async () => {
+      const {wrapOptionalAuthHandler, response} = await import('./lambda-helpers')
+      let receivedMetadata: {traceId: string} | undefined
+      const handler = wrapOptionalAuthHandler<TestEvent>(async ({context, metadata}) => {
+        receivedMetadata = metadata
+        return response(context, 200, {})
+      })
+
+      await handler(authenticatedEvent, mockContext)
+
+      expect(receivedMetadata?.traceId).toBe('test-request-id')
+    })
+
+    it('should return 500 when handler throws', async () => {
+      const {wrapOptionalAuthHandler} = await import('./lambda-helpers')
+      const handler = wrapOptionalAuthHandler<TestEvent>(async () => {
+        throw new Error('Internal error')
+      })
+
+      const result = await handler(authenticatedEvent, mockContext)
+
+      expect(result.statusCode).toBe(500)
+      expect(JSON.parse(result.body).error.message).toBe('Internal error')
+    })
+  })
+
   describe('wrapAuthorizer', () => {
     const mockContext = {awsRequestId: 'auth-request-id'} as Context
     const mockEvent = {

--- a/test/integration/workflows/auth.flow.integration.test.ts
+++ b/test/integration/workflows/auth.flow.integration.test.ts
@@ -268,17 +268,17 @@ describe('Auth Flow Integration Tests', () => {
       expect(usersMock.entity.update).not.toHaveBeenCalled()
     })
 
-    test('should return 400 when required name fields are missing', async () => {
-      // registerUserSchema requires firstName and lastName
+    test('should allow registration without optional name fields', async () => {
+      // registerUserSchema has firstName and lastName as optional
       const body: AuthRequestBody = {idToken: 'valid-apple-id-token'}
       const event = createAuthEvent(body, '/auth/register')
       const result = await registerHandler(event, mockContext)
 
-      // Schema validation should fail
-      expect(result.statusCode).toBe(400)
+      // Schema validation should pass (firstName/lastName are optional)
+      expect(result.statusCode).toBe(200)
 
-      // Better Auth should NOT be called due to validation failure
-      expect(signInSocialMock).not.toHaveBeenCalled()
+      // Better Auth should be called
+      expect(signInSocialMock).toHaveBeenCalled()
     })
 
     test('should validate request body - missing idToken', async () => {

--- a/test/integration/workflows/deviceRegistration.integration.test.ts
+++ b/test/integration/workflows/deviceRegistration.integration.test.ts
@@ -41,7 +41,7 @@ import {createMockDevice, createMockUserDevice} from '../helpers/test-data'
 
 import {fileURLToPath} from 'url'
 import {dirname, resolve} from 'path'
-import {CustomAPIGatewayRequestAuthorizerEvent} from '../../../src/types/infrastructure-types'
+import type {CustomAPIGatewayRequestAuthorizerEvent} from '../../../src/types/infrastructure-types'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -232,7 +232,7 @@ describe('Device Registration Integration Tests', () => {
 
     unsubscribeMock.mockResolvedValue(undefined)
 
-    const body: DeviceRegistrationBody = {deviceId, token}
+    const body: DeviceRegistrationBody = {deviceId, token, name: 'iPhone 15', systemName: 'iOS', systemVersion: '17.0'}
     const event = createRegisterDeviceEvent(body, userId, UserStatus.Authenticated)
     const result = await handler(event, mockContext)
 
@@ -261,7 +261,7 @@ describe('Device Registration Integration Tests', () => {
       SubscriptionArn: 'arn:aws:sns:us-west-2:123456789012:TestTopic:sub-anon'
     })
 
-    const body: DeviceRegistrationBody = {deviceId, token}
+    const body: DeviceRegistrationBody = {deviceId, token, name: 'iPhone 15', systemName: 'iOS', systemVersion: '17.0'}
     const event = createRegisterDeviceEvent(body, undefined, UserStatus.Anonymous)
     const result = await handler(event, mockContext)
 
@@ -287,7 +287,7 @@ describe('Device Registration Integration Tests', () => {
       data: {...createMockDevice(deviceId, endpointArn), token}
     })
 
-    const body: DeviceRegistrationBody = {deviceId, token}
+    const body: DeviceRegistrationBody = {deviceId, token, name: 'iPhone 15', systemName: 'iOS', systemVersion: '17.0'}
     // Create event with Authorization header but invalid/no userId
     // getUserDetailsFromEvent returns Unauthenticated when there's an auth header but no userId
     const event = {
@@ -349,7 +349,7 @@ describe('Device Registration Integration Tests', () => {
     // Mock SNS failure
     createPlatformEndpointMock.mockResolvedValue(undefined as unknown as {EndpointArn: string})
 
-    const body: DeviceRegistrationBody = {deviceId, token}
+    const body: DeviceRegistrationBody = {deviceId, token, name: 'iPhone 15', systemName: 'iOS', systemVersion: '17.0'}
     const event = createRegisterDeviceEvent(body, userId, UserStatus.Authenticated)
     const result = await handler(event, mockContext)
 

--- a/test/integration/workflows/userDelete.cascade.integration.test.ts
+++ b/test/integration/workflows/userDelete.cascade.integration.test.ts
@@ -40,7 +40,7 @@ import {createMockDevice, createMockUserDevice, createMockUserFile} from '../hel
 
 import {fileURLToPath} from 'url'
 import {dirname, resolve} from 'path'
-import {CustomAPIGatewayRequestAuthorizerEvent} from '../../../src/types/infrastructure-types'
+import type {CustomAPIGatewayRequestAuthorizerEvent} from '../../../src/types/infrastructure-types'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -299,7 +299,8 @@ describe('UserDelete Cascade Integration Tests', () => {
 
     const result = await handler(event, mockContext)
 
-    expect(result.statusCode).toBe(500)
+    // wrapAuthenticatedHandler rejects Unauthenticated users with 401
+    expect(result.statusCode).toBe(401)
   })
 
   test('should handle multiple devices with SNS endpoint deletion', async () => {


### PR DESCRIPTION
## Summary

- Add type-safe `wrapAuthenticatedHandler` and `wrapOptionalAuthHandler` wrappers to eliminate boilerplate `getUserDetailsFromEvent()` + `UserStatus` checks
- **Security fix**: UserSubscribe now requires authentication (was previously unprotected)
- Add MCP validation rule and ESLint custom rule for future compliance
- Migrate 5 Lambda handlers to use the new wrappers

## Changes

### New Types (`src/types/lambda-wrappers.ts`)
- `AuthenticatedApiParams`: Parameters with guaranteed `userId: string` (compiler enforces this)
- `OptionalAuthApiParams`: Parameters with `userId: string | undefined` and `userStatus: UserStatus`

### New Wrappers (`src/util/lambda-helpers.ts`)
| Wrapper | Behavior | userId Type |
|---------|----------|-------------|
| `wrapAuthenticatedHandler` | Rejects Unauthenticated AND Anonymous with 401 | `string` (guaranteed) |
| `wrapOptionalAuthHandler` | Rejects only Unauthenticated with 401 | `string \| undefined` |

### Lambda Migrations
| Lambda | New Wrapper | Change |
|--------|-------------|--------|
| **UserDelete** | `wrapAuthenticatedHandler` | Removed manual `!userId` check |
| **WebhookFeedly** | `wrapAuthenticatedHandler` | Removed manual `!userId` check |
| **UserSubscribe** | `wrapAuthenticatedHandler` | **SECURITY FIX** - Added missing auth |
| **ListFiles** | `wrapOptionalAuthHandler` | Simplified status logic |
| **RegisterDevice** | `wrapOptionalAuthHandler` | Simplified status logic |

### Enforcement
- MCP Rule: `authenticated-handler-enforcement` (HIGH severity)
- ESLint Rule: `local-rules/authenticated-handler-enforcement` (warn level)

## Test plan

- [x] All 559 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] New wrapper unit tests (13 tests for auth scenarios)
- [x] MCP validation rule tests (14 tests)
- [ ] Manual verification of auth behavior in staging

## Breaking Changes

**UserSubscribe** now requires authentication. Previously, anyone could subscribe any endpoint to any topic without authentication.