### PR TITLE
feat(entities): optimize Drizzle ORM queries for performance and data integrity

### DIFF
--- a/src/lib/vendor/Drizzle/index.ts
+++ b/src/lib/vendor/Drizzle/index.ts
@@ -7,8 +7,8 @@
  * @see {@link file://../../../docs/wiki/Conventions/Vendor-Encapsulation-Policy.md | Vendor Encapsulation Policy} for usage examples
  */
 
-export { closeDrizzleClient, getDrizzleClient } from './client'
-export type { PostgresJsDatabase } from './client'
+export { closeDrizzleClient, getDrizzleClient, withTransaction } from './client'
+export type { PostgresJsDatabase, TransactionClient } from './client'
 
 export * from './schema'
 export * from './types'


### PR DESCRIPTION
## Summary

Comprehensive optimization of Drizzle ORM queries to improve performance, data integrity, and concurrency safety.

### Changes

- **Add transaction support** - New `withTransaction` helper for atomic multi-table operations
- **Wrap user operations in transactions** - `createUser` and `deleteUser` now atomic (rollback on failure)
- **Convert upserts to atomic operations** - 5 upsert functions now use PostgreSQL `ON CONFLICT` for race-free concurrency
- **Add selective column fetching** - New ID-only queries reduce data transfer
- **Fix batch delete loop** - Single query with OR conditions instead of N separate queries

### Key Improvements

| Area | Before | After |
|------|--------|-------|
| `createUser` failure | Orphaned user record | Atomic rollback |
| `deleteUser` failure | Orphaned identity provider | Atomic rollback |
| Concurrent upserts | Race condition possible | Guaranteed consistency |
| `deleteUserFilesBatch(N)` | N queries | 1 query |

### Files Changed

- `src/lib/vendor/Drizzle/client.ts` - Add `withTransaction` helper
- `src/lib/vendor/Drizzle/index.ts` - Export transaction types
- `src/entities/queries/user-queries.ts` - Transaction-wrapped operations
- `src/entities/queries/device-queries.ts` - Atomic upsert
- `src/entities/queries/file-queries.ts` - Atomic upserts, selective column query
- `src/entities/queries/relationship-queries.ts` - Atomic upserts, batch delete fix, ID-only queries

### Test Plan

- [x] All 793 unit tests pass
- [x] All integration tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Convention validation passes
- [x] Dependency rules pass