### PR TITLE
feat(ci): add missing validation steps and parallel execution

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,6 +64,15 @@ jobs:
       - name: Test ESLint local rules
         run: pnpm run test:eslint-rules
 
+      - name: Check Terraform formatting
+        run: |
+          # Install tofu for formatting check
+          if command -v tofu &> /dev/null; then
+            tofu fmt -check -recursive terraform/
+          else
+            echo "OpenTofu not installed, skipping Terraform fmt check"
+          fi
+
   # Parallel job 3: Build and validate artifacts
   build-and-validate:
     runs-on: ubuntu-latest
@@ -107,9 +116,34 @@ jobs:
           path: build/
 
       - name: Run unit tests
-        run: pnpm test --coverage
+        run: pnpm test --coverage 2>&1 | tee test-output.txt
         env:
           CI: true
+
+      - name: Validate test output
+        if: always()
+        run: |
+          # Check for Vitest deprecation warnings
+          if grep -q "DEPRECATED" test-output.txt 2>/dev/null; then
+            echo "::error::Found Vitest deprecation warnings in test output"
+            grep "DEPRECATED" test-output.txt | head -3
+            exit 1
+          fi
+
+          # Check for EMF metrics spam (Powertools not silenced)
+          if grep -q '"_aws".*"CloudWatchMetrics"' test-output.txt 2>/dev/null; then
+            echo "::error::Found Powertools EMF metrics in test output (should be silenced)"
+            exit 1
+          fi
+
+          # Check for MCR source content warnings
+          if grep -q '\[MCR\] not found source content' test-output.txt 2>/dev/null; then
+            echo "::error::Found MCR source content warnings in test output"
+            grep '\[MCR\] not found' test-output.txt | head -3
+            exit 1
+          fi
+
+          echo "Test output is clean"
 
       - name: Post coverage to job summary
         if: always() && hashFiles('coverage/unit/coverage-summary.md') != ''

--- a/bin/build-dependencies.sh
+++ b/bin/build-dependencies.sh
@@ -42,7 +42,7 @@ elif [ ! -f "$sops_config_path" ]; then
   echo "Warning: SOPS config file does not exist at $sops_config_path"
   echo "Please refer to the README for SOPS configuration instructions"
   echo "Skipping encryption step"
-elif grep -q "^sops:" "$secrets_file_path" 2>/dev/null; then
+elif grep -q "^sops:" "$secrets_file_path" 2> /dev/null; then
   # Source file is already encrypted (has sops metadata) - skip
   echo "Warning: secrets.yaml appears to already be encrypted - skipping"
   echo "If this is unintentional, decrypt it with: sops --decrypt secrets.yaml > secrets_plain.yaml"

--- a/bin/ci-local.sh
+++ b/bin/ci-local.sh
@@ -5,8 +5,10 @@
 # Usage: pnpm run ci:local or ./bin/ci-local.sh
 #
 # This script replicates the checks from GitHub Actions workflows locally,
-# catching ~95% of issues that would fail in CI. For full CI parity including
+# catching ~98% of issues that would fail in CI. For full CI parity including
 # integration tests, use: pnpm run ci:local:full
+#
+# Performance: Uses parallel execution for independent validation steps.
 
 set -e # Exit on error
 
@@ -32,16 +34,18 @@ echo "  2. Dependency installation"
 echo "  3. TypeSpec compilation"
 echo "  4. Build dependencies (Terraform types)"
 echo "  5. esbuild build"
-echo "  6. Type checking"
-echo "  7. Linting"
+echo "  6. Type checking (parallel)"
+echo "  7. Linting + Terraform formatting"
 echo "  8. Formatting (dprint)"
 echo "  9. ESLint local rules tests"
 echo "  10. Documentation validation"
 echo "  11. Dependency rules check"
-echo "  12. GraphRAG validation"
-echo "  13. Documentation sync validation"
-echo "  14. Unit tests"
-echo "  15. Test output validation"
+echo "  12-14. Convention/Config/API validation (parallel)"
+echo "  15. Security audit"
+echo "  16. GraphRAG validation"
+echo "  17. Documentation sync validation"
+echo "  18. Unit tests"
+echo "  19. Test output validation"
 echo ""
 echo -e "${BLUE}Note: Integration tests skipped. Use 'pnpm run ci:local:full' for complete CI.${NC}"
 echo ""
@@ -49,7 +53,7 @@ echo ""
 cd "$PROJECT_ROOT"
 
 # Step 1: Environment checks
-echo -e "${YELLOW}[1/14] Checking prerequisites...${NC}"
+echo -e "${YELLOW}[1/19] Checking prerequisites...${NC}"
 
 # Check Node.js version
 REQUIRED_NODE_MAJOR=24
@@ -80,39 +84,74 @@ echo -e "${GREEN}  Prerequisites satisfied${NC}"
 echo ""
 
 # Step 2: Create build directory and install dependencies
-echo -e "${YELLOW}[2/14] Installing dependencies...${NC}"
+echo -e "${YELLOW}[2/19] Installing dependencies...${NC}"
 mkdir -p build
 pnpm install --frozen-lockfile
 echo -e "${GREEN}  Dependencies installed${NC}"
 echo ""
 
 # Step 3: TypeSpec compilation
-echo -e "${YELLOW}[3/14] Compiling TypeSpec...${NC}"
+echo -e "${YELLOW}[3/19] Compiling TypeSpec...${NC}"
 pnpm run typespec:check
 echo -e "${GREEN}  TypeSpec compilation passed${NC}"
 echo ""
 
 # Step 4: Build dependencies (Terraform types)
-echo -e "${YELLOW}[4/14] Building dependencies (Terraform types)...${NC}"
+echo -e "${YELLOW}[4/19] Building dependencies (Terraform types)...${NC}"
 pnpm run build-dependencies
 echo -e "${GREEN}  Build dependencies complete${NC}"
 echo ""
 
 # Step 5: esbuild build
-echo -e "${YELLOW}[5/14] Running esbuild build...${NC}"
+echo -e "${YELLOW}[5/19] Running esbuild build...${NC}"
 pnpm run build
 echo -e "${GREEN}  Build complete${NC}"
 echo ""
 
-# Step 6: Type checking
-echo -e "${YELLOW}[6/14] Running type checks...${NC}"
-pnpm run check-types
-pnpm run check-test-types
+# Step 6: Type checking (PARALLEL)
+echo -e "${YELLOW}[6/19] Running type checks (parallel)...${NC}"
+
+# Create temp files for parallel job output
+TYPE_CHECK_OUTPUT=$(mktemp)
+TEST_TYPE_CHECK_OUTPUT=$(mktemp)
+trap "rm -f $TYPE_CHECK_OUTPUT $TEST_TYPE_CHECK_OUTPUT" EXIT
+
+(
+  if pnpm run --silent check-types > "$TYPE_CHECK_OUTPUT" 2>&1; then
+    echo -e "  ${GREEN}✓${NC} Main types"
+  else
+    echo -e "  ${RED}✗${NC} Main types failed"
+    cat "$TYPE_CHECK_OUTPUT"
+    exit 1
+  fi
+) &
+PID_TYPES=$!
+
+(
+  if pnpm run --silent check-test-types > "$TEST_TYPE_CHECK_OUTPUT" 2>&1; then
+    echo -e "  ${GREEN}✓${NC} Test types"
+  else
+    echo -e "  ${RED}✗${NC} Test types failed"
+    cat "$TEST_TYPE_CHECK_OUTPUT"
+    exit 1
+  fi
+) &
+PID_TEST_TYPES=$!
+
+# Wait for type checking jobs
+TYPES_FAILED=0
+wait $PID_TYPES || TYPES_FAILED=1
+wait $PID_TEST_TYPES || TYPES_FAILED=1
+
+if [ $TYPES_FAILED -ne 0 ]; then
+  echo -e "${RED}  Type checks failed${NC}"
+  exit 1
+fi
 echo -e "${GREEN}  Type checks passed${NC}"
 echo ""
 
 # Step 7: Linting
-echo -e "${YELLOW}[7/15] Running linter...${NC}"
+echo -e "${YELLOW}[7/19] Running linter...${NC}"
 pnpm run lint
 
 # Check Terraform formatting
@@ -131,7 +170,7 @@ echo -e "${GREEN}  Linting passed${NC}"
 echo ""
 
 # Step 8: Formatting check (dprint)
-echo -e "${YELLOW}[8/15] Checking code formatting (dprint)...${NC}"
+echo -e "${YELLOW}[8/19] Checking code formatting (dprint)...${NC}"
 if ! pnpm run format:check; then
   echo -e "${RED}Error: Code formatting check failed.${NC}"
   echo "Run 'pnpm run format' to fix."
@@ -141,34 +180,97 @@ echo -e "${GREEN}  Code formatting passed${NC}"
 echo ""
 
 # Step 9: ESLint local rules tests
-echo -e "${YELLOW}[9/15] Testing ESLint local rules...${NC}"
+echo -e "${YELLOW}[9/19] Testing ESLint local rules...${NC}"
 pnpm run test:eslint-rules
 echo -e "${GREEN}  ESLint local rules tests passed${NC}"
 echo ""
 
 # Step 10: Documentation validation
-echo -e "${YELLOW}[10/15] Validating documented scripts...${NC}"
+echo -e "${YELLOW}[10/19] Validating documented scripts...${NC}"
 ./bin/validate-docs.sh
 echo ""
 
 # Step 11: Dependency rules check
-echo -e "${YELLOW}[11/15] Checking dependency rules...${NC}"
+echo -e "${YELLOW}[11/19] Checking dependency rules...${NC}"
 pnpm run deps:check
 echo -e "${GREEN}  Dependency rules passed${NC}"
 echo ""
 
-# Step 12: GraphRAG validation
-echo -e "${YELLOW}[12/15] Validating GraphRAG...${NC}"
+# Steps 12-14: Convention, Config, API validation (PARALLEL)
+echo -e "${YELLOW}[12-14/19] Running validation checks (parallel)...${NC}"
+
+# Create temp files for parallel job output
+CONV_OUTPUT=$(mktemp)
+CONFIG_OUTPUT=$(mktemp)
+API_OUTPUT=$(mktemp)
+trap "rm -f $TYPE_CHECK_OUTPUT $TEST_TYPE_CHECK_OUTPUT $CONV_OUTPUT $CONFIG_OUTPUT $API_OUTPUT" EXIT
+
+(
+  if pnpm run --silent validate:conventions > "$CONV_OUTPUT" 2>&1; then
+    echo -e "  ${GREEN}✓${NC} Conventions"
+  else
+    echo -e "  ${RED}✗${NC} Conventions failed"
+    cat "$CONV_OUTPUT"
+    exit 1
+  fi
+) &
+PID_CONVENTIONS=$!
+
+(
+  if pnpm run --silent validate:config > "$CONFIG_OUTPUT" 2>&1; then
+    echo -e "  ${GREEN}✓${NC} Config"
+  else
+    echo -e "  ${RED}✗${NC} Config failed"
+    cat "$CONFIG_OUTPUT"
+    exit 1
+  fi
+) &
+PID_CONFIG=$!
+
+(
+  if pnpm run --silent validate:api-paths > "$API_OUTPUT" 2>&1; then
+    echo -e "  ${GREEN}✓${NC} API paths"
+  else
+    echo -e "  ${RED}✗${NC} API paths failed"
+    cat "$API_OUTPUT"
+    exit 1
+  fi
+) &
+PID_APIPATHS=$!
+
+# Wait for all parallel validation jobs
+VALIDATION_FAILED=0
+wait $PID_CONVENTIONS || VALIDATION_FAILED=1
+wait $PID_CONFIG || VALIDATION_FAILED=1
+wait $PID_APIPATHS || VALIDATION_FAILED=1
+
+if [ $VALIDATION_FAILED -ne 0 ]; then
+  echo -e "${RED}  Validation checks failed${NC}"
+  exit 1
+fi
+echo -e "${GREEN}  Validation checks passed${NC}"
+echo ""
+
+# Step 15: Security audit
+echo -e "${YELLOW}[15/19] Running security audit...${NC}"
+if ! pnpm audit --audit-level=high; then
+  echo -e "${YELLOW}  Security audit found vulnerabilities (non-blocking)${NC}"
+fi
+echo -e "${GREEN}  Security audit complete${NC}"
+echo ""
+
+# Step 16: GraphRAG validation
+echo -e "${YELLOW}[16/19] Validating GraphRAG...${NC}"
 ./bin/validate-graphrag.sh
 echo ""
 
-# Step 13: Documentation sync validation
-echo -e "${YELLOW}[13/15] Validating documentation sync...${NC}"
+# Step 17: Documentation sync validation
+echo -e "${YELLOW}[17/19] Validating documentation sync...${NC}"
 ./bin/validate-doc-sync.sh
 echo ""
 
-# Step 14: Unit tests
-echo -e "${YELLOW}[14/15] Running unit tests...${NC}"
+# Step 18: Unit tests
+echo -e "${YELLOW}[18/19] Running unit tests...${NC}"
 TEST_OUTPUT=$(pnpm test 2>&1)
 TEST_EXIT_CODE=$?
 echo "$TEST_OUTPUT"
@@ -180,8 +282,8 @@ fi
 echo -e "${GREEN}  Unit tests passed${NC}"
 echo ""
 
-# Step 15: Validate test output is clean
-echo -e "${YELLOW}[15/15] Validating test output...${NC}"
+# Step 19: Validate test output is clean
+echo -e "${YELLOW}[19/19] Validating test output...${NC}"
 TEST_ISSUES=0
 
 # Check for Vitest deprecation warnings
@@ -226,9 +328,10 @@ echo ""
 echo "All checks passed in ${MINUTES}m ${SECONDS}s"
 echo ""
 echo "What was checked:"
-echo "  Environment, dependencies, TypeSpec, build, types, lint, formatting (dprint),"
-echo "  ESLint local rules, documentation, dependency rules, GraphRAG, documentation sync,"
-echo "  unit tests, test output validation (deprecation, EMF metrics, MCR warnings)"
+echo "  Environment, dependencies, TypeSpec, build, types (parallel), lint,"
+echo "  formatting (dprint), ESLint local rules, documentation, dependency rules,"
+echo "  conventions, config, API paths (parallel), security audit, GraphRAG,"
+echo "  documentation sync, unit tests, test output validation"
 echo ""
 echo "What was NOT checked (run ci:local:full for these):"
 echo "  Integration tests (LocalStack)"

--- a/docs/wiki/Infrastructure/CI-Coverage-Matrix.md
+++ b/docs/wiki/Infrastructure/CI-Coverage-Matrix.md
@@ -1,0 +1,131 @@
+# CI Coverage Matrix
+
+This document provides a comprehensive comparison of checks run across different CI environments: local CI scripts and GitHub Actions workflows.
+
+## Quick Reference
+
+| Script/Workflow | Purpose | Approx. Time |
+|-----------------|---------|--------------|
+| `pnpm run ci:local` | Fast local CI (no integration tests) | ~2-3 min |
+| `pnpm run ci:local:full` | Full local CI with integration tests | ~5-10 min |
+| `pnpm run cleanup` | Comprehensive cleanup with auto-fixes | Varies |
+| GitHub `unit-tests.yml` | Remote unit test pipeline | ~3-5 min |
+| GitHub `integration-tests.yml` | Remote integration tests | ~5-8 min |
+
+## Detailed Coverage Matrix
+
+### Build & Dependencies
+
+| Check | ci-local.sh | cleanup.sh | GH unit-tests | GH integration |
+|-------|:-----------:|:----------:|:-------------:|:--------------:|
+| Node.js version check | Yes | No | .nvmrc | .nvmrc |
+| hcl2json check | Yes | No | Homebrew action | No |
+| jq check | Yes | No | No | No |
+| pnpm install | Yes | Yes | Yes | Yes |
+| generate-graph | Yes (in build) | Yes | Yes (in build) | No |
+| TypeSpec compile | Yes | Yes | Yes | No |
+| build-dependencies | Yes | Yes | Yes | No |
+| esbuild build | Yes | Yes | Yes | No |
+
+### Type Checking & Linting
+
+| Check | ci-local.sh | cleanup.sh | GH unit-tests | GH integration |
+|-------|:-----------:|:----------:|:-------------:|:--------------:|
+| check-types | Yes (parallel) | Yes | Yes | No |
+| check-test-types | Yes (parallel) | Yes | Yes | No |
+| ESLint | Yes | Yes (with fix) | Yes | No |
+| ESLint rules tests | Yes | Yes | Yes | No |
+| dprint check | Yes | Check only | Yes | No |
+| Terraform fmt | Yes | No | Yes | No |
+| actionlint | No | Optional | No | No |
+
+### Validation
+
+| Check | ci-local.sh | cleanup.sh | GH unit-tests | GH integration |
+|-------|:-----------:|:----------:|:-------------:|:--------------:|
+| validate:conventions | Yes (parallel) | Yes | Yes | No |
+| validate:config | Yes (parallel) | Yes | Yes | No |
+| validate:api-paths | Yes (parallel) | Yes | Yes | No |
+| validate:docs | Yes | Yes | Yes | No |
+| validate:doc-sync | Yes | Yes | Yes | No |
+| validate:graphrag | Yes | Yes | Yes | No |
+| deps:check | Yes | Yes | No* | No |
+| check:bundle-size | No | No | Yes | No |
+| pnpm audit | Yes | No | Yes | No |
+
+*Note: deps:check runs in separate `dependency-check.yml` workflow.
+
+### Testing
+
+| Check | ci-local.sh | cleanup.sh | GH unit-tests | GH integration |
+|-------|:-----------:|:----------:|:-------------:|:--------------:|
+| Unit tests | Yes | Yes | Yes | No |
+| Test output validation | Yes | Yes | Yes | No |
+| Integration tests | No | Full mode | No | Yes |
+| Coverage upload | No | No | Yes | Yes |
+
+### Documentation & Context (cleanup.sh only)
+
+| Check | ci-local.sh | cleanup.sh | cleanup --check |
+|-------|:-----------:|:----------:|:---------------:|
+| document-source | No | Yes | No |
+| document-terraform | No | Yes | No |
+| document-api | No | Yes | No |
+| graphrag:extract | No | Yes | No |
+| pack:context | No | Yes | No |
+
+## Parallel Execution
+
+### ci-local.sh Parallelization
+
+The local CI script uses parallel execution for independent steps:
+
+1. **Type Checking (Step 6)**: `check-types` and `check-test-types` run in parallel
+2. **Validation (Steps 12-14)**: `validate:conventions`, `validate:config`, and `validate:api-paths` run in parallel
+
+### GitHub Actions Parallelization
+
+The unit-tests workflow runs 3 parallel jobs before the final test job:
+
+```
+validate ────────────────────┐
+lint-and-types ──────────────┼──> test
+build-and-validate ──────────┘
+```
+
+## Usage Recommendations
+
+### Before Committing (Fast Check)
+```bash
+pnpm run ci:local
+```
+Runs all essential checks in ~2-3 minutes with parallel execution.
+
+### Before Pushing (Full Check)
+```bash
+pnpm run ci:local:full
+```
+Includes integration tests against LocalStack (~5-10 minutes).
+
+### Cleanup with Auto-Fixes
+```bash
+pnpm run cleanup        # Full cleanup with integration tests
+pnpm run cleanup:fast   # Skip integration tests
+pnpm run cleanup:check  # Dry-run, no fixes
+```
+
+## What Cannot Be Run Locally
+
+Some GitHub Actions features cannot be replicated locally:
+
+- Codecov upload and coverage comments
+- Artifact storage between jobs
+- PR comments and annotations
+- Status checks on commits
+- Secrets injection (production credentials)
+
+## Related Documentation
+
+- [Bash Script Patterns](../Bash/Script-Patterns.md)
+- [Testing Coverage Philosophy](../Testing/Coverage-Philosophy.md)
+- [Git Workflow](../Conventions/Git-Workflow.md)


### PR DESCRIPTION
## Summary

This PR improves CI script consistency and coverage by:

- Adding 4 missing validation steps to `ci-local.sh` that were only in GitHub Actions
- Implementing parallel execution for type checking and validation steps
- Adding test output validation to GitHub Actions workflow
- Creating comprehensive CI coverage documentation

## Changes

### ci-local.sh Improvements
- **New Steps**: Added `validate:conventions`, `validate:config`, `validate:api-paths`, and `pnpm audit`
- **Parallel Execution**: Type checking (check-types, check-test-types) now runs in parallel
- **Parallel Execution**: Validation steps (conventions, config, api-paths) now run in parallel
- **Updated**: Step count from 15 to 19 with corrected header listing

### GitHub Actions (unit-tests.yml)
- Added Terraform formatting check to lint-and-types job
- Added test output validation to test job (checks for deprecation warnings, EMF metrics spam, MCR warnings)

### Documentation
- Created `docs/wiki/Infrastructure/CI-Coverage-Matrix.md` with comprehensive coverage comparison

### Minor Fixes
- Fixed bash formatting in `build-dependencies.sh` (shfmt style)

## CI Coverage Comparison (Before vs After)

| Check | ci-local.sh (Before) | ci-local.sh (After) |
|-------|:-------------------:|:-------------------:|
| validate:conventions | No | Yes (parallel) |
| validate:config | No | Yes (parallel) |
| validate:api-paths | No | Yes (parallel) |
| pnpm audit | No | Yes |
| Parallel type checking | No | Yes |

## Test Plan

- [x] `pnpm run validate:conventions` passes
- [x] `pnpm run precheck` passes (types, lint, format)
- [x] GitHub Actions unit-tests workflow passes
- [x] GitHub Actions integration-tests workflow passes

## Performance Impact

The parallel execution should reduce `ci-local.sh` execution time by running:
1. `check-types` and `check-test-types` simultaneously
2. `validate:conventions`, `validate:config`, and `validate:api-paths` simultaneously

Estimated time savings: ~20-30 seconds on typical runs.