### PR TITLE
feat: unify response helpers and improve logging consistency

### DIFF
--- a/docs/wiki/TypeScript/Lambda-Function-Patterns.md
+++ b/docs/wiki/TypeScript/Lambda-Function-Patterns.md
@@ -63,16 +63,17 @@ All wrappers provide:
 
 ## Response Format (REQUIRED)
 
-**Mandatory**: ALWAYS use the `response` and `lambdaErrorResponse` helper functions from `lambda-helpers.ts`. Never return raw API Gateway response objects.
+**Mandatory**: ALWAYS use the `buildApiResponse` helper function from `lambda-helpers.ts`. Never return raw API Gateway response objects.
 
 ```typescript
-// ✅ CORRECT - Use response helper
-return response(context, 200, {
-  data: result,
-  requestId: context.awsRequestId
-})
+// ✅ CORRECT - Use buildApiResponse with status code
+return buildApiResponse(context, 200, {data: result})
 
-// ✅ CORRECT - Use error response helper
+// ✅ CORRECT - Use buildApiResponse with Error object
+return buildApiResponse(context, new ValidationError('Invalid input'))
+
+// ✅ CORRECT - Legacy helpers still work (deprecated but supported)
+return response(context, 200, {data: result})
 return lambdaErrorResponse(context, error)
 
 // ❌ WRONG - Never return raw objects

--- a/eslint-local-rules/rules/response-helpers.cjs
+++ b/eslint-local-rules/rules/response-helpers.cjs
@@ -14,7 +14,7 @@ module.exports = {
       recommended: true
     },
     messages: {
-      rawResponse: 'Raw response object detected. Use response(statusCode, data) or lambdaErrorResponse() from lambda-helpers instead.',
+      rawResponse: 'Raw response object detected. Use buildApiResponse(), response(), or lambdaErrorResponse() from lambda-helpers instead.',
       missingImport: 'Lambda handler returns API Gateway responses but does not import response helpers from lambda-helpers.'
     },
     schema: []
@@ -43,7 +43,7 @@ module.exports = {
           for (const spec of specifiers) {
             if (spec.type === 'ImportSpecifier') {
               const name = spec.imported?.name || spec.local?.name
-              if (name === 'response' || name === 'lambdaErrorResponse') {
+              if (name === 'response' || name === 'lambdaErrorResponse' || name === 'buildApiResponse') {
                 hasResponseImport = true
               }
             }

--- a/src/lambdas/StartFileUpload/src/index.ts
+++ b/src/lambdas/StartFileUpload/src/index.ts
@@ -89,10 +89,12 @@ async function updateDownloadState(fileId: string, status: DownloadStatus, class
 
   try {
     // Try to update existing record first
-    await FileDownloads.update({fileId}).set(update).go()
+    logDebug('FileDownloads.update <=', {fileId, update})
+    const updateResponse = await FileDownloads.update({fileId}).set(update).go()
+    logDebug('FileDownloads.update =>', updateResponse)
   } catch {
     // If record doesn't exist, create it
-    await FileDownloads.create({
+    const createData = {
       fileId,
       status,
       retryCount,
@@ -102,7 +104,10 @@ async function updateDownloadState(fileId: string, status: DownloadStatus, class
       retryAfter: classification?.retryAfter,
       sourceUrl: `https://www.youtube.com/watch?v=${fileId}`,
       ttl: update.ttl as number | undefined
-    }).go()
+    }
+    logDebug('FileDownloads.create <=', createData)
+    const createResponse = await FileDownloads.create(createData).go()
+    logDebug('FileDownloads.create =>', createResponse)
   }
 }
 
@@ -243,7 +248,9 @@ export const handler = withPowertools(async (event: StartFileUploadParams, conte
   let existingRetryCount = 0
   let existingMaxRetries = 5
   try {
+    logDebug('FileDownloads.get <=', {fileId})
     const {data: existingDownload} = await FileDownloads.get({fileId}).go()
+    logDebug('FileDownloads.get =>', existingDownload ?? 'null')
     if (existingDownload) {
       existingRetryCount = existingDownload.retryCount ?? 0
       existingMaxRetries = existingDownload.maxRetries ?? 5

--- a/src/mcp/handlers/validation.ts
+++ b/src/mcp/handlers/validation.ts
@@ -148,7 +148,7 @@ export async function handleValidationQuery(args: ValidationQueryArgs) {
         violations: result.violations,
         skipped: result.skipped.includes('response-helpers') ? 'Rule skipped: Not a Lambda handler file' : undefined,
         message: result.valid
-          ? 'Lambda uses response() and lambdaErrorResponse() helpers correctly.'
+          ? 'Lambda uses buildApiResponse(), response(), or lambdaErrorResponse() helpers correctly.'
           : 'Raw response objects detected. Use helper functions for consistent formatting.'
       }
     }

--- a/src/mcp/validation/rules/response-helpers.test.ts
+++ b/src/mcp/validation/rules/response-helpers.test.ts
@@ -209,7 +209,7 @@ export async function handler() {
 
       const violations = responseHelpersRule.validate(sourceFile, 'src/lambdas/Test/src/index.ts')
 
-      expect(violations[0].suggestion).toContain('response')
+      expect(violations[0].suggestion).toContain('buildApiResponse')
     })
 
     test('should suggest importing helper when missing', () => {

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -84,3 +84,4 @@ export class Apns2Error extends Error {
 }
 
 export const providerFailureErrorMessage = 'AWS request failed'
+export const UNAUTHORIZED_ERROR_MESSAGE = 'Invalid Authentication token; login'

--- a/src/util/github-helpers.ts
+++ b/src/util/github-helpers.ts
@@ -40,9 +40,9 @@ export async function createFailedUserDeletionIssue(userId: string, devices: Dev
 
   try {
     const octokit = await getOctokitInstance()
-    logDebug('createFailedUserDeletionIssue =>', params)
+    logDebug('createFailedUserDeletionIssue <=', params)
     const response = await octokit.rest.issues.create(params)
-    logDebug('createFailedUserDeletionIssue <=', response)
+    logDebug('createFailedUserDeletionIssue =>', response)
     return response
   } catch (githubError) {
     // Don't fail the Lambda if GitHub issue creation fails
@@ -59,9 +59,9 @@ export async function createVideoDownloadFailureIssue(fileId: string, fileUrl: s
 
   try {
     const octokit = await getOctokitInstance()
-    logDebug('createVideoDownloadFailureIssue =>', params)
+    logDebug('createVideoDownloadFailureIssue <=', params)
     const response = await octokit.rest.issues.create(params)
-    logDebug('createVideoDownloadFailureIssue <=', response)
+    logDebug('createVideoDownloadFailureIssue =>', response)
     return response
   } catch (githubError) {
     // Don't fail the Lambda if GitHub issue creation fails
@@ -78,7 +78,7 @@ export async function createCookieExpirationIssue(fileId: string, fileUrl: strin
 
   try {
     const octokit = await getOctokitInstance()
-    logDebug('createCookieExpirationIssue =>', params)
+    logDebug('createCookieExpirationIssue <=', params)
     const response = await octokit.rest.issues.create(params)
     logInfo('Created GitHub issue for cookie expiration', {issueNumber: response.data.number, issueUrl: response.data.html_url})
     return response


### PR DESCRIPTION
## Summary

- Create `buildApiResponse()` with dual signatures (status code or Error)
- Deprecate `response()` and `lambdaErrorResponse()` as backwards-compatible aliases
- Rename `unknownErrorToString` to `getErrorMessage` (internal helper)
- Add `UNAUTHORIZED_ERROR_MESSAGE` constant to errors.ts
- Add missing ElectroDB logging to StartFileUpload handler
- Fix reversed arrow directions in github-helpers.ts
- Update ESLint and MCP validation rules for buildApiResponse
- Update documentation with new helper function examples

## Test plan

- [x] All 560 unit tests pass
- [x] Type checking passes
- [x] ESLint passes
- [x] Documentation validation passes