### PR TITLE
feat(infra): add multi-environment support with workspaces

### DIFF
--- a/bin/deploy-prod.sh
+++ b/bin/deploy-prod.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../terraform"
+tofu workspace select prod 2>/dev/null || tofu workspace new prod
+tofu apply -var-file=environments/prod.tfvars "$@"

--- a/bin/deploy-stag.sh
+++ b/bin/deploy-stag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../terraform"
+tofu workspace select stag 2>/dev/null || tofu workspace new stag
+tofu apply -var-file=environments/stag.tfvars "$@"

--- a/bin/plan-prod.sh
+++ b/bin/plan-prod.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../terraform"
+tofu workspace select prod 2>/dev/null || tofu workspace new prod
+tofu plan -var-file=environments/prod.tfvars "$@"

--- a/bin/plan-stag.sh
+++ b/bin/plan-stag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../terraform"
+tofu workspace select stag 2>/dev/null || tofu workspace new stag
+tofu plan -var-file=environments/stag.tfvars "$@"

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_api_gateway_rest_api" "Main" {
-  name           = "OfflineMediaDownloader"
+  name           = "${var.resource_prefix}-API"
   description    = "The API that supports the App"
   api_key_source = "HEADER"
 
@@ -43,7 +43,7 @@ resource "aws_api_gateway_deployment" "Main" {
 }
 
 resource "aws_api_gateway_stage" "Production" {
-  stage_name    = "prod"
+  stage_name    = var.environment
   rest_api_id   = aws_api_gateway_rest_api.Main.id
   deployment_id = aws_api_gateway_deployment.Main.id
 
@@ -63,7 +63,7 @@ resource "aws_api_gateway_method_settings" "Production" {
 }
 
 resource "aws_api_gateway_usage_plan" "iOSApp" {
-  name        = "iOSApp"
+  name        = "${var.resource_prefix}-iOSApp"
   description = "Internal consumption"
   api_stages {
     api_id = aws_api_gateway_rest_api.Main.id
@@ -72,7 +72,7 @@ resource "aws_api_gateway_usage_plan" "iOSApp" {
 }
 
 resource "aws_api_gateway_api_key" "iOSApp" {
-  name        = "iOSAppKey"
+  name        = "${var.resource_prefix}-iOSAppKey"
   description = "The key for the iOS App"
   enabled     = true
   tags        = local.common_tags
@@ -101,7 +101,7 @@ resource "aws_api_gateway_gateway_response" "Default500GatewayResponse" {
 }
 
 resource "aws_iam_role" "ApiGatewayCloudwatch" {
-  name               = "ApiGatewayCloudwatch"
+  name               = "${var.resource_prefix}-ApiGatewayCloudwatch"
   assume_role_policy = data.aws_iam_policy_document.ApiGatewayCloudwatch.json
   tags               = local.common_tags
 }
@@ -123,7 +123,7 @@ data "aws_iam_policy_document" "ApiGatewayCloudwatch" {
 }
 
 resource "aws_iam_role_policy" "ApiGatewayCloudwatch" {
-  name   = "ApiGatewayCloudwatch"
+  name   = "${var.resource_prefix}-ApiGatewayCloudwatch"
   role   = aws_iam_role.ApiGatewayCloudwatch.id
   policy = data.aws_iam_policy_document.CommonLambdaLogging.json
 }

--- a/terraform/api_gateway_authorizer.tf
+++ b/terraform/api_gateway_authorizer.tf
@@ -1,5 +1,5 @@
 locals {
-  api_gateway_authorizer_function_name = "ApiGatewayAuthorizer"
+  api_gateway_authorizer_function_name = "${var.resource_prefix}-ApiGatewayAuthorizer"
 }
 
 resource "aws_iam_role" "ApiGatewayAuthorizer" {
@@ -23,7 +23,7 @@ resource "aws_iam_role_policy" "ApiGatewayAuthorizerInvocation" {
 
 resource "aws_cloudwatch_log_group" "ApiGatewayAuthorizer" {
   name              = "/aws/lambda/${aws_lambda_function.ApiGatewayAuthorizer.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/aurora_dsql.tf
+++ b/terraform/aurora_dsql.tf
@@ -3,9 +3,9 @@
 # See: https://github.com/j0nathan-ll0yd/aws-cloudformation-media-downloader/issues/196
 
 resource "aws_dsql_cluster" "media_downloader" {
-  deletion_protection_enabled = true
+  deletion_protection_enabled = var.environment == "prod"
   tags = merge(local.common_tags, {
-    Name = "MediaDownloader-DSQL"
+    Name = "${var.resource_prefix}-DSQL"
   })
 }
 
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "dsql_access" {
 }
 
 resource "aws_iam_policy" "LambdaDSQLAccess" {
-  name        = "LambdaDSQLAccess"
+  name        = "${var.resource_prefix}-LambdaDSQLAccess"
   description = "Allows Lambda functions to connect to Aurora DSQL"
   policy      = data.aws_iam_policy_document.dsql_access.json
   tags        = local.common_tags

--- a/terraform/cleanup_expired_records.tf
+++ b/terraform/cleanup_expired_records.tf
@@ -3,7 +3,7 @@
 # Runs daily at 3 AM UTC to delete expired records from Aurora DSQL
 
 locals {
-  cleanup_expired_records_function_name = "CleanupExpiredRecords"
+  cleanup_expired_records_function_name = "${var.resource_prefix}-CleanupExpiredRecords"
 }
 
 resource "aws_iam_role" "CleanupExpiredRecords" {
@@ -29,7 +29,7 @@ resource "aws_iam_role_policy_attachment" "CleanupExpiredRecordsDSQL" {
 
 resource "aws_cloudwatch_log_group" "CleanupExpiredRecords" {
   name              = "/aws/lambda/${aws_lambda_function.CleanupExpiredRecords.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/cloudfront_middleware.tf
+++ b/terraform/cloudfront_middleware.tf
@@ -1,5 +1,9 @@
+locals {
+  cloudfront_middleware_function_name = "${var.resource_prefix}-CloudfrontMiddleware"
+}
+
 resource "aws_iam_role" "CloudfrontMiddleware" {
-  name               = "CloudfrontMiddleware"
+  name               = local.cloudfront_middleware_function_name
   assume_role_policy = data.aws_iam_policy_document.LamdbaEdgeAssumeRole.json
   tags               = local.common_tags
 }
@@ -27,7 +31,7 @@ data "archive_file" "CloudfrontMiddleware" {
 
 resource "aws_lambda_function" "CloudfrontMiddleware" {
   description      = "A lambda that acts as middleware before hitting the API."
-  function_name    = "CloudfrontMiddleware"
+  function_name    = local.cloudfront_middleware_function_name
   role             = aws_iam_role.CloudfrontMiddleware.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
@@ -41,7 +45,7 @@ resource "aws_lambda_function" "CloudfrontMiddleware" {
   }
 
   tags = merge(local.common_tags, {
-    Name = "CloudfrontMiddleware"
+    Name = local.cloudfront_middleware_function_name
   })
 }
 
@@ -92,7 +96,7 @@ resource "aws_cloudfront_distribution" "Production" {
   }
 
   tags = merge(local.common_tags, {
-    Name = "Production"
+    Name = "${var.resource_prefix}-CloudFront"
   })
 }
 

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -4,48 +4,48 @@
 
 locals {
   lambda_functions = [
-    "ApiGatewayAuthorizer",
-    "CloudfrontMiddleware",
-    "ListFiles",
-    "LogClientEvent",
-    "LoginUser",
-    "PruneDevices",
-    "RefreshToken",
-    "RegisterDevice",
-    "RegisterUser",
-    "S3ObjectCreated",
-    "SendPushNotification",
-    "StartFileUpload",
-    "UserDelete",
-    "UserSubscribe",
-    "WebhookFeedly"
+    "${var.resource_prefix}-ApiGatewayAuthorizer",
+    "${var.resource_prefix}-CloudfrontMiddleware",
+    "${var.resource_prefix}-ListFiles",
+    "${var.resource_prefix}-DeviceEvent",
+    "${var.resource_prefix}-LoginUser",
+    "${var.resource_prefix}-PruneDevices",
+    "${var.resource_prefix}-RefreshToken",
+    "${var.resource_prefix}-RegisterDevice",
+    "${var.resource_prefix}-RegisterUser",
+    "${var.resource_prefix}-S3ObjectCreated",
+    "${var.resource_prefix}-SendPushNotification",
+    "${var.resource_prefix}-StartFileUpload",
+    "${var.resource_prefix}-UserDelete",
+    "${var.resource_prefix}-UserSubscribe",
+    "${var.resource_prefix}-WebhookFeedly"
   ]
 
   # Split lambdas into groups for CloudWatch alarms (max 10 metrics per alarm)
   lambda_functions_api = [
-    "ApiGatewayAuthorizer",
-    "ListFiles",
-    "LogClientEvent",
-    "LoginUser",
-    "RefreshToken",
-    "RegisterDevice",
-    "RegisterUser",
-    "UserDelete",
-    "UserSubscribe",
-    "WebhookFeedly"
+    "${var.resource_prefix}-ApiGatewayAuthorizer",
+    "${var.resource_prefix}-ListFiles",
+    "${var.resource_prefix}-DeviceEvent",
+    "${var.resource_prefix}-LoginUser",
+    "${var.resource_prefix}-RefreshToken",
+    "${var.resource_prefix}-RegisterDevice",
+    "${var.resource_prefix}-RegisterUser",
+    "${var.resource_prefix}-UserDelete",
+    "${var.resource_prefix}-UserSubscribe",
+    "${var.resource_prefix}-WebhookFeedly"
   ]
 
   lambda_functions_background = [
-    "CloudfrontMiddleware",
-    "PruneDevices",
-    "S3ObjectCreated",
-    "SendPushNotification",
-    "StartFileUpload"
+    "${var.resource_prefix}-CloudfrontMiddleware",
+    "${var.resource_prefix}-PruneDevices",
+    "${var.resource_prefix}-S3ObjectCreated",
+    "${var.resource_prefix}-SendPushNotification",
+    "${var.resource_prefix}-StartFileUpload"
   ]
 }
 
 resource "aws_cloudwatch_dashboard" "Main" {
-  dashboard_name = "MediaDownloader"
+  dashboard_name = "${var.resource_prefix}-Dashboard"
 
   dashboard_body = jsonencode({
     widgets = [
@@ -290,7 +290,7 @@ output "cloudwatch_dashboard_url" {
 
 # Lambda Errors Alarm (API) - triggers when total errors across API Lambdas exceed threshold
 resource "aws_cloudwatch_metric_alarm" "LambdaErrorsApi" {
-  alarm_name          = "MediaDownloader-Lambda-Errors-API"
+  alarm_name          = "${var.resource_prefix}-Lambda-Errors-API"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = 5
@@ -325,7 +325,7 @@ resource "aws_cloudwatch_metric_alarm" "LambdaErrorsApi" {
 
 # Lambda Errors Alarm (Background) - triggers when total errors across background Lambdas exceed threshold
 resource "aws_cloudwatch_metric_alarm" "LambdaErrorsBackground" {
-  alarm_name          = "MediaDownloader-Lambda-Errors-Background"
+  alarm_name          = "${var.resource_prefix}-Lambda-Errors-Background"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = 3
@@ -360,7 +360,7 @@ resource "aws_cloudwatch_metric_alarm" "LambdaErrorsBackground" {
 
 # Lambda Throttles Alarm (API) - any throttle is concerning
 resource "aws_cloudwatch_metric_alarm" "LambdaThrottlesApi" {
-  alarm_name          = "MediaDownloader-Lambda-Throttles-API"
+  alarm_name          = "${var.resource_prefix}-Lambda-Throttles-API"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = 0
@@ -395,7 +395,7 @@ resource "aws_cloudwatch_metric_alarm" "LambdaThrottlesApi" {
 
 # Lambda Throttles Alarm (Background) - any throttle is concerning
 resource "aws_cloudwatch_metric_alarm" "LambdaThrottlesBackground" {
-  alarm_name          = "MediaDownloader-Lambda-Throttles-Background"
+  alarm_name          = "${var.resource_prefix}-Lambda-Throttles-Background"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   threshold           = 0
@@ -430,7 +430,7 @@ resource "aws_cloudwatch_metric_alarm" "LambdaThrottlesBackground" {
 
 # SQS DLQ Alarm - any message in DLQ requires investigation
 resource "aws_cloudwatch_metric_alarm" "SqsDlqMessages" {
-  alarm_name          = "MediaDownloader-SQS-DLQ-Messages"
+  alarm_name          = "${var.resource_prefix}-SQS-DLQ-Messages"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -450,7 +450,7 @@ resource "aws_cloudwatch_metric_alarm" "SqsDlqMessages" {
 
 # SQS Queue Age Alarm - messages shouldn't be stuck in queue
 resource "aws_cloudwatch_metric_alarm" "SqsQueueAge" {
-  alarm_name          = "MediaDownloader-SQS-Queue-Age"
+  alarm_name          = "${var.resource_prefix}-SQS-Queue-Age"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 2
   metric_name         = "ApproximateAgeOfOldestMessage"

--- a/terraform/device_event.tf
+++ b/terraform/device_event.tf
@@ -1,5 +1,5 @@
 locals {
-  device_event_function_name = "DeviceEvent"
+  device_event_function_name = "${var.resource_prefix}-DeviceEvent"
 }
 
 resource "aws_iam_role" "DeviceEvent" {
@@ -26,7 +26,7 @@ resource "aws_lambda_permission" "DeviceEvent" {
 
 resource "aws_cloudwatch_log_group" "DeviceEvent" {
   name              = "/aws/lambda/${aws_lambda_function.DeviceEvent.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/download_queue.tf
+++ b/terraform/download_queue.tf
@@ -12,7 +12,7 @@
 # @see src/lambdas/StartFileUpload for consumer
 
 locals {
-  download_queue_name = "DownloadQueue"
+  download_queue_name = "${var.resource_prefix}-DownloadQueue"
   # StartFileUpload timeout is 900s (15 min)
   # Visibility timeout should be 6x Lambda timeout = 5400s (90 min)
   download_queue_visibility_timeout = 5400
@@ -61,7 +61,7 @@ resource "aws_lambda_event_source_mapping" "StartFileUploadSQS" {
 # CloudWatch Alarm: Alert when messages are in DLQ
 # DLQ messages indicate permanent failures requiring investigation
 resource "aws_cloudwatch_metric_alarm" "DownloadDLQMessages" {
-  alarm_name          = "MediaDownloader-Download-DLQ-Messages"
+  alarm_name          = "${var.resource_prefix}-Download-DLQ-Messages"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"

--- a/terraform/dynamodb_idempotency.tf
+++ b/terraform/dynamodb_idempotency.tf
@@ -3,7 +3,7 @@
 # TTL automatically cleans up expired records
 
 resource "aws_dynamodb_table" "IdempotencyTable" {
-  name         = "MediaDownloader-Idempotency"
+  name         = "${var.resource_prefix}-Idempotency"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "id"
 
@@ -18,7 +18,7 @@ resource "aws_dynamodb_table" "IdempotencyTable" {
   }
 
   tags = merge(local.common_tags, {
-    Name    = "MediaDownloader-Idempotency"
+    Name    = "${var.resource_prefix}-Idempotency"
     Purpose = "Powertools idempotency storage"
   })
 }

--- a/terraform/environments/prod.tfvars
+++ b/terraform/environments/prod.tfvars
@@ -1,0 +1,8 @@
+# Production Environment Configuration
+# Deploy with: tofu apply -var-file=environments/prod.tfvars
+
+environment        = "prod"
+resource_prefix    = "prod"
+s3_bucket_name     = "prod-media-files"
+log_level          = "INFO"
+log_retention_days = 7

--- a/terraform/environments/stag.tfvars
+++ b/terraform/environments/stag.tfvars
@@ -1,0 +1,8 @@
+# Staging Environment Configuration
+# Deploy with: tofu apply -var-file=environments/stag.tfvars
+
+environment        = "stag"
+resource_prefix    = "stag"
+s3_bucket_name     = "stag-media-files"
+log_level          = "DEBUG"
+log_retention_days = 3

--- a/terraform/eventbridge.tf
+++ b/terraform/eventbridge.tf
@@ -12,7 +12,7 @@
 # @see terraform/download_queue.tf for SQS configuration
 
 locals {
-  event_bus_name = "MediaDownloader"
+  event_bus_name = "${var.resource_prefix}-EventBus"
 }
 
 # Event Bus: Central routing for all domain events
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_event_bus" "MediaDownloader" {
 
 # Rule: Route DownloadRequested events to DownloadQueue
 resource "aws_cloudwatch_event_rule" "DownloadRequested" {
-  name           = "DownloadRequested"
+  name           = "${var.resource_prefix}-DownloadRequested"
   event_bus_name = aws_cloudwatch_event_bus.MediaDownloader.name
   description    = "Route DownloadRequested events to download processing queue"
 

--- a/terraform/feedly_webhook.tf
+++ b/terraform/feedly_webhook.tf
@@ -1,6 +1,6 @@
 locals {
-  webhook_feedly_function_name    = "WebhookFeedly"
-  start_file_upload_function_name = "StartFileUpload"
+  webhook_feedly_function_name    = "${var.resource_prefix}-WebhookFeedly"
+  start_file_upload_function_name = "${var.resource_prefix}-StartFileUpload"
 }
 
 resource "aws_iam_role" "WebhookFeedly" {
@@ -65,7 +65,7 @@ resource "aws_lambda_permission" "WebhookFeedly" {
 
 resource "aws_cloudwatch_log_group" "WebhookFeedly" {
   name              = "/aws/lambda/${aws_lambda_function.WebhookFeedly.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 
@@ -384,6 +384,6 @@ resource "aws_lambda_function" "StartFileUpload" {
 
 resource "aws_cloudwatch_log_group" "StartFileUpload" {
   name              = "/aws/lambda/${aws_lambda_function.StartFileUpload.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }

--- a/terraform/file_bucket.tf
+++ b/terraform/file_bucket.tf
@@ -1,9 +1,9 @@
 locals {
-  s3_object_created_function_name = "S3ObjectCreated"
+  s3_object_created_function_name = "${var.resource_prefix}-S3ObjectCreated"
 }
 
 resource "aws_s3_bucket" "Files" {
-  bucket = "lifegames-media-downloader-files"
+  bucket = var.s3_bucket_name
   tags   = local.common_tags
 }
 
@@ -24,7 +24,7 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "FilesTiering" {
 
 # Origin Access Control for CloudFront (replaces public-read ACL)
 resource "aws_cloudfront_origin_access_control" "MediaFilesOAC" {
-  name                              = "media-files-oac"
+  name                              = "${var.resource_prefix}-media-files-oac"
   description                       = "OAC for media files S3 bucket"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "MediaFiles" {
   }
 
   tags = merge(local.common_tags, {
-    Name = "MediaFilesDistribution"
+    Name = "${var.resource_prefix}-MediaFilesDistribution"
   })
 }
 
@@ -119,7 +119,7 @@ resource "aws_lambda_permission" "S3ObjectCreated" {
 
 resource "aws_cloudwatch_log_group" "S3ObjectCreated" {
   name              = "/aws/lambda/${aws_lambda_function.S3ObjectCreated.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/list_files.tf
+++ b/terraform/list_files.tf
@@ -1,5 +1,5 @@
 locals {
-  list_files_function_name = "ListFiles"
+  list_files_function_name = "${var.resource_prefix}-ListFiles"
 }
 
 resource "aws_iam_role" "ListFiles" {
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "ListFiles" {
 
 resource "aws_cloudwatch_log_group" "ListFiles" {
   name              = "/aws/lambda/${aws_lambda_function.ListFiles.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/login_user.tf
+++ b/terraform/login_user.tf
@@ -1,5 +1,5 @@
 locals {
-  login_user_function_name = "LoginUser"
+  login_user_function_name = "${var.resource_prefix}-LoginUser"
 }
 
 resource "aws_iam_role" "LoginUser" {
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "LoginUser" {
 
 resource "aws_cloudwatch_log_group" "LoginUser" {
   name              = "/aws/lambda/${aws_lambda_function.LoginUser.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,7 +36,7 @@ locals {
   common_tags = {
     ManagedBy   = "terraform"
     Project     = "media-downloader"
-    Environment = "production"
+    Environment = var.environment
   }
 
   # Common environment variables for all lambdas with ADOT layer
@@ -51,7 +51,7 @@ locals {
     OPENTELEMETRY_EXTENSION_LOG_LEVEL  = "warn"
     OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/var/task/collector.yaml"
     NODE_OPTIONS                       = "--no-deprecation"
-    LOG_LEVEL                          = "DEBUG"
+    LOG_LEVEL                          = var.log_level
     # Aurora DSQL connection configuration
     # Aurora DSQL endpoints follow the pattern: <identifier>.dsql.<region>.on.aws
     DSQL_CLUSTER_ENDPOINT = "${aws_dsql_cluster.media_downloader.identifier}.dsql.${data.aws_region.current.id}.on.aws"
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "CommonLambdaLogging" {
 }
 
 resource "aws_iam_policy" "CommonLambdaLogging" {
-  name        = "CommonLambdaLogging"
+  name        = "${var.resource_prefix}-CommonLambdaLogging"
   description = "Allows Lambda functions to write to ALL CloudWatch logs"
   policy      = data.aws_iam_policy_document.CommonLambdaLogging.json
   tags        = local.common_tags
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "CommonLambdaXRay" {
 }
 
 resource "aws_iam_policy" "CommonLambdaXRay" {
-  name        = "CommonLambdaXRay"
+  name        = "${var.resource_prefix}-CommonLambdaXRay"
   description = "Allows Lambda functions to write X-Ray traces"
   policy      = data.aws_iam_policy_document.CommonLambdaXRay.json
   tags        = local.common_tags

--- a/terraform/migrate_dsql.tf
+++ b/terraform/migrate_dsql.tf
@@ -5,7 +5,7 @@
 # See: docs/wiki/Conventions/Database-Migrations.md
 
 locals {
-  migrate_dsql_function_name = "MigrateDSQL"
+  migrate_dsql_function_name = "${var.resource_prefix}-MigrateDSQL"
 }
 
 resource "aws_iam_role" "MigrateDSQL" {
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy_attachment" "MigrateDSQLDSQL" {
 
 resource "aws_cloudwatch_log_group" "MigrateDSQL" {
   name              = "/aws/lambda/${aws_lambda_function.MigrateDSQL.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/prune_devices.tf
+++ b/terraform/prune_devices.tf
@@ -1,5 +1,5 @@
 locals {
-  prune_devices_function_name = "PruneDevices"
+  prune_devices_function_name = "${var.resource_prefix}-PruneDevices"
 }
 
 resource "aws_iam_role" "PruneDevices" {
@@ -51,7 +51,7 @@ resource "aws_cloudwatch_event_target" "PruneDevices" {
 
 
 resource "aws_cloudwatch_event_rule" "PruneDevices" {
-  name                = "PruneDevices"
+  name                = local.prune_devices_function_name
   schedule_expression = "rate(1 day)"
   state               = "ENABLED"
   tags                = local.common_tags
@@ -66,7 +66,7 @@ resource "aws_lambda_permission" "PruneDevices" {
 
 resource "aws_cloudwatch_log_group" "PruneDevices" {
   name              = "/aws/lambda/${aws_lambda_function.PruneDevices.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/refresh_token.tf
+++ b/terraform/refresh_token.tf
@@ -1,5 +1,5 @@
 locals {
-  refresh_token_function_name = "RefreshToken"
+  refresh_token_function_name = "${var.resource_prefix}-RefreshToken"
 }
 
 resource "aws_iam_role" "RefreshToken" {
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "RefreshToken" {
 
 resource "aws_cloudwatch_log_group" "RefreshToken" {
   name              = "/aws/lambda/${aws_lambda_function.RefreshToken.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/register_device.tf
+++ b/terraform/register_device.tf
@@ -1,5 +1,5 @@
 locals {
-  register_device_function_name = "RegisterDevice"
+  register_device_function_name = "${var.resource_prefix}-RegisterDevice"
 }
 
 resource "aws_iam_role" "RegisterDevice" {
@@ -57,7 +57,7 @@ resource "aws_lambda_permission" "RegisterDevice" {
 
 resource "aws_cloudwatch_log_group" "RegisterDevice" {
   name              = "/aws/lambda/${aws_lambda_function.RegisterDevice.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 
@@ -122,12 +122,12 @@ resource "aws_api_gateway_integration" "RegisterDevicePost" {
 }
 
 resource "aws_sns_topic" "PushNotifications" {
-  name = "PushNotifications"
+  name = "${var.resource_prefix}-PushNotifications"
 }
 
 resource "aws_sns_platform_application" "OfflineMediaDownloader" {
   count                     = 1 # APNS certificate valid until 2027-01-03
-  name                      = "OfflineMediaDownloader"
+  name                      = "${var.resource_prefix}-OfflineMediaDownloader"
   platform                  = "APNS_SANDBOX"
   platform_credential       = data.sops_file.secrets.data["apns.staging.privateKey"]  # APNS PRIVATE KEY
   platform_principal        = data.sops_file.secrets.data["apns.staging.certificate"] # APNS CERTIFICATE
@@ -136,7 +136,7 @@ resource "aws_sns_platform_application" "OfflineMediaDownloader" {
 }
 
 resource "aws_iam_role" "SNSLoggingRole" {
-  name               = "SNSLoggingRole"
+  name               = "${var.resource_prefix}-SNSLoggingRole"
   assume_role_policy = data.aws_iam_policy_document.SNSAssumeRole.json
   tags               = local.common_tags
 }

--- a/terraform/register_user.tf
+++ b/terraform/register_user.tf
@@ -1,5 +1,5 @@
 locals {
-  register_user_function_name = "RegisterUser"
+  register_user_function_name = "${var.resource_prefix}-RegisterUser"
 }
 
 resource "aws_iam_role" "RegisterUser" {
@@ -31,7 +31,7 @@ resource "aws_lambda_permission" "RegisterUser" {
 
 resource "aws_cloudwatch_log_group" "RegisterUser" {
   name              = "/aws/lambda/${aws_lambda_function.RegisterUser.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/send_push_notification.tf
+++ b/terraform/send_push_notification.tf
@@ -1,5 +1,5 @@
 locals {
-  send_push_notification_function_name = "SendPushNotification"
+  send_push_notification_function_name = "${var.resource_prefix}-SendPushNotification"
 }
 
 resource "aws_iam_role" "SendPushNotification" {
@@ -63,7 +63,7 @@ resource "aws_lambda_permission" "SendPushNotification" {
 
 resource "aws_cloudwatch_log_group" "SendPushNotification" {
   name              = "/aws/lambda/${aws_lambda_function.SendPushNotification.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 
@@ -101,7 +101,7 @@ resource "aws_lambda_function" "SendPushNotification" {
 
 # Dead Letter Queue for failed push notifications
 resource "aws_sqs_queue" "SendPushNotificationDLQ" {
-  name                      = "SendPushNotification-DLQ"
+  name                      = "${var.resource_prefix}-SendPushNotification-DLQ"
   message_retention_seconds = 1209600 # 14 days for investigation
   tags = merge(local.common_tags, {
     Purpose = "Dead letter queue for failed push notifications"
@@ -109,7 +109,7 @@ resource "aws_sqs_queue" "SendPushNotificationDLQ" {
 }
 
 resource "aws_sqs_queue" "SendPushNotification" {
-  name                       = "SendPushNotification"
+  name                       = "${var.resource_prefix}-SendPushNotification"
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 345600

--- a/terraform/user_delete.tf
+++ b/terraform/user_delete.tf
@@ -1,5 +1,5 @@
 locals {
-  user_delete_function_name = "UserDelete"
+  user_delete_function_name = "${var.resource_prefix}-UserDelete"
 }
 
 resource "aws_iam_role" "UserDelete" {
@@ -52,7 +52,7 @@ resource "aws_lambda_permission" "UserDelete" {
 
 resource "aws_cloudwatch_log_group" "UserDelete" {
   name              = "/aws/lambda/${aws_lambda_function.UserDelete.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/user_subscribe.tf
+++ b/terraform/user_subscribe.tf
@@ -1,5 +1,5 @@
 locals {
-  user_subscribe_function_name = "UserSubscribe"
+  user_subscribe_function_name = "${var.resource_prefix}-UserSubscribe"
 }
 
 resource "aws_iam_role" "UserSubscribe" {
@@ -47,7 +47,7 @@ resource "aws_lambda_permission" "UserSubscribe" {
 
 resource "aws_cloudwatch_log_group" "UserSubscribe" {
   name              = "/aws/lambda/${aws_lambda_function.UserSubscribe.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
   tags              = local.common_tags
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,33 @@
+# Environment Configuration Variables
+# Used with OpenTofu workspaces for multi-environment support
+
+variable "environment" {
+  type        = string
+  description = "Environment name (stag, prod)"
+  validation {
+    condition     = contains(["stag", "prod"], var.environment)
+    error_message = "Environment must be 'stag' or 'prod'."
+  }
+}
+
+variable "resource_prefix" {
+  type        = string
+  description = "Prefix for all resource names (e.g., 'stag', 'prod')"
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "S3 bucket name for media files"
+}
+
+variable "log_level" {
+  type        = string
+  description = "Log level for Lambda functions"
+  default     = "INFO"
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "CloudWatch log retention in days"
+  default     = 7
+}


### PR DESCRIPTION
## Summary
- Add OpenTofu workspace support for staging and production environments
- Create `stag-*` and `prod-*` resource prefixes for environment isolation
- Add deployment scripts for each environment
- Enable separate Aurora DSQL clusters per environment

## Changes
- **New**: `terraform/variables.tf` - Environment variable definitions
- **New**: `terraform/environments/stag.tfvars` - Staging configuration (DEBUG logs, 3-day retention)
- **New**: `terraform/environments/prod.tfvars` - Production configuration (INFO logs, 7-day retention)
- **New**: `bin/deploy-stag.sh`, `bin/deploy-prod.sh` - Deployment scripts
- **New**: `bin/plan-stag.sh`, `bin/plan-prod.sh` - Plan scripts
- **Modified**: All 23 `.tf` files updated to use `${var.resource_prefix}-*` naming

## Resource Naming Convention
| Resource Type | Staging | Production |
|--------------|---------|------------|
| Lambda | `stag-ListFiles` | `prod-ListFiles` |
| S3 Bucket | `stag-media-files` | `prod-media-files` |
| EventBridge | `stag-EventBus` | `prod-EventBus` |
| DynamoDB | `stag-Idempotency` | `prod-Idempotency` |

## Test plan
- [x] `tofu validate` passes
- [x] All unit tests pass (793 tests)
- [x] All integration tests pass
- [x] GitHub CI tests pass
- [ ] Manual: `./bin/plan-stag.sh` shows staging resources
- [ ] Manual: `./bin/plan-prod.sh` shows production resources
- [ ] Manual: Deploy staging and verify resources

## Migration Notes
**Staging**: Can be deployed directly - creates new resources with `stag-*` prefix

**Production**: Requires migration strategy:
1. Option A (recommended): Destroy and recreate with `prod-*` prefix
2. Option B: Use Terraform state manipulation to rename resources

Both options require a maintenance window and S3 data backup.