### PR TITLE
docs(security): add secrets management audit and rotation runbook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,15 @@
 
 echo "Running pre-commit checks..."
 
+# Check for secrets in staged files (fast - < 1 second)
+echo "Checking for secrets..."
+if ! ./bin/check-secrets.sh; then
+  echo ""
+  echo "Secret detection failed."
+  echo "Fix the issues or use 'git commit --no-verify' to bypass (emergency only)"
+  exit 1
+fi
+
 # Check for dependency violations (fast - usually < 1 second)
 echo "Checking dependency architecture..."
 if ! pnpm run deps:check; then

--- a/bin/check-secrets.sh
+++ b/bin/check-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# check-secrets.sh - Detect potential secrets in staged files
+#
+# Purpose: Pre-commit hook to prevent accidental secret commits
+# Usage: pnpm run check-secrets
+#        Or automatically via .husky/pre-commit
+#
+# This script checks for:
+# 1. secrets.yaml being staged (should never be committed)
+# 2. Patterns that look like hardcoded secrets
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Error handler
+error() {
+  echo -e "${RED}ERROR:${NC} $1" >&2
+}
+
+# Warning handler
+warn() {
+  echo -e "${YELLOW}WARNING:${NC} $1" >&2
+}
+
+# Success handler
+success() {
+  echo -e "${GREEN}OK:${NC} $1"
+}
+
+check_staged_files() {
+  local staged_files
+  staged_files=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || echo "")
+
+  if [ -z "$staged_files" ]; then
+    success "No staged files to check"
+    return 0
+  fi
+
+  local found_secrets=0
+
+  # Check 1: secrets.yaml should never be staged
+  if echo "$staged_files" | grep -q "^secrets\.yaml$"; then
+    error "secrets.yaml is staged for commit!"
+    echo ""
+    echo "This file contains unencrypted secrets and should never be committed."
+    echo "The encrypted version (secrets.enc.yaml) is safe to commit."
+    echo ""
+    echo "To unstage: git reset HEAD secrets.yaml"
+    echo ""
+    found_secrets=1
+  fi
+
+  # Check 2: Any .yaml files in secure/ directory
+  if echo "$staged_files" | grep -qE "^secure/.*\.(yaml|yml|json|pem|p12|key)$"; then
+    error "Sensitive file from secure/ directory is staged!"
+    echo ""
+    echo "Files in secure/ should never be committed."
+    echo ""
+    found_secrets=1
+  fi
+
+  # Check 3: Cookie files
+  if echo "$staged_files" | grep -qE "youtube-cookies\.txt$"; then
+    error "YouTube cookies file is staged!"
+    echo ""
+    echo "Cookie files contain session data and should never be committed."
+    echo ""
+    found_secrets=1
+  fi
+
+  # Check 4: .env files (except .env.example)
+  if echo "$staged_files" | grep -qE "^\.env$|^\.env\.local$|^\.env\.production$"; then
+    error ".env file is staged for commit!"
+    echo ""
+    echo "Environment files may contain secrets. Use .env.example for templates."
+    echo ""
+    found_secrets=1
+  fi
+
+  # Check 5: Scan for potential hardcoded secrets in text files
+  for file in $staged_files; do
+    if [ -f "${PROJECT_ROOT}/${file}" ]; then
+      # Skip binary files, encrypted files, and test fixtures
+      if file "${PROJECT_ROOT}/${file}" 2>/dev/null | grep -q "text" && \
+         ! echo "$file" | grep -qE "\.(enc|encrypted)\." && \
+         ! echo "$file" | grep -qE "^test/fixtures/"; then
+
+        # Pattern: Potential API keys or tokens (long alphanumeric strings after common key names)
+        if grep -nE "(api[_-]?key|api[_-]?token|secret[_-]?key|private[_-]?key|auth[_-]?token)\s*[:=]\s*['\"][A-Za-z0-9_\-]{32,}['\"]" \
+             "${PROJECT_ROOT}/${file}" 2>/dev/null | \
+           grep -vE "(placeholder|example|test|mock|fake|dummy|YOUR_)" > /dev/null; then
+          warn "Potential hardcoded secret in $file"
+          found_secrets=1
+        fi
+
+        # Pattern: AWS access keys
+        if grep -nE "AKIA[A-Z0-9]{16}" "${PROJECT_ROOT}/${file}" 2>/dev/null > /dev/null; then
+          error "AWS Access Key ID found in $file"
+          found_secrets=1
+        fi
+
+        # Pattern: GitHub tokens
+        if grep -nE "ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{82}" "${PROJECT_ROOT}/${file}" 2>/dev/null | \
+           grep -vE "(test|mock|fake)" > /dev/null; then
+          error "GitHub token found in $file"
+          found_secrets=1
+        fi
+      fi
+    fi
+  done
+
+  if [ $found_secrets -eq 1 ]; then
+    echo ""
+    echo "Secret detection found potential issues."
+    echo ""
+    echo "If these are false positives, you can bypass with:"
+    echo "  git commit --no-verify"
+    echo ""
+    return 1
+  fi
+
+  success "No secrets detected in staged files"
+  return 0
+}
+
+main() {
+  echo "Checking for secrets in staged files..."
+  check_staged_files
+}
+
+main "$@"

--- a/docs/wiki/Meta/Conventions-Tracking.md
+++ b/docs/wiki/Meta/Conventions-Tracking.md
@@ -10,7 +10,7 @@ Central registry of all project conventions with their documentation and enforce
 |--------|-------|-------------|
 | **MCP Rules** | 20 | AST-based validation via ts-morph |
 | **ESLint** | 24 | Linting rules including 9 JSDoc rules + 2 Drizzle safety rules + 8 local rules + TSDoc |
-| **Git Hooks** | 4 | Pre-commit, commit-msg, pre-push, post-checkout |
+| **Git Hooks** | 5 | Pre-commit (deps + secrets), commit-msg, pre-push, post-checkout |
 | **Dependency Cruiser** | 8 | Architectural boundary enforcement |
 | **CI Workflows** | 4 | Script validation, type checking, GraphRAG sync, security audit |
 | **Dependabot** | 2 | npm + GitHub Actions ecosystem updates |
@@ -61,6 +61,8 @@ Central registry of all project conventions with their documentation and enforce
 | No Underscore-Prefixed Variables | [Lambda Function Patterns](../TypeScript/Lambda-Function-Patterns.md) | MCP `config-enforcement` |
 | Use pnpm deploy, never tofu apply | [Drift Prevention](../Infrastructure/Drift-Prevention.md) | Script enforcement (pre-deploy-check.sh) |
 | Security Audit in CI | [Dependabot Resolution](../Methodologies/Dependabot-Resolution.md) | GitHub Actions + Dependabot |
+| All Secrets Encrypted with SOPS | [Secret-Rotation-Runbook](../Security/Secret-Rotation-Runbook.md) | .gitignore + pre-commit hook |
+| Never Commit secrets.yaml | [Secret-Rotation-Runbook](../Security/Secret-Rotation-Runbook.md) | .gitignore + pre-commit hook |
 
 ### HIGH Severity
 
@@ -87,6 +89,7 @@ Central registry of all project conventions with their documentation and enforce
 | Database Migrations via SQL Files | [Database Migrations](../Conventions/Database-Migrations.md) | MigrateDSQL Lambda + Terraform |
 | Aurora DSQL CREATE INDEX ASYNC | [Database Migrations](../Conventions/Database-Migrations.md) | Code review |
 | Lambda Layer Binary Version Tracking | [Lambda Layers](../Infrastructure/Lambda-Layers.md) | Terraform + Code review |
+| Use getRequiredEnv() for Secret Access | [Secret-Rotation-Runbook](../Security/Secret-Rotation-Runbook.md) | ESLint `local-rules/env-validation` |
 
 ### MEDIUM Severity
 
@@ -100,6 +103,8 @@ Central registry of all project conventions with their documentation and enforce
 | Lambda Directory Naming | [Naming Conventions](../Conventions/Naming-Conventions.md) | Code review |
 | camelCase TypeScript File Naming | [Naming Conventions](../Conventions/Naming-Conventions.md) | Code review + MCP |
 | GraphRAG Synchronization | [GraphRAG Automation](../Infrastructure/GraphRAG-Automation.md) | GitHub Actions |
+| YouTube Cookie Rotation (30-60 days) | [Secret-Rotation-Runbook](../Security/Secret-Rotation-Runbook.md) | Auto-detection via 403 errors |
+| Document Secret Expiration Dates | [Secret-Rotation-Runbook](../Security/Secret-Rotation-Runbook.md) | Manual (runbook) |
 
 ---
 

--- a/docs/wiki/Security/Secret-Rotation-Runbook.md
+++ b/docs/wiki/Security/Secret-Rotation-Runbook.md
@@ -1,0 +1,235 @@
+# Secret Rotation Runbook
+
+This runbook documents all secrets used in the media downloader infrastructure, their rotation procedures, and expiration tracking.
+
+## Secret Inventory
+
+| Secret | Location | Rotation Frequency | Expiration | Owner |
+|--------|----------|-------------------|------------|-------|
+| Sign In With Apple Key | secrets.enc.yaml | As needed | No expiry | Apple Developer Account |
+| Better Auth Secret | secrets.enc.yaml | On compromise | No expiry | Generated |
+| APNS Signing Key | secrets.enc.yaml | Certificate renewal | 2027-01-03 | Apple Developer Account |
+| APNS Certificate | secrets.enc.yaml | Certificate renewal | 2027-01-03 | Apple Developer Account |
+| GitHub PAT | secrets.enc.yaml | 90 days recommended | Check GitHub | GitHub Account |
+| YouTube Cookies | layers/yt-dlp/cookies/ | 30-60 days | Auto-detected | Firefox Browser |
+
+## Expiration Calendar
+
+| Secret | Expiration Date | Reminder Date | Action Required |
+|--------|-----------------|---------------|-----------------|
+| APNS Signing Key | 2027-01-03 | 2026-12-01 | Renew in Apple Developer Portal |
+| APNS Certificate | 2027-01-03 | 2026-12-01 | Renew in Apple Developer Portal |
+| GitHub PAT | Varies | Check GitHub settings | Regenerate token |
+| YouTube Cookies | ~30-60 days | Auto-detected via 403 error | Run update script |
+
+---
+
+## Rotation Procedures
+
+### YouTube Cookies
+
+**Frequency**: Every 30-60 days, or when downloads fail with 403 errors.
+
+**Auto-detection**: The system automatically detects cookie expiration via 403 errors and creates a GitHub issue with priority label.
+
+**Procedure**:
+1. Log into YouTube in Firefox browser
+2. Close Firefox completely
+3. Run the update script:
+   ```bash
+   pnpm run update-cookies
+   ```
+4. Verify the cookies were extracted:
+   ```bash
+   cat layers/yt-dlp/cookies/youtube-cookies.txt | head -10
+   ```
+5. Deploy the updated layer:
+   ```bash
+   pnpm run deploy
+   ```
+
+**Troubleshooting**:
+- If extraction fails, ensure you're logged into YouTube in Firefox
+- Firefox must be completely closed during extraction
+- Check that yt-dlp is installed: `brew install yt-dlp`
+
+---
+
+### GitHub Personal Access Token
+
+**Frequency**: Every 90 days recommended, or immediately on suspected compromise.
+
+**Purpose**: Used for automated GitHub issue creation when errors occur.
+
+**Procedure**:
+1. Visit [GitHub Token Settings](https://github.com/settings/tokens)
+2. Create a new fine-grained personal access token:
+   - Repository access: Only select the target repository
+   - Permissions: Issues (Read and write)
+   - Expiration: 90 days
+3. Decrypt the secrets file:
+   ```bash
+   sops --decrypt secrets.enc.yaml > secrets.yaml
+   ```
+4. Update the token in `secrets.yaml`:
+   ```yaml
+   github:
+     issue:
+       token: github_pat_YOUR_NEW_TOKEN_HERE
+   ```
+5. Re-encrypt and deploy:
+   ```bash
+   pnpm run build-dependencies  # Auto-encrypts
+   pnpm run deploy
+   ```
+
+**Verification**:
+```bash
+# Test the token (replace with actual values)
+curl -H "Authorization: token YOUR_TOKEN" \
+     https://api.github.com/repos/OWNER/REPO/issues
+```
+
+---
+
+### APNS Certificates
+
+**Frequency**: Certificate renewal (current expiration: 2027-01-03)
+
+**Components**:
+- APNS Signing Key (P8 format) - for token-based authentication
+- APNS Certificate (PEM format) - for SNS platform application
+- APNS Private Key (PEM format) - for SNS platform application
+
+**Procedure**:
+1. Log into [Apple Developer Portal](https://developer.apple.com/account)
+2. Navigate to Certificates, Identifiers & Profiles
+3. Generate new APNS key/certificate as needed
+4. Download the new credentials
+5. Extract/convert as needed:
+   ```bash
+   # For P12 to PEM conversion
+   openssl pkcs12 -in certificate.p12 -out certificate.pem -clcerts -nokeys
+   openssl pkcs12 -in certificate.p12 -out privatekey.pem -nocerts -nodes
+   ```
+6. Update `secrets.yaml` with new values:
+   ```yaml
+   apns:
+     staging:
+       team: YOUR_TEAM_ID
+       keyId: YOUR_KEY_ID
+       signingKey: |
+         -----BEGIN PRIVATE KEY-----
+         YOUR_SIGNING_KEY_HERE
+         -----END PRIVATE KEY-----
+       privateKey: |
+         -----BEGIN PRIVATE KEY-----
+         YOUR_PRIVATE_KEY_HERE
+         -----END PRIVATE KEY-----
+       certificate: |
+         -----BEGIN CERTIFICATE-----
+         YOUR_CERTIFICATE_HERE
+         -----END CERTIFICATE-----
+   ```
+7. Re-encrypt and deploy:
+   ```bash
+   pnpm run build-dependencies
+   pnpm run deploy
+   ```
+
+**Verification**:
+- Send a test push notification to a registered device
+- Check CloudWatch logs for SendPushNotification Lambda
+
+---
+
+### Better Auth Secret
+
+**Frequency**: Only on suspected compromise.
+
+**Purpose**: Used for session token signing and encryption.
+
+**Impact**: Rotating this secret will invalidate ALL existing user sessions.
+
+**Procedure**:
+1. Generate a new random secret:
+   ```bash
+   openssl rand -base64 32
+   ```
+2. Update `secrets.yaml`:
+   ```yaml
+   platform:
+     key: 'YOUR_NEW_SECRET_HERE'
+   ```
+3. Re-encrypt and deploy:
+   ```bash
+   pnpm run build-dependencies
+   pnpm run deploy
+   ```
+
+**Post-rotation**:
+- All users will need to re-authenticate
+- Monitor authentication Lambda logs for issues
+
+---
+
+### Sign In With Apple Key
+
+**Frequency**: As needed (key rotation or suspected compromise).
+
+**Procedure**:
+1. Log into [Apple Developer Portal](https://developer.apple.com/account)
+2. Navigate to Keys section
+3. Create a new Sign In With Apple key
+4. Download the P8 key file
+5. Note the new Key ID
+6. Update `secrets.yaml`:
+   ```yaml
+   signInWithApple:
+     config: |
+       {"client_id":"YOUR_APP_ID","team_id":"YOUR_TEAM_ID","redirect_uri":"","key_id":"NEW_KEY_ID","scope":"email name"}
+     authKey: |
+       -----BEGIN PRIVATE KEY-----
+       CONTENTS_OF_P8_FILE
+       -----END PRIVATE KEY-----
+   ```
+7. Re-encrypt and deploy:
+   ```bash
+   pnpm run build-dependencies
+   pnpm run deploy
+   ```
+
+---
+
+## Emergency Rotation
+
+If a secret is suspected to be compromised:
+
+1. **Immediate**: Rotate the affected secret using procedures above
+2. **Deploy**: Push changes immediately with `pnpm run deploy`
+3. **Audit**: Check CloudWatch logs for unauthorized access
+4. **Notify**: Update team on incident
+
+---
+
+## Automation Status
+
+| Secret | Detection | Rotation | Notes |
+|--------|-----------|----------|-------|
+| YouTube Cookies | Automated (403 detection) | Manual | GitHub issue created automatically |
+| GitHub PAT | Manual | Manual | Set calendar reminder |
+| APNS Credentials | Manual | Manual | Set calendar reminder for 2026-12-01 |
+| Better Auth | Manual | Manual | Only rotate on compromise |
+| Sign In With Apple | Manual | Manual | Only rotate as needed |
+
+---
+
+## Related Documentation
+
+- [Security Audit Report](Security-Audit-Report.md)
+- [Vendor Encapsulation Policy](../Conventions/Vendor-Encapsulation-Policy.md)
+- [Lambda Environment Variables](../AWS/Lambda-Environment-Variables.md)
+
+---
+
+*Last updated: 2026-01-03*

--- a/docs/wiki/Security/Security-Audit-Report.md
+++ b/docs/wiki/Security/Security-Audit-Report.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-This security audit evaluated five critical areas of the codebase:
+This security audit evaluated six critical areas of the codebase:
 
 | Area | Status | Findings |
 |------|--------|----------|
@@ -17,6 +17,7 @@ This security audit evaluated five critical areas of the codebase:
 | IAM Policies | SECURE | Follows least privilege |
 | Authentication | SECURE | Properly implemented |
 | OWASP Top 10 | 4 ISSUES | 1 HIGH, 2 MEDIUM, 1 LOW |
+| Secret Rotation | NEEDS IMPROVEMENT | No automated rotation |
 
 ---
 
@@ -230,6 +231,46 @@ if (!parseResult.success) {
 
 ---
 
+## 6. Secret Rotation Assessment
+
+### Status: NEEDS IMPROVEMENT
+
+### Findings
+
+**Current State:**
+- All secrets properly encrypted with SOPS (AGE encryption)
+- No automated rotation for any secrets
+- Limited expiration tracking (only APNS has documented dates)
+
+**Secret Expiration Tracking:**
+
+| Secret | Expiration | Status |
+|--------|------------|--------|
+| APNS Signing Key | 2027-01-03 | Documented |
+| APNS Certificate | 2027-01-03 | Documented |
+| GitHub PAT | Varies | Check GitHub settings |
+| YouTube Cookies | ~30-60 days | Auto-detected via 403 errors |
+| Better Auth Secret | No expiry | Rotate on compromise only |
+| Sign In With Apple | No expiry | Rotate as needed |
+
+**Positive Observations:**
+- YouTube cookie expiration is automatically detected
+- GitHub issues are created when cookies expire
+- SOPS encryption prevents accidental secret exposure
+
+**Gaps Identified:**
+1. No calendar reminders for APNS certificate renewal
+2. GitHub PAT expiration not tracked
+3. No documentation for rotation procedures (now addressed)
+
+### Remediation
+
+1. **Created**: [Secret-Rotation-Runbook.md](Secret-Rotation-Runbook.md) with detailed procedures
+2. **Recommended**: Set calendar reminder for APNS renewal (2026-12-01)
+3. **Recommended**: Configure GitHub PAT with 90-day expiration
+
+---
+
 ## Recommendations Summary
 
 | Priority | Finding | Action |
@@ -237,6 +278,7 @@ if (!parseResult.success) {
 | HIGH | Remote test bypass | Add production guard |
 | MEDIUM | Wildcard CORS | Remove CORS headers |
 | MEDIUM | Dynamic function | Use safe interpolation |
+| MEDIUM | Secret rotation docs | Document procedures (DONE) |
 | LOW | SQS validation | Add Zod schemas |
 
 ---

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:mutation": "stryker run",
     "test:mutation:incremental": "stryker run --incremental",
     "test:mutation:auth": "stryker run --mutate 'src/lambdas/{ApiGatewayAuthorizer,LoginUser,RegisterUser,RefreshToken}/**/src/**/*.ts'",
+    "check-secrets": "./bin/check-secrets.sh",
     "validate:docs": "./bin/validate-docs.sh",
     "validate:doc-sync": "./bin/validate-doc-sync.sh",
     "audit:wiki": "./bin/audit-wiki-docs.sh",


### PR DESCRIPTION
## Summary

This PR adds comprehensive secrets management documentation and pre-commit protection as part of a security audit.

### Changes

- **New Files**:
  - `docs/wiki/Security/Secret-Rotation-Runbook.md` - Detailed rotation procedures for all secrets
  - `bin/check-secrets.sh` - Pre-commit hook to detect potential secret exposure

- **Updated Files**:
  - `docs/wiki/Security/Security-Audit-Report.md` - Added Section 6: Secret Rotation Assessment
  - `docs/wiki/Meta/Conventions-Tracking.md` - Added security conventions
  - `.husky/pre-commit` - Integrated secrets checking into pre-commit workflow
  - `package.json` - Added `check-secrets` npm script

### Secret Inventory Documented

| Secret | Storage | Rotation | Expiration |
|--------|---------|----------|------------|
| Sign In With Apple Key | SOPS | As needed | No expiry |
| Better Auth Secret | SOPS | On compromise | No expiry |
| APNS Signing Key | SOPS | Certificate renewal | 2027-01-03 |
| APNS Certificate | SOPS | Certificate renewal | 2027-01-03 |
| GitHub PAT | SOPS | 90 days recommended | Varies |
| YouTube Cookies | Lambda Layer | 30-60 days | Auto-detected |

### Security Conventions Added

| Convention | Severity | Enforcement |
|------------|----------|-------------|
| All Secrets Encrypted with SOPS | CRITICAL | .gitignore + pre-commit |
| Never Commit secrets.yaml | CRITICAL | .gitignore + pre-commit |
| Use getRequiredEnv() for Secret Access | HIGH | ESLint |
| YouTube Cookie Rotation (30-60 days) | MEDIUM | Auto-detection |
| Document Secret Expiration Dates | MEDIUM | Runbook |

### Pre-commit Hook Features

The new `check-secrets.sh` script detects:
- `secrets.yaml` being staged for commit
- Files in `secure/` directory
- YouTube cookie files
- `.env` files (except `.env.example`)
- Potential hardcoded secrets (API keys, AWS credentials, GitHub tokens)

## Test Plan

- [x] `pnpm run precheck` passes
- [x] `pnpm run validate:conventions` passes
- [x] `pnpm run test` passes (1140 tests)
- [x] `pnpm run check-secrets` works correctly
- [x] Pre-commit hook detects secrets.yaml if staged
- [x] CI passes on GitHub