### PR TITLE
fix: resolve 30 ESLint warnings

### DIFF
--- a/src/lib/domain/notification/endpoint-cleanup.ts
+++ b/src/lib/domain/notification/endpoint-cleanup.ts
@@ -38,7 +38,6 @@ export type { EndpointCleanupResult }
  */
 export async function cleanupDisabledEndpoint(deviceId: string, endpointArn: string): Promise<EndpointCleanupResult> {
   logInfo('Cleaning up disabled endpoint', {deviceId, endpointArn})
-
   try {
     // Step 1: Delete UserDevices junction records first (children)
     await deleteUserDevicesByDeviceId(deviceId)

--- a/src/lib/lambda/middleware/correlation.ts
+++ b/src/lib/lambda/middleware/correlation.ts
@@ -58,7 +58,6 @@ export function extractCorrelationFromS3(event: S3Event): string {
   if (record?.responseElements?.['x-amz-request-id']) {
     return record.responseElements['x-amz-request-id']
   }
-  // Fallback to event source ARN or timestamp-based ID
   return record?.s3?.object?.key || `s3-${Date.now()}`
 }
 
@@ -73,7 +72,6 @@ export function extractCorrelationFromS3Record(record: S3EventRecord): string {
   if (record?.responseElements?.['x-amz-request-id']) {
     return record.responseElements['x-amz-request-id']
   }
-  // Fallback to object key or timestamp-based ID
   return record?.s3?.object?.key || `s3-${Date.now()}`
 }
 

--- a/src/lib/system/circuit-breaker.ts
+++ b/src/lib/system/circuit-breaker.ts
@@ -91,8 +91,6 @@ export class CircuitBreaker {
    */
   async execute<T>(operation: () => Promise<T>): Promise<T> {
     const state = getState(this.config.name)
-
-    // Check if circuit should transition from OPEN to HALF_OPEN
     if (state.state === 'OPEN') {
       const timeSinceFailure = Date.now() - state.lastFailureTime
       if (timeSinceFailure >= this.config.resetTimeout) {
@@ -102,7 +100,6 @@ export class CircuitBreaker {
         throw new CircuitBreakerOpenError(this.config.name, this.config.resetTimeout - timeSinceFailure)
       }
     }
-
     try {
       const result = await operation()
       this.onSuccess(state)

--- a/test/helpers/entity-fixtures.ts
+++ b/test/helpers/entity-fixtures.ts
@@ -123,8 +123,8 @@ export const DEFAULT_SESSION_ID = 'session-1234-5678-9abc-def012345678'
  *
  * @example
  * const file = createMockFile()
- * const failedFile = createMockFile({status: 'Failed', size: 0})
- * const customFile = createMockFile({fileId: 'custom123', title: 'My Video'})
+ * const failedFile = createMockFile(\{status: 'Failed', size: 0\})
+ * const customFile = createMockFile(\{fileId: 'custom123', title: 'My Video'\})
  */
 export function createMockFile(overrides: Partial<FileRow> = {}): FileRow {
   const fileId = overrides.fileId ?? DEFAULT_FILE_ID
@@ -151,7 +151,7 @@ export function createMockFile(overrides: Partial<FileRow> = {}): FileRow {
  *
  * @example
  * const device = createMockDevice()
- * const customDevice = createMockDevice({name: "User's iPad", systemName: 'iPadOS'})
+ * const customDevice = createMockDevice(\{name: "User's iPad", systemName: 'iPadOS'\})
  */
 export function createMockDevice(overrides: Partial<DeviceRow> = {}): DeviceRow {
   const deviceId = overrides.deviceId ?? DEFAULT_DEVICE_ID
@@ -173,8 +173,8 @@ export function createMockDevice(overrides: Partial<DeviceRow> = {}): DeviceRow 
  *
  * @example
  * const user = createMockUser()
- * const unverifiedUser = createMockUser({emailVerified: false})
- * const customUser = createMockUser({id: 'custom-uuid', email: 'custom@example.com'})
+ * const unverifiedUser = createMockUser(\{emailVerified: false\})
+ * const customUser = createMockUser(\{id: 'custom-uuid', email: 'custom\@example.com'\})
  */
 export function createMockUser(overrides: Partial<UserRow> = {}): UserRow {
   const now = new Date()
@@ -200,7 +200,7 @@ export function createMockUser(overrides: Partial<UserRow> = {}): UserRow {
  *
  * @example
  * const userFile = createMockUserFile()
- * const customLink = createMockUserFile({userId: 'user-123', fileId: 'file-456'})
+ * const customLink = createMockUserFile(\{userId: 'user-123', fileId: 'file-456'\})
  */
 export function createMockUserFile(overrides: Partial<UserFileRow> = {}): UserFileRow {
   return {userId: DEFAULT_USER_ID, fileId: DEFAULT_FILE_ID, createdAt: new Date(), ...overrides}
@@ -213,7 +213,7 @@ export function createMockUserFile(overrides: Partial<UserFileRow> = {}): UserFi
  *
  * @example
  * const userDevice = createMockUserDevice()
- * const customLink = createMockUserDevice({userId: 'user-123', deviceId: 'device-456'})
+ * const customLink = createMockUserDevice(\{userId: 'user-123', deviceId: 'device-456'\})
  */
 export function createMockUserDevice(overrides: Partial<UserDeviceRow> = {}): UserDeviceRow {
   return {userId: DEFAULT_USER_ID, deviceId: DEFAULT_DEVICE_ID, createdAt: new Date(), ...overrides}
@@ -226,7 +226,7 @@ export function createMockUserDevice(overrides: Partial<UserDeviceRow> = {}): Us
  *
  * @example
  * const session = createMockSession()
- * const expiredSession = createMockSession({expiresAt: new Date(Date.now() - 3600000)})
+ * const expiredSession = createMockSession(\{expiresAt: new Date(Date.now() - 3600000)\})
  */
 export function createMockSession(overrides: Partial<SessionRow> = {}): SessionRow {
   const now = new Date()
@@ -251,7 +251,7 @@ export function createMockSession(overrides: Partial<SessionRow> = {}): SessionR
  *
  * @example
  * const idp = createMockIdentityProvider()
- * const expiredIdp = createMockIdentityProvider({expiresAt: Math.floor(Date.now() / 1000) - 3600})
+ * const expiredIdp = createMockIdentityProvider(\{expiresAt: Math.floor(Date.now() / 1000) - 3600\})
  */
 export function createMockIdentityProvider(overrides: Partial<IdentityProviderRow> = {}): IdentityProviderRow {
   return {
@@ -276,8 +276,8 @@ export function createMockIdentityProvider(overrides: Partial<IdentityProviderRo
  *
  * @example
  * const download = createMockFileDownload()
- * const failedDownload = createMockFileDownload({status: 'Failed', lastError: 'Network timeout'})
- * const retrying = createMockFileDownload({retryCount: 2, retryAfter: new Date()})
+ * const failedDownload = createMockFileDownload(\{status: 'Failed', lastError: 'Network timeout'\})
+ * const retrying = createMockFileDownload(\{retryCount: 2, retryAfter: new Date()\})
  */
 export function createMockFileDownload(overrides: Partial<FileDownloadRow> = {}): FileDownloadRow {
   const now = new Date()
@@ -305,7 +305,7 @@ export function createMockFileDownload(overrides: Partial<FileDownloadRow> = {})
  *
  * @example
  * const files = createMockFiles(3)  // Creates 3 files with IDs file-1, file-2, file-3
- * const customFiles = createMockFiles(2, {status: 'Queued'})  // All files queued
+ * const customFiles = createMockFiles(2, \{status: 'Queued'\})  // All files queued
  */
 export function createMockFiles(count: number, overrides: Partial<FileRow> = {}): FileRow[] {
   return Array.from({length: count}, (_, i) => createMockFile({fileId: `file-${i + 1}`, title: `Test Video ${i + 1}`, ...overrides}))


### PR DESCRIPTION
## Summary
- Remove unnecessary blank lines in simple functions (spacing-conventions rule)
- Escape curly braces in TSDoc @example blocks (tsdoc/syntax rule)

## Changes
| File | Fix |
|------|-----|
| `src/lib/domain/notification/endpoint-cleanup.ts` | Removed blank line between logInfo and try block |
| `src/lib/lambda/middleware/correlation.ts` | Removed fallback comments creating gaps in simple functions |
| `src/lib/system/circuit-breaker.ts` | Removed comment and blank line in execute() method |
| `test/helpers/entity-fixtures.ts` | Escaped curly braces `{}` and `@` in TSDoc examples |

## Test plan
- [x] All 887 unit tests pass
- [x] All integration tests pass
- [x] `pnpm run lint` returns no warnings
- [x] Pre-commit hooks pass