### PR TITLE
build: update esbuild config for 2025 best practices

### DIFF
--- a/config/esbuild.config.ts
+++ b/config/esbuild.config.ts
@@ -51,12 +51,15 @@ async function build() {
       entryPoints: [entryFile],
       bundle: true,
       platform: 'node',
-      target: 'es2022', // Node.js 24 supports ES2022
+      target: 'node24', // Node.js 24 Lambda runtime
       format: 'esm', // ESM for Node.js 24
       outfile: `${lambdaDir}/index.mjs`,
       outExtension: {'.js': '.mjs'}, // Explicit .mjs extension
       external: awsSdkExternals,
       minify: true,
+      legalComments: 'none', // Strip license comments from minified output
+      drop: ['debugger'], // Remove debugger statements in production
+      charset: 'utf8', // Explicit UTF-8 encoding
       sourcemap: false,
       metafile: isAnalyze, // Generate metafile for bundle analysis
       treeShaking: true,


### PR DESCRIPTION
## Summary

Updates the esbuild configuration with 2025 best practices for AWS Lambda Node.js 24 optimization:

- **Update target from es2022 to node24**: Enables Node.js-specific optimizations for the Lambda runtime
- **Add legalComments: none**: Strips license comments from minified output (~450KB reduction)
- **Add drop: debugger**: Removes debugger statements in production (safe - doesnt affect console.log or other logging)
- **Add charset: utf8**: Explicit UTF-8 encoding for consistency

## Bundle Size Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total bundle size | 11.02 MB | 10.57 MB | **-4.1%** |

All 17 Lambda functions remain within their configured size limits.

## Test Results

- All 1140 unit tests pass
- Bundle size check passes (1 warning: PruneDevices at 98.6% - pre-existing)
- Convention validation passes (only pre-existing MEDIUM violations)
- Pre-commit checks pass

## Changes

**File**: config/esbuild.config.ts (lines 54, 60-62)

## Test Plan

- [x] Build succeeds: pnpm run build
- [x] All unit tests pass: pnpm run test (1140 passed)
- [x] Bundle size check passes: pnpm run check:bundle-size
- [x] TypeScript types pass: pnpm run check-types
- [x] Linting passes: pnpm run lint
- [x] Convention validation passes: pnpm run validate:conventions
- [x] CI pipeline passes on GitHub