### PR TITLE
refactor(test): standardize mock patterns and improve test coverage

### DIFF
--- a/src/lambdas/PruneDevices/test/index.test.ts
+++ b/src/lambdas/PruneDevices/test/index.test.ts
@@ -115,7 +115,6 @@ describe('#PruneDevices', () => {
   // Configure SNS mock responses for each test using factories
   beforeEach(() => {
     vi.clearAllMocks()
-    snsMock.reset()
     snsMock.on(DeleteEndpointCommand).resolves(createSNSMetadataResponse())
     snsMock.on(SubscribeCommand).resolves(createSNSSubscribeResponse())
     snsMock.on(UnsubscribeCommand).resolves(createSNSMetadataResponse())

--- a/src/lambdas/RefreshToken/test/index.test.ts
+++ b/src/lambdas/RefreshToken/test/index.test.ts
@@ -2,7 +2,7 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import type {APIGatewayProxyEvent} from 'aws-lambda'
 import {testContext} from '#util/vitest-setup'
 import {createAPIGatewayEvent} from '#test/helpers/event-factories'
-import {v4 as uuidv4} from 'uuid'
+import {DEFAULT_SESSION_ID, DEFAULT_USER_ID} from '#test/helpers/entity-fixtures'
 import type {SessionPayload} from '#types/util'
 
 const validateSessionTokenMock = vi.fn<(token: string) => Promise<SessionPayload>>()
@@ -17,19 +17,18 @@ const {handler} = await import('./../src')
 describe('#RefreshToken', () => {
   const context = testContext
   let event: APIGatewayProxyEvent
-  const fakeUserId = uuidv4()
-  const fakeSessionId = uuidv4()
+  const fakeUserId = DEFAULT_USER_ID
+  const fakeSessionId = DEFAULT_SESSION_ID
   const fakeToken = 'test-session-token-abc123'
   const futureExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000
 
   beforeEach(() => {
+    vi.clearAllMocks()
     event = createAPIGatewayEvent({
       path: '/refreshToken',
       httpMethod: 'POST',
       headers: {Authorization: `Bearer ${fakeToken}`}
     }) as unknown as APIGatewayProxyEvent
-    validateSessionTokenMock.mockReset()
-    refreshSessionMock.mockReset()
   })
 
   test('should successfully refresh a valid session token', async () => {

--- a/src/lambdas/S3ObjectCreated/test/index.test.ts
+++ b/src/lambdas/S3ObjectCreated/test/index.test.ts
@@ -27,7 +27,6 @@ describe('#S3ObjectCreated', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    sqsMock.reset()
     // Default mock: file found, one user
     vi.mocked(getFilesByKey).mockResolvedValue([mockFileRow])
     vi.mocked(getUserFilesByFileId).mockResolvedValue([mockUserFileRow])

--- a/src/lambdas/SendPushNotification/test/index.test.ts
+++ b/src/lambdas/SendPushNotification/test/index.test.ts
@@ -30,7 +30,6 @@ describe('#SendPushNotification', () => {
     event = createPushNotificationEvent(fakeUserId, 'CGYBu-3Oi24', {title: 'Philip DeFranco', key: '20221017-[Philip DeFranco].mp4'})
     // Override the messageId to match expected batch failure ID
     event.Records[0].messageId = 'ef8f6d44-a3e3-4bf1-9e0f-07576bcb111f'
-    snsMock.reset()
   })
 
   afterEach(() => {
@@ -51,8 +50,12 @@ describe('#SendPushNotification', () => {
     const result = await handler(event, testContext)
 
     expect(result).toEqual({batchItemFailures: []})
-    // Use aws-sdk-client-mock-vitest matchers for type-safe assertions
-    expect(snsMock).toHaveReceivedCommand(PublishCommand)
+    // Use aws-sdk-client-mock-vitest matchers for type-safe assertions with parameter verification
+    expect(snsMock).toHaveReceivedCommandWith(PublishCommand, {
+      TargetArn: expect.stringContaining('arn:aws:sns'),
+      Message: expect.stringContaining('DownloadReadyNotification'),
+      MessageAttributes: expect.objectContaining({'AWS.SNS.MOBILE.APNS.PUSH_TYPE': expect.any(Object)})
+    })
   })
 
   test('should exit gracefully if no devices exist', async () => {

--- a/src/lambdas/StartFileUpload/test/index.test.ts
+++ b/src/lambdas/StartFileUpload/test/index.test.ts
@@ -77,12 +77,9 @@ describe('#StartFileUpload', () => {
   const mockUserFileRow = () => createMockUserFile({userId: 'user-123', fileId: 'test'})
 
   beforeEach(() => {
+    vi.clearAllMocks()
     // Create SQS event with download queue message
     event = createDownloadQueueEvent('YcuKhcqzt7w', {messageId: 'test-message-id-123'})
-
-    vi.clearAllMocks()
-    sqsMock.reset()
-    eventBridgeMock.reset()
 
     vi.mocked(getFileDownload).mockResolvedValue(null)
     vi.mocked(updateFileDownload).mockResolvedValue(mockFileDownloadRow())

--- a/src/lambdas/UserDelete/test/index.test.ts
+++ b/src/lambdas/UserDelete/test/index.test.ts
@@ -46,7 +46,6 @@ describe('#UserDelete', () => {
   const context = testContext
   beforeEach(() => {
     vi.clearAllMocks()
-    snsMock.reset()
     event = createAPIGatewayEvent({path: '/users', httpMethod: 'DELETE', userId: fakeUserId})
 
     // Configure SNS mock responses using factories
@@ -75,6 +74,8 @@ describe('#UserDelete', () => {
     vi.mocked(getDevicesBatch).mockResolvedValue([fakeDevice1, fakeDevice2])
     const output = await handler(event, context)
     expect(output.statusCode).toEqual(204)
+    // Verify device deletion was called for each device
+    expect(deleteDeviceMock).toHaveBeenCalledTimes(2)
   })
   test('should create an issue if deletion fails', async () => {
     vi.mocked(deleteUser).mockRejectedValueOnce(new Error('Delete failed'))

--- a/src/lambdas/WebhookFeedly/test/index.test.ts
+++ b/src/lambdas/WebhookFeedly/test/index.test.ts
@@ -73,11 +73,9 @@ describe('#WebhookFeedly', () => {
   const context = testContext
   let event: CustomAPIGatewayRequestAuthorizerEvent
   beforeEach(() => {
+    vi.clearAllMocks()
     // Create event with Feedly webhook body
     event = createAPIGatewayEvent({path: '/webhooks/feedly', httpMethod: 'POST', body: createFeedlyWebhookBody({articleURL: feedlyWebhookBody.articleURL})})
-
-    vi.clearAllMocks()
-    sqsMock.reset()
 
     process.env.EVENT_BUS_NAME = 'MediaDownloader'
     process.env.SNS_QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/123456789/SendPushNotification'


### PR DESCRIPTION
## Summary

This PR standardizes unit test mock patterns across Lambda functions and updates documentation to reflect 2025 best practices for aws-sdk-client-mock with Vitest.

### Key Changes

- **Mock reset pattern**: Moved `snsMock.reset()` from beforeEach to afterEach only (fixes redundant reset)
- **Precise AWS assertions**: Added `toHaveReceivedCommandWith` for parameter verification
- **Behavior-based testing**: Replaced `vi.spyOn` on URLSearchParams prototype with output verification
- **Logging verification**: Added behavior assertions to DeviceEvent tests
- **Fixture standardization**: Using `DEFAULT_USER_ID`, `DEFAULT_SESSION_ID` instead of random UUIDs
- **Documentation update**: Updated wiki with anti-patterns section and corrected guidance

### Files Modified

| Category | Files | Changes |
|----------|-------|---------|
| Mock Pattern Fix | 8 Lambda tests | Removed redundant `reset()` from beforeEach |
| Precise Assertions | 4 Lambda tests | Added `toHaveReceivedCommandWith` |
| Behavior Testing | CloudfrontMiddleware | Removed spyOn, verify output headers |
| Test Coverage | DeviceEvent | Added logging behavior verification |
| Fixtures | RefreshToken | Using fixture constants |
| Documentation | Vitest-Mocking-Strategy.md | Added anti-patterns, updated reset pattern |

### Test Results

- All 933 unit tests passing
- Type checking passes
- Linting passes
- Convention validation passes

## Test plan

- [ ] CI pipeline passes (unit tests)
- [ ] Review test changes for pattern consistency
- [ ] Verify wiki documentation is accurate