### PR TITLE
feat(infra): migrate 15 Lambdas to ARM64 (Graviton2) and reduce log retention

### DIFF
--- a/terraform/api_gateway_authorizer.tf
+++ b/terraform/api_gateway_authorizer.tf
@@ -23,7 +23,7 @@ resource "aws_iam_role_policy" "ApiGatewayAuthorizerInvocation" {
 
 resource "aws_cloudwatch_log_group" "ApiGatewayAuthorizer" {
   name              = "/aws/lambda/${aws_lambda_function.ApiGatewayAuthorizer.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -71,6 +71,7 @@ resource "aws_lambda_function" "ApiGatewayAuthorizer" {
   role          = aws_iam_role.ApiGatewayAuthorizer.arn
   handler       = "index.handler"
   runtime       = "nodejs24.x"
+  architectures = [local.lambda_architecture]
   timeout       = 10
   depends_on = [
     aws_iam_role_policy_attachment.ApiGatewayAuthorizer,

--- a/terraform/cleanup_expired_records.tf
+++ b/terraform/cleanup_expired_records.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role_policy_attachment" "CleanupExpiredRecordsDSQL" {
 
 resource "aws_cloudwatch_log_group" "CleanupExpiredRecords" {
   name              = "/aws/lambda/${aws_lambda_function.CleanupExpiredRecords.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -45,6 +45,7 @@ resource "aws_lambda_function" "CleanupExpiredRecords" {
   role             = aws_iam_role.CleanupExpiredRecords.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   timeout          = 60 # Allow time for database operations
   depends_on       = [aws_iam_role_policy_attachment.CleanupExpiredRecords]
   filename         = data.archive_file.CleanupExpiredRecords.output_path

--- a/terraform/device_event.tf
+++ b/terraform/device_event.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_permission" "DeviceEvent" {
 
 resource "aws_cloudwatch_log_group" "DeviceEvent" {
   name              = "/aws/lambda/${aws_lambda_function.DeviceEvent.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -42,6 +42,7 @@ resource "aws_lambda_function" "DeviceEvent" {
   role             = aws_iam_role.DeviceEvent.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   depends_on       = [aws_iam_role_policy_attachment.DeviceEventLogging]
   filename         = data.archive_file.DeviceEvent.output_path
   source_code_hash = data.archive_file.DeviceEvent.output_base64sha256

--- a/terraform/feedly_webhook.tf
+++ b/terraform/feedly_webhook.tf
@@ -65,7 +65,7 @@ resource "aws_lambda_permission" "WebhookFeedly" {
 
 resource "aws_cloudwatch_log_group" "WebhookFeedly" {
   name              = "/aws/lambda/${aws_lambda_function.WebhookFeedly.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -81,6 +81,7 @@ resource "aws_lambda_function" "WebhookFeedly" {
   role             = aws_iam_role.WebhookFeedly.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   memory_size      = 512
   depends_on       = [aws_iam_role_policy_attachment.WebhookFeedly]
   filename         = data.archive_file.WebhookFeedly.output_path
@@ -341,6 +342,7 @@ resource "aws_lambda_function" "StartFileUpload" {
   role                           = aws_iam_role.StartFileUpload.arn
   handler                        = "index.handler"
   runtime                        = "nodejs24.x"
+  architectures                  = ["x86_64"] # Must use x86_64 - yt-dlp and ffmpeg layers are amd64 binaries
   depends_on                     = [aws_iam_role_policy_attachment.StartFileUpload]
   timeout                        = 900
   memory_size                    = 2048
@@ -382,6 +384,6 @@ resource "aws_lambda_function" "StartFileUpload" {
 
 resource "aws_cloudwatch_log_group" "StartFileUpload" {
   name              = "/aws/lambda/${aws_lambda_function.StartFileUpload.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }

--- a/terraform/file_bucket.tf
+++ b/terraform/file_bucket.tf
@@ -119,7 +119,7 @@ resource "aws_lambda_permission" "S3ObjectCreated" {
 
 resource "aws_cloudwatch_log_group" "S3ObjectCreated" {
   name              = "/aws/lambda/${aws_lambda_function.S3ObjectCreated.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -135,6 +135,7 @@ resource "aws_lambda_function" "S3ObjectCreated" {
   role             = aws_iam_role.S3ObjectCreated.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   depends_on       = [aws_iam_role_policy_attachment.S3ObjectCreated]
   filename         = data.archive_file.S3ObjectCreated.output_path
   source_code_hash = data.archive_file.S3ObjectCreated.output_base64sha256

--- a/terraform/list_files.tf
+++ b/terraform/list_files.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "ListFiles" {
 
 resource "aws_cloudwatch_log_group" "ListFiles" {
   name              = "/aws/lambda/${aws_lambda_function.ListFiles.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -48,6 +48,7 @@ resource "aws_lambda_function" "ListFiles" {
   role             = aws_iam_role.ListFiles.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   memory_size      = 512
   depends_on       = [aws_iam_role_policy_attachment.ListFilesLogging]
   filename         = data.archive_file.ListFiles.output_path

--- a/terraform/login_user.tf
+++ b/terraform/login_user.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "LoginUser" {
 
 resource "aws_cloudwatch_log_group" "LoginUser" {
   name              = "/aws/lambda/${aws_lambda_function.LoginUser.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -47,6 +47,7 @@ resource "aws_lambda_function" "LoginUser" {
   role             = aws_iam_role.LoginUser.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   timeout          = 30
   depends_on       = [aws_iam_role_policy_attachment.LoginUserLogging]
   filename         = data.archive_file.LoginUser.output_path

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,7 +28,9 @@ data "aws_caller_identity" "current" {}
 # Layer version list: https://aws-otel.github.io/docs/getting-started/lambda/lambda-js#lambda-layer
 # AWS-managed layer published in account 901920570463
 locals {
-  adot_layer_arn = "arn:aws:lambda:${data.aws_region.current.id}:901920570463:layer:aws-otel-nodejs-amd64-ver-1-30-2:1"
+  # Lambda architecture: arm64 (Graviton2) for 20% cost savings and 13-24% faster cold starts
+  lambda_architecture = "arm64"
+  adot_layer_arn      = "arn:aws:lambda:${data.aws_region.current.id}:901920570463:layer:aws-otel-nodejs-arm64-ver-1-30-2:1"
 
   # Common tags for all resources (drift detection & identification)
   common_tags = {

--- a/terraform/migrate_dsql.tf
+++ b/terraform/migrate_dsql.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy_attachment" "MigrateDSQLDSQL" {
 
 resource "aws_cloudwatch_log_group" "MigrateDSQL" {
   name              = "/aws/lambda/${aws_lambda_function.MigrateDSQL.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -47,6 +47,7 @@ resource "aws_lambda_function" "MigrateDSQL" {
   role             = aws_iam_role.MigrateDSQL.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   timeout          = 300 # 5 minutes for complex migrations
   memory_size      = 256
   depends_on       = [aws_iam_role_policy_attachment.MigrateDSQL]

--- a/terraform/prune_devices.tf
+++ b/terraform/prune_devices.tf
@@ -66,7 +66,7 @@ resource "aws_lambda_permission" "PruneDevices" {
 
 resource "aws_cloudwatch_log_group" "PruneDevices" {
   name              = "/aws/lambda/${aws_lambda_function.PruneDevices.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -82,6 +82,7 @@ resource "aws_lambda_function" "PruneDevices" {
   role             = aws_iam_role.PruneDevices.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   depends_on       = [aws_iam_role_policy_attachment.PruneDevices]
   filename         = data.archive_file.PruneDevices.output_path
   source_code_hash = data.archive_file.PruneDevices.output_base64sha256

--- a/terraform/refresh_token.tf
+++ b/terraform/refresh_token.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "RefreshToken" {
 
 resource "aws_cloudwatch_log_group" "RefreshToken" {
   name              = "/aws/lambda/${aws_lambda_function.RefreshToken.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -47,6 +47,7 @@ resource "aws_lambda_function" "RefreshToken" {
   role             = aws_iam_role.RefreshToken.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   timeout          = 30
   depends_on       = [aws_iam_role_policy_attachment.RefreshTokenLogging]
   filename         = data.archive_file.RefreshToken.output_path

--- a/terraform/register_device.tf
+++ b/terraform/register_device.tf
@@ -57,7 +57,7 @@ resource "aws_lambda_permission" "RegisterDevice" {
 
 resource "aws_cloudwatch_log_group" "RegisterDevice" {
   name              = "/aws/lambda/${aws_lambda_function.RegisterDevice.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -73,6 +73,7 @@ resource "aws_lambda_function" "RegisterDevice" {
   role             = aws_iam_role.RegisterDevice.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   timeout          = 10
   depends_on       = [aws_iam_role_policy_attachment.RegisterDevice]
   filename         = data.archive_file.RegisterDevice.output_path

--- a/terraform/register_user.tf
+++ b/terraform/register_user.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "RegisterUser" {
 
 resource "aws_cloudwatch_log_group" "RegisterUser" {
   name              = "/aws/lambda/${aws_lambda_function.RegisterUser.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -47,6 +47,7 @@ resource "aws_lambda_function" "RegisterUser" {
   role             = aws_iam_role.RegisterUser.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   timeout          = 10
   depends_on       = [aws_iam_role_policy_attachment.RegisterUserLogging]
   filename         = data.archive_file.RegisterUser.output_path

--- a/terraform/send_push_notification.tf
+++ b/terraform/send_push_notification.tf
@@ -63,7 +63,7 @@ resource "aws_lambda_permission" "SendPushNotification" {
 
 resource "aws_cloudwatch_log_group" "SendPushNotification" {
   name              = "/aws/lambda/${aws_lambda_function.SendPushNotification.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -79,6 +79,7 @@ resource "aws_lambda_function" "SendPushNotification" {
   role             = aws_iam_role.SendPushNotification.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   depends_on       = [aws_iam_role_policy_attachment.SendPushNotificationLogging]
   filename         = data.archive_file.SendPushNotification.output_path
   source_code_hash = data.archive_file.SendPushNotification.output_base64sha256

--- a/terraform/user_delete.tf
+++ b/terraform/user_delete.tf
@@ -52,7 +52,7 @@ resource "aws_lambda_permission" "UserDelete" {
 
 resource "aws_cloudwatch_log_group" "UserDelete" {
   name              = "/aws/lambda/${aws_lambda_function.UserDelete.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -68,6 +68,7 @@ resource "aws_lambda_function" "UserDelete" {
   role             = aws_iam_role.UserDelete.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   depends_on       = [aws_iam_role_policy_attachment.UserDelete]
   filename         = data.archive_file.UserDelete.output_path
   source_code_hash = data.archive_file.UserDelete.output_base64sha256

--- a/terraform/user_subscribe.tf
+++ b/terraform/user_subscribe.tf
@@ -47,7 +47,7 @@ resource "aws_lambda_permission" "UserSubscribe" {
 
 resource "aws_cloudwatch_log_group" "UserSubscribe" {
   name              = "/aws/lambda/${aws_lambda_function.UserSubscribe.function_name}"
-  retention_in_days = 14
+  retention_in_days = 7
   tags              = local.common_tags
 }
 
@@ -63,6 +63,7 @@ resource "aws_lambda_function" "UserSubscribe" {
   role             = aws_iam_role.UserSubscribe.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   depends_on       = [aws_iam_role_policy_attachment.UserSubscribe]
   filename         = data.archive_file.UserSubscribe.output_path
   source_code_hash = data.archive_file.UserSubscribe.output_base64sha256


### PR DESCRIPTION
## Summary

Migrates 15 Lambda functions from x86_64 to ARM64 (Graviton2) architecture and reduces CloudWatch Logs retention from 14 to 7 days.

### Why ARM64 (Graviton2)?

Based on comprehensive analysis (22 web searches) of cost optimization strategies for this ~$3/month project:

| Benefit | Impact | Source |
|---------|--------|--------|
| **Cost reduction** | 20% cheaper duration pricing | [AWS Lambda Pricing](https://aws.amazon.com/lambda/pricing/) |
| **Cold start** | 13-24% faster | [Performance Benchmarks](https://github.com/cebert/aws-lambda-performance-benchmarks) |
| **Price/performance** | Up to 34% better | [AWS Blog](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/) |
| **Energy efficiency** | Up to 60% less energy | [AWS Graviton](https://aws.amazon.com/ec2/graviton/) |

### Technical Details

**Architecture migration:**
- Added `lambda_architecture = "arm64"` local variable in `main.tf` for centralized config
- Updated ADOT layer ARN from `aws-otel-nodejs-amd64-ver-1-30-2:1` to `aws-otel-nodejs-arm64-ver-1-30-2:1`
- Added `architectures = [local.lambda_architecture]` to 15 Lambda functions

**CloudWatch Logs optimization:**
- Reduced `retention_in_days` from 14 to 7 across 16 log groups

### Lambdas NOT migrated (with reason)

| Lambda | Reason |
|--------|--------|
| CloudfrontMiddleware | Lambda@Edge does not support ARM64 |
| StartFileUpload | Uses x86_64 yt-dlp and ffmpeg binaries |

### Files Changed (16)

- `terraform/main.tf` - Added `lambda_architecture` local, updated ADOT layer
- `terraform/api_gateway_authorizer.tf` - ARM64 + 7-day retention
- `terraform/cleanup_expired_records.tf` - ARM64 + 7-day retention
- `terraform/device_event.tf` - ARM64 + 7-day retention
- `terraform/feedly_webhook.tf` - ARM64 (WebhookFeedly only) + 7-day retention
- `terraform/file_bucket.tf` - ARM64 + 7-day retention
- `terraform/list_files.tf` - ARM64 + 7-day retention
- `terraform/login_user.tf` - ARM64 + 7-day retention
- `terraform/migrate_dsql.tf` - ARM64 + 7-day retention
- `terraform/prune_devices.tf` - ARM64 + 7-day retention
- `terraform/refresh_token.tf` - ARM64 + 7-day retention
- `terraform/register_device.tf` - ARM64 + 7-day retention
- `terraform/register_user.tf` - ARM64 + 7-day retention
- `terraform/send_push_notification.tf` - ARM64 + 7-day retention
- `terraform/user_delete.tf` - ARM64 + 7-day retention
- `terraform/user_subscribe.tf` - ARM64 + 7-day retention

## Test Plan

- [ ] CI pipeline passes (type checking, linting, unit tests)
- [ ] `tofu validate` passes (verified locally)
- [ ] `tofu plan` shows expected changes (15 Lambda architecture updates, 16 log group retention updates)
- [ ] Post-deploy: Verify cold start metrics via CloudWatch
- [ ] Post-deploy: Verify all API endpoints functional

## Rollback Plan

If issues occur post-deployment:
1. Change `lambda_architecture` to `"x86_64"` in `main.tf`
2. Update ADOT layer back to `amd64` variant
3. Run `tofu apply`

## References

- [AWS Lambda Graviton2 Announcement](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/)
- [AWS Lambda ARM vs x86 Analysis](https://aws.amazon.com/blogs/apn/comparing-aws-lambda-arm-vs-x86-performance-cost-and-analysis-2/)
- [Performance Benchmarks (Dec 2025)](https://github.com/cebert/aws-lambda-performance-benchmarks)
- [Fastest Node 22 Lambda Coldstart (July 2025)](https://speedrun.nobackspacecrew.com/blog/2025/07/21/the-fastest-node-22-lambda-coldstart-configuration.html)