### PR TITLE
feat(test): standardize mock patterns and expand test coverage

### DIFF
--- a/docs/wiki/Testing/Vitest-Mocking-Strategy.md
+++ b/docs/wiki/Testing/Vitest-Mocking-Strategy.md
@@ -225,6 +225,36 @@ anonEvent.requestContext.authorizer!.principalId = 'unknown'
 | Property X doesn't exist | Incomplete mock | Add missing properties |
 | Works locally, fails CI | Environment differences | Mock all transitive deps |
 
+## Mock Reset Pattern (Required)
+
+All test files MUST follow this pattern for consistent mock state:
+
+```typescript
+// Module-level mock creation
+const sqsMock = mockClient(SQSClient)
+
+beforeEach(() => {
+  vi.clearAllMocks()  // Reset all vi.fn() mocks
+  sqsMock.reset()     // Reset aws-sdk-client-mock instances
+  // Configure default mock responses...
+})
+
+afterEach(() => {
+  sqsMock.reset()     // Ensure clean state for next test
+})
+```
+
+**Rationale**:
+- `beforeEach` reset ensures tests start from clean state
+- `vi.clearAllMocks()` resets all Vitest mocks, not just AWS
+- `afterEach` reset prevents leakage between test files
+- Always reset BEFORE configuring mock responses
+
+**Common mistakes**:
+- Forgetting `vi.clearAllMocks()` in beforeEach (vi.fn() mocks retain state)
+- Putting `vi.clearAllMocks()` in afterEach instead of beforeEach
+- Not resetting AWS mocks between tests
+
 ## Best Practices
 
 1. **Mock first, import second** - Always mock before importing
@@ -233,6 +263,7 @@ anonEvent.requestContext.authorizer!.principalId = 'unknown'
 4. **Use mock helpers** - Entity mock helper for entities, AWS SDK mock helpers for AWS services
 5. **Map dependencies** - Trace all transitive imports
 6. **Prefer aws-sdk-client-mock** - For AWS SDK v3 clients, use `aws-sdk-client-mock` for type-safe assertions
+7. **Reset mocks in beforeEach** - Always use `vi.clearAllMocks()` and `awsMock.reset()` in beforeEach
 
 ## AWS SDK Mock Utilities
 

--- a/src/lambdas/ApiGatewayAuthorizer/test/index.test.ts
+++ b/src/lambdas/ApiGatewayAuthorizer/test/index.test.ts
@@ -33,6 +33,11 @@ const {handler} = await import('./../src')
 
 describe('#APIGatewayAuthorizer', () => {
   const successResponseKeys = ['context', 'policyDocument', 'principalId', 'usageIdentifierKey']
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   describe('#HeaderApiKey', () => {
     let event: APIGatewayRequestAuthorizerEvent
     beforeEach(() => {
@@ -59,7 +64,6 @@ describe('#APIGatewayAuthorizer', () => {
     beforeEach(() => {
       event = createApiGatewayAuthorizerEvent({queryStringParameters: {ApiKey: fakeUsageIdentifierKey}, headers: {Authorization: 'Bearer test-token'}})
       process.env.MULTI_AUTHENTICATION_PATH_PARTS = 'files'
-      validateSessionTokenMock.mockReset()
     })
     test('should handle a valid Authorization header', async () => {
       getApiKeysMock.mockReturnValue(getApiKeysDefaultResponse)

--- a/src/lambdas/ListFiles/test/index.test.ts
+++ b/src/lambdas/ListFiles/test/index.test.ts
@@ -28,6 +28,7 @@ describe('#ListFiles', () => {
   const context = testContext
   let event: CustomAPIGatewayRequestAuthorizerEvent
   beforeEach(() => {
+    vi.clearAllMocks()
     event = createAPIGatewayEvent({path: '/files', httpMethod: 'GET', userId: fakeUserId})
   })
   test('(anonymous) should return default file for anonymous users', async () => {

--- a/src/lambdas/PruneDevices/test/index.test.ts
+++ b/src/lambdas/PruneDevices/test/index.test.ts
@@ -114,6 +114,8 @@ describe('#PruneDevices', () => {
 
   // Configure SNS mock responses for each test using factories
   beforeEach(() => {
+    vi.clearAllMocks()
+    snsMock.reset()
     snsMock.on(DeleteEndpointCommand).resolves(createSNSMetadataResponse())
     snsMock.on(SubscribeCommand).resolves(createSNSSubscribeResponse())
     snsMock.on(UnsubscribeCommand).resolves(createSNSMetadataResponse())
@@ -121,7 +123,6 @@ describe('#PruneDevices', () => {
 
   afterEach(() => {
     snsMock.reset()
-    vi.clearAllMocks()
   })
 
   test('should search for and remove disabled devices (single)', async () => {

--- a/src/lambdas/SendPushNotification/test/index.test.ts
+++ b/src/lambdas/SendPushNotification/test/index.test.ts
@@ -25,6 +25,7 @@ describe('#SendPushNotification', () => {
   let event: SQSEvent
 
   beforeEach(() => {
+    vi.clearAllMocks()
     // Create push notification event with message ID for batch failure tracking
     event = createPushNotificationEvent(fakeUserId, 'CGYBu-3Oi24', {title: 'Philip DeFranco', key: '20221017-[Philip DeFranco].mp4'})
     // Override the messageId to match expected batch failure ID
@@ -92,6 +93,105 @@ describe('#SendPushNotification', () => {
 
       expect(result).toEqual({batchItemFailures: [{itemIdentifier: 'ef8f6d44-a3e3-4bf1-9e0f-07576bcb111f'}]})
       expect(snsMock).not.toHaveReceivedCommand(PublishCommand)
+    })
+
+    test('should return batch failure when SNS publish fails', async () => {
+      vi.mocked(getUserDevicesByUserId).mockResolvedValue(getUserDevicesByUserIdResponse)
+      vi.mocked(getDevice).mockResolvedValue(getDeviceResponse)
+      snsMock.on(PublishCommand).rejects(new Error('SNS service unavailable'))
+
+      const result = await handler(event, testContext)
+
+      expect(result.batchItemFailures).toEqual([{itemIdentifier: 'ef8f6d44-a3e3-4bf1-9e0f-07576bcb111f'}])
+    })
+
+    test('should return batch failure when getUserDevicesByUserId throws', async () => {
+      vi.mocked(getUserDevicesByUserId).mockRejectedValue(new Error('Database timeout'))
+
+      const result = await handler(event, testContext)
+
+      expect(result.batchItemFailures).toEqual([{itemIdentifier: 'ef8f6d44-a3e3-4bf1-9e0f-07576bcb111f'}])
+    })
+  })
+
+  describe('#EdgeCases', () => {
+    test('should send notifications to multiple devices', async () => {
+      const multipleDevices = [
+        createMockUserDevice({deviceId: 'device-1', userId: fakeUserId}),
+        createMockUserDevice({deviceId: 'device-2', userId: fakeUserId})
+      ]
+      vi.mocked(getUserDevicesByUserId).mockResolvedValue(multipleDevices)
+      vi.mocked(getDevice).mockResolvedValue(getDeviceResponse)
+      snsMock.on(PublishCommand).resolves(createSNSPublishResponse())
+
+      const result = await handler(event, testContext)
+
+      expect(result.batchItemFailures).toEqual([])
+      expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 2)
+    })
+
+    test('should process multiple SQS records in batch', async () => {
+      const multiRecordEvent: SQSEvent = {
+        Records: [
+          ...createPushNotificationEvent(fakeUserId, 'file-1').Records,
+          ...createPushNotificationEvent(fakeUserId, 'file-2').Records
+        ]
+      }
+      vi.mocked(getUserDevicesByUserId).mockResolvedValue(getUserDevicesByUserIdResponse)
+      vi.mocked(getDevice).mockResolvedValue(getDeviceResponse)
+      snsMock.on(PublishCommand).resolves(createSNSPublishResponse())
+
+      const result = await handler(multiRecordEvent, testContext)
+
+      expect(result.batchItemFailures).toEqual([])
+      expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 2)
+    })
+
+    test('should continue processing when one device lookup fails (partial success)', async () => {
+      const multipleDevices = [
+        createMockUserDevice({deviceId: 'device-1', userId: fakeUserId}),
+        createMockUserDevice({deviceId: 'device-2', userId: fakeUserId})
+      ]
+      vi.mocked(getUserDevicesByUserId).mockResolvedValue(multipleDevices)
+      // First device succeeds, second device not found
+      vi.mocked(getDevice).mockResolvedValueOnce(getDeviceResponse).mockResolvedValueOnce(null)
+      snsMock.on(PublishCommand).resolves(createSNSPublishResponse())
+
+      const result = await handler(event, testContext)
+
+      // Partial success = message processed successfully (1 of 2 succeeded)
+      expect(result.batchItemFailures).toEqual([])
+      expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1)
+    })
+
+    test('should handle device with no endpoint ARN configured', async () => {
+      const deviceWithNoArn = createMockDevice({deviceId: fakeDeviceId, endpointArn: undefined})
+      vi.mocked(getUserDevicesByUserId).mockResolvedValue(getUserDevicesByUserIdResponse)
+      vi.mocked(getDevice).mockResolvedValue(deviceWithNoArn)
+
+      const result = await handler(event, testContext)
+
+      // Device without ARN counts as failure, and it's the only device, so batch fails
+      expect(result.batchItemFailures).toEqual([{itemIdentifier: 'ef8f6d44-a3e3-4bf1-9e0f-07576bcb111f'}])
+      expect(snsMock).not.toHaveReceivedCommand(PublishCommand)
+    })
+
+    test('should handle batch with mixed record outcomes', async () => {
+      const multiRecordEvent: SQSEvent = {
+        Records: [
+          {...createPushNotificationEvent(fakeUserId, 'file-1').Records[0], messageId: 'msg-1'},
+          {...createPushNotificationEvent(fakeUserId, 'file-2').Records[0], messageId: 'msg-2'}
+        ]
+      }
+      // First record succeeds, second record has no devices (also succeeds)
+      vi.mocked(getUserDevicesByUserId).mockResolvedValueOnce(getUserDevicesByUserIdResponse).mockResolvedValueOnce([])
+      vi.mocked(getDevice).mockResolvedValue(getDeviceResponse)
+      snsMock.on(PublishCommand).resolves(createSNSPublishResponse())
+
+      const result = await handler(multiRecordEvent, testContext)
+
+      expect(result.batchItemFailures).toEqual([])
+      expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1)
     })
   })
 })

--- a/test/helpers/aws-sdk-mock.ts
+++ b/test/helpers/aws-sdk-mock.ts
@@ -35,7 +35,17 @@ import {type AwsClientStub, mockClient} from 'aws-sdk-client-mock'
 import {SQSClient} from '@aws-sdk/client-sqs'
 import {SNSClient} from '@aws-sdk/client-sns'
 import {EventBridgeClient} from '@aws-sdk/client-eventbridge'
-import {setTestEventBridgeClient, setTestSNSClient, setTestSQSClient} from '#lib/vendor/AWS/clients'
+import {S3Client} from '@aws-sdk/client-s3'
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
+import {LambdaClient} from '@aws-sdk/client-lambda'
+import {
+  setTestDynamoDBClient,
+  setTestEventBridgeClient,
+  setTestLambdaClient,
+  setTestS3Client,
+  setTestSNSClient,
+  setTestSQSClient
+} from '#lib/vendor/AWS/clients'
 
 // Base interface for mock instances with reset/restore methods
 interface MockInstance {
@@ -80,6 +90,39 @@ export function createEventBridgeMock(): AwsClientStub<EventBridgeClient> {
 }
 
 /**
+ * Creates a mock S3 client and injects it into the client factory.
+ * @returns The mock client instance for configuring responses and assertions
+ */
+export function createS3Mock(): AwsClientStub<S3Client> {
+  const mock = mockClient(S3Client)
+  mockInstances.push(mock)
+  setTestS3Client(mock as unknown as S3Client)
+  return mock
+}
+
+/**
+ * Creates a mock DynamoDB client and injects it into the client factory.
+ * @returns The mock client instance for configuring responses and assertions
+ */
+export function createDynamoDBMock(): AwsClientStub<DynamoDBClient> {
+  const mock = mockClient(DynamoDBClient)
+  mockInstances.push(mock)
+  setTestDynamoDBClient(mock as unknown as DynamoDBClient)
+  return mock
+}
+
+/**
+ * Creates a mock Lambda client and injects it into the client factory.
+ * @returns The mock client instance for configuring responses and assertions
+ */
+export function createLambdaMock(): AwsClientStub<LambdaClient> {
+  const mock = mockClient(LambdaClient)
+  mockInstances.push(mock)
+  setTestLambdaClient(mock as unknown as LambdaClient)
+  return mock
+}
+
+/**
  * Resets all AWS mock clients and clears the test client injections.
  * Call this in afterAll() to clean up between test files.
  */
@@ -94,6 +137,9 @@ export function resetAllAwsMocks(): void {
   setTestSQSClient(null)
   setTestSNSClient(null)
   setTestEventBridgeClient(null)
+  setTestS3Client(null)
+  setTestDynamoDBClient(null)
+  setTestLambdaClient(null)
 }
 
 // Re-export types for convenience


### PR DESCRIPTION
## Summary

This PR improves the unit testing infrastructure by addressing mock pattern inconsistencies, expanding test coverage, and implementing missing AWS SDK mock helpers.

### Changes

**1. Added Missing AWS SDK Mock Helpers** (`test/helpers/aws-sdk-mock.ts`)
- Implemented `createS3Mock()` for S3 client mocking
- Implemented `createDynamoDBMock()` for DynamoDB client mocking  
- Implemented `createLambdaMock()` for Lambda client mocking
- Updated `resetAllAwsMocks()` to clear new test client injections

**2. Standardized Mock Reset Patterns**
- `src/lambdas/ListFiles/test`: Added `vi.clearAllMocks()` to beforeEach
- `src/lambdas/SendPushNotification/test`: Added `vi.clearAllMocks()` to beforeEach
- `src/lambdas/PruneDevices/test`: Moved `vi.clearAllMocks()` from afterEach to beforeEach
- `src/lambdas/ApiGatewayAuthorizer/test`: Added global `vi.clearAllMocks()` in beforeEach

**3. Expanded SendPushNotification Test Coverage** (5 → 12 tests)
New tests added:
- SNS publish failure handling
- Database timeout handling
- Multiple devices per user
- Multiple SQS records in batch
- Partial device failure handling
- Device with no endpoint ARN
- Mixed batch outcomes

**4. Documentation Updates** (`docs/wiki/Testing/Vitest-Mocking-Strategy.md`)
- Added "Mock Reset Pattern (Required)" section
- Documented standard beforeEach/afterEach patterns
- Listed common mistakes to avoid
- Added best practice #7 for mock resets

## Test Plan

- [x] All 1062 unit tests pass
- [x] All 141 integration tests pass
- [x] `pnpm run precheck` passes (TypeScript + lint + format)
- [x] `pnpm run validate:conventions` passes
- [x] `pnpm run ci:local:full` passes

## Files Changed

| File | Changes |
|------|---------|
| `test/helpers/aws-sdk-mock.ts` | +45 lines (3 new mock helpers) |
| `src/lambdas/ListFiles/test/index.test.ts` | +1 line |
| `src/lambdas/SendPushNotification/test/index.test.ts` | +105 lines (7 new tests) |
| `src/lambdas/PruneDevices/test/index.test.ts` | +2 lines |
| `src/lambdas/ApiGatewayAuthorizer/test/index.test.ts` | +4 lines |
| `docs/wiki/Testing/Vitest-Mocking-Strategy.md` | +30 lines |