### PR TITLE
chore: add Makefile for humanlayer worktree compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: setup
+
+setup:
+	pnpm install --frozen-lockfile || pnpm install


### PR DESCRIPTION
## Summary
- Adds a minimal Makefile with a setup target that runs pnpm install
- Enables compatibility with the humanlayer:create-worktree Claude Code plugin skill
- The plugin expects make setup to exist for worktree initialization

## Context
The humanlayer plugin create-worktree skill runs make setup after creating a worktree. This project previously had no Makefile, causing the skill to fail. The new Makefile delegates to pnpm install, which triggers the prepare script that runs husky to set up git hooks.

## Changes Made
- Added Makefile with setup target

## Test plan
- [x] Verified make setup runs successfully
- [x] Verified husky hooks are installed after make setup
- [x] Unit tests pass