### PR TITLE
feat(infrastructure): add AWS Device Farm E2E testing infrastructure

### DIFF
--- a/src/types/infrastructure.d.ts
+++ b/src/types/infrastructure.d.ts
@@ -15,6 +15,7 @@ export interface InfrastructureD {
     provider:  Provider;
     resource:  Resource;
     terraform: Terraform[];
+    variable:  Variable;
 }
 
 export interface Data {
@@ -64,8 +65,11 @@ export interface AwsIamPolicyDocument {
     UserDelete:                     PruneDevice[];
     UserSubscribe:                  RegisterDevice[];
     WebhookFeedly:                  APIGatewayAuthorizerInvocationElement[];
-    dsql_access:                    DsqlAAccess[];
-    dsql_admin_access:              DsqlAAccess[];
+    codepipeline_e2e_assume_role:   AssumeRole[];
+    codepipeline_e2e_device_farm:   CodepipelineE2EDeviceFarm[];
+    codepipeline_e2e_s3_access:     CodepipelineE2EDeviceFarm[];
+    dsql_access:                    CodepipelineE2EDeviceFarm[];
+    dsql_admin_access:              CodepipelineE2EDeviceFarm[];
 }
 
 export interface APIGatewayAuthorizerInvocationElement {
@@ -144,11 +148,11 @@ export interface AwsIamPolicyDocumentSendPushNotification {
     statement: Ent[];
 }
 
-export interface DsqlAAccess {
-    statement: DsqlAccessStatement[];
+export interface CodepipelineE2EDeviceFarm {
+    statement: CodepipelineE2EDeviceFarmStatement[];
 }
 
-export interface DsqlAccessStatement {
+export interface CodepipelineE2EDeviceFarmStatement {
     actions:   string[];
     resources: string[];
     sid:       string;
@@ -195,6 +199,7 @@ export interface Local {
     lambda_functions_api?:                  string[];
     lambda_functions_background?:           string[];
     device_event_function_name?:            string;
+    e2e_test_project_name?:                 string;
     download_queue_name?:                   string;
     download_queue_visibility_timeout?:     number;
     event_bus_name?:                        string;
@@ -240,10 +245,16 @@ export interface Output {
     cloudfront_distribution_domain: APIGatewayStage[];
     cloudfront_media_files_domain:  APIGatewayStage[];
     cloudwatch_dashboard_url:       APIGatewayStage[];
+    codepipeline_e2e_arn:           APIGatewayStage[];
+    codepipeline_e2e_console_url:   APIGatewayStage[];
+    device_farm_device_pool_arn:    APIGatewayStage[];
+    device_farm_project_arn:        APIGatewayStage[];
+    device_farm_project_id:         APIGatewayStage[];
     download_queue_arn:             APIGatewayStage[];
     download_queue_url:             APIGatewayStage[];
     dsql_cluster_arn:               APIGatewayStage[];
     dsql_cluster_endpoint:          APIGatewayStage[];
+    e2e_test_artifacts_bucket:      APIGatewayStage[];
     event_bus_arn:                  APIGatewayStage[];
     event_bus_name:                 APIGatewayStage[];
     idempotency_table_arn:          APIGatewayStage[];
@@ -287,6 +298,7 @@ export interface Resource {
     aws_api_gateway_stage:                           AwsAPIGatewayStage;
     aws_api_gateway_usage_plan:                      AwsAPIGatewayUsagePlan;
     aws_api_gateway_usage_plan_key:                  AwsAPIGatewayUsagePlanKey;
+    aws_budgets_budget:                              AwsBudgetsBudget;
     aws_cloudfront_distribution:                     AwsCloudfrontDistribution;
     aws_cloudfront_origin_access_control:            AwsCloudfrontOriginAccessControl;
     aws_cloudwatch_dashboard:                        AwsCloudwatchDashboard;
@@ -295,6 +307,9 @@ export interface Resource {
     aws_cloudwatch_event_target:                     AwsCloudwatchEventTarget;
     aws_cloudwatch_log_group:                        { [key: string]: AwsCloudwatchLogGroup[] };
     aws_cloudwatch_metric_alarm:                     AwsCloudwatchMetricAlarm;
+    aws_codepipeline:                                AwsCodepipeline;
+    aws_devicefarm_device_pool:                      AwsDevicefarmDevicePool;
+    aws_devicefarm_project:                          AwsDevicefarmProject;
     aws_dsql_cluster:                                AwsDsqlCluster;
     aws_dynamodb_table:                              AwsDynamodbTable;
     aws_iam_policy:                                  { [key: string]: AwsIamPolicy[] };
@@ -307,8 +322,11 @@ export interface Resource {
     aws_lambda_permission:                           { [key: string]: AwsLambdaPermission[] };
     aws_s3_bucket:                                   AwsS3Bucket;
     aws_s3_bucket_intelligent_tiering_configuration: AwsS3BucketIntelligentTieringConfiguration;
+    aws_s3_bucket_lifecycle_configuration:           AwsS3BucketLifecycleConfiguration;
     aws_s3_bucket_notification:                      AwsS3BucketNotification;
     aws_s3_bucket_policy:                            AwsS3BucketPolicy;
+    aws_s3_bucket_public_access_block:               AwsS3BucketPublicAccessBlock;
+    aws_s3_bucket_versioning:                        AwsS3BucketVersioning;
     aws_s3_object:                                   AwsS3Object;
     aws_sns_platform_application:                    AwsSnsPlatformApplication;
     aws_sns_topic:                                   AwsSnsTopic;
@@ -550,6 +568,36 @@ export interface AwsAPIGatewayUsagePlanKeyIOSApp {
     key_id:        string;
     key_type:      string;
     usage_plan_id: string;
+}
+
+export interface AwsBudgetsBudget {
+    device_farm: DeviceFarm[];
+}
+
+export interface DeviceFarm {
+    budget_type:       string;
+    cost_filter:       CostFilter[];
+    count:             string;
+    limit_amount:      string;
+    limit_unit:        string;
+    name:              string;
+    notification:      Notification[];
+    tags:              string;
+    time_period_start: string;
+    time_unit:         string;
+}
+
+export interface CostFilter {
+    name:   string;
+    values: string[];
+}
+
+export interface Notification {
+    comparison_operator:        string;
+    notification_type:          string;
+    subscriber_email_addresses: string[];
+    threshold:                  number;
+    threshold_type:             string;
 }
 
 export interface AwsCloudfrontDistribution {
@@ -826,6 +874,83 @@ export interface LambdaErrorsAPIMetricQuery {
     return_data: boolean;
 }
 
+export interface AwsCodepipeline {
+    ios_e2e_tests: AwsCodepipelineIosE2ETest[];
+}
+
+export interface AwsCodepipelineIosE2ETest {
+    artifact_store: ArtifactStore[];
+    name:           string;
+    pipeline_type:  string;
+    role_arn:       string;
+    stage:          Stage[];
+    tags:           string;
+}
+
+export interface ArtifactStore {
+    location: string;
+    type:     string;
+}
+
+export interface Stage {
+    action: ActionElement[];
+    name:   string;
+}
+
+export interface ActionElement {
+    category:          string;
+    configuration:     Configuration;
+    name:              string;
+    output_artifacts?: string[];
+    owner:             string;
+    provider:          string;
+    version:           string;
+    input_artifacts?:  string[];
+}
+
+export interface Configuration {
+    PollForSourceChanges?: string;
+    S3Bucket?:             string;
+    S3ObjectKey?:          string;
+    CustomData?:           string;
+    ExternalEntityLink?:   string;
+    App?:                  string;
+    AppType?:              string;
+    DevicePoolArn?:        string;
+    ProjectId?:            string;
+    Test?:                 string;
+    TestType?:             string;
+}
+
+export interface AwsDevicefarmDevicePool {
+    latest_iphone: LatestIphone[];
+}
+
+export interface LatestIphone {
+    description: string;
+    max_devices: number;
+    name:        string;
+    project_arn: string;
+    rule:        LatestIphoneRule[];
+    tags:        Tags;
+}
+
+export interface LatestIphoneRule {
+    attribute: string;
+    operator:  string;
+    value:     string;
+}
+
+export interface AwsDevicefarmProject {
+    ios_e2e_tests: AwsDevicefarmProjectIosE2ETest[];
+}
+
+export interface AwsDevicefarmProjectIosE2ETest {
+    default_job_timeout_minutes: number;
+    name:                        string;
+    tags:                        string;
+}
+
 export interface AwsDsqlCluster {
     media_downloader: MediaDownloaderElement[];
 }
@@ -998,13 +1123,13 @@ export interface Ffmpeg {
 }
 
 export interface AwsLambdaPermission {
-    action:        Action;
+    action:        ActionEnum;
     function_name: string;
     principal:     PrincipalEnum;
     source_arn?:   string;
 }
 
-export enum Action {
+export enum ActionEnum {
     LambdaInvokeFunction = "lambda:InvokeFunction",
 }
 
@@ -1015,12 +1140,13 @@ export enum PrincipalEnum {
 }
 
 export interface AwsS3Bucket {
-    Files: AwsS3BucketFile[];
+    Files:              File[];
+    e2e_test_artifacts: File[];
 }
 
-export interface AwsS3BucketFile {
+export interface File {
     bucket: string;
-    tags:   Tags;
+    tags:   string;
 }
 
 export interface AwsS3BucketIntelligentTieringConfiguration {
@@ -1036,6 +1162,35 @@ export interface FilesTiering {
 export interface Tiering {
     access_tier: string;
     days:        number;
+}
+
+export interface AwsS3BucketLifecycleConfiguration {
+    e2e_test_artifacts: AwsS3BucketLifecycleConfigurationE2ETestArtifact[];
+}
+
+export interface AwsS3BucketLifecycleConfigurationE2ETestArtifact {
+    bucket: string;
+    rule:   E2ETestArtifactRule[];
+}
+
+export interface E2ETestArtifactRule {
+    expiration:                     Expiration[];
+    filter:                         Filter[];
+    id:                             string;
+    noncurrent_version_expiration?: NoncurrentVersionExpiration[];
+    status:                         string;
+}
+
+export interface Expiration {
+    days: number;
+}
+
+export interface Filter {
+    prefix: string;
+}
+
+export interface NoncurrentVersionExpiration {
+    noncurrent_days: number;
 }
 
 export interface AwsS3BucketNotification {
@@ -1059,6 +1214,31 @@ export interface AwsS3BucketPolicy {
 export interface CloudfrontAccess {
     bucket: string;
     policy: string;
+}
+
+export interface AwsS3BucketPublicAccessBlock {
+    e2e_test_artifacts: AwsS3BucketPublicAccessBlockE2ETestArtifact[];
+}
+
+export interface AwsS3BucketPublicAccessBlockE2ETestArtifact {
+    block_public_acls:       boolean;
+    block_public_policy:     boolean;
+    bucket:                  string;
+    ignore_public_acls:      boolean;
+    restrict_public_buckets: boolean;
+}
+
+export interface AwsS3BucketVersioning {
+    e2e_test_artifacts: AwsS3BucketVersioningE2ETestArtifact[];
+}
+
+export interface AwsS3BucketVersioningE2ETestArtifact {
+    bucket:                   string;
+    versioning_configuration: VersioningConfiguration[];
+}
+
+export interface VersioningConfiguration {
+    status: string;
 }
 
 export interface AwsS3Object {
@@ -1184,6 +1364,16 @@ export interface RequiredProvider {
 export interface AwsClass {
     source:  string;
     version: string;
+}
+
+export interface Variable {
+    budget_notification_email: BudgetNotificationEmail[];
+}
+
+export interface BudgetNotificationEmail {
+    default:     string;
+    description: string;
+    type:        string;
 }
 
 // Converts JSON strings to/from your types
@@ -1358,6 +1548,7 @@ const typeMap: any = {
         { json: "provider", js: "provider", typ: r("Provider") },
         { json: "resource", js: "resource", typ: r("Resource") },
         { json: "terraform", js: "terraform", typ: a(r("Terraform")) },
+        { json: "variable", js: "variable", typ: r("Variable") },
     ], false),
     "Data": o([
         { json: "archive_file", js: "archive_file", typ: m(a(r("ArchiveFile"))) },
@@ -1398,8 +1589,11 @@ const typeMap: any = {
         { json: "UserDelete", js: "UserDelete", typ: a(r("PruneDevice")) },
         { json: "UserSubscribe", js: "UserSubscribe", typ: a(r("RegisterDevice")) },
         { json: "WebhookFeedly", js: "WebhookFeedly", typ: a(r("APIGatewayAuthorizerInvocationElement")) },
-        { json: "dsql_access", js: "dsql_access", typ: a(r("DsqlAAccess")) },
-        { json: "dsql_admin_access", js: "dsql_admin_access", typ: a(r("DsqlAAccess")) },
+        { json: "codepipeline_e2e_assume_role", js: "codepipeline_e2e_assume_role", typ: a(r("AssumeRole")) },
+        { json: "codepipeline_e2e_device_farm", js: "codepipeline_e2e_device_farm", typ: a(r("CodepipelineE2EDeviceFarm")) },
+        { json: "codepipeline_e2e_s3_access", js: "codepipeline_e2e_s3_access", typ: a(r("CodepipelineE2EDeviceFarm")) },
+        { json: "dsql_access", js: "dsql_access", typ: a(r("CodepipelineE2EDeviceFarm")) },
+        { json: "dsql_admin_access", js: "dsql_admin_access", typ: a(r("CodepipelineE2EDeviceFarm")) },
     ], false),
     "APIGatewayAuthorizerInvocationElement": o([
         { json: "statement", js: "statement", typ: a(r("Ent")) },
@@ -1461,10 +1655,10 @@ const typeMap: any = {
         { json: "dynamic", js: "dynamic", typ: r("PruneDeviceDynamic") },
         { json: "statement", js: "statement", typ: a(r("Ent")) },
     ], false),
-    "DsqlAAccess": o([
-        { json: "statement", js: "statement", typ: a(r("DsqlAccessStatement")) },
+    "CodepipelineE2EDeviceFarm": o([
+        { json: "statement", js: "statement", typ: a(r("CodepipelineE2EDeviceFarmStatement")) },
     ], false),
-    "DsqlAccessStatement": o([
+    "CodepipelineE2EDeviceFarmStatement": o([
         { json: "actions", js: "actions", typ: a("") },
         { json: "resources", js: "resources", typ: a("") },
         { json: "sid", js: "sid", typ: "" },
@@ -1502,6 +1696,7 @@ const typeMap: any = {
         { json: "lambda_functions_api", js: "lambda_functions_api", typ: u(undefined, a("")) },
         { json: "lambda_functions_background", js: "lambda_functions_background", typ: u(undefined, a("")) },
         { json: "device_event_function_name", js: "device_event_function_name", typ: u(undefined, "") },
+        { json: "e2e_test_project_name", js: "e2e_test_project_name", typ: u(undefined, "") },
         { json: "download_queue_name", js: "download_queue_name", typ: u(undefined, "") },
         { json: "download_queue_visibility_timeout", js: "download_queue_visibility_timeout", typ: u(undefined, 0) },
         { json: "event_bus_name", js: "event_bus_name", typ: u(undefined, "") },
@@ -1544,10 +1739,16 @@ const typeMap: any = {
         { json: "cloudfront_distribution_domain", js: "cloudfront_distribution_domain", typ: a(r("APIGatewayStage")) },
         { json: "cloudfront_media_files_domain", js: "cloudfront_media_files_domain", typ: a(r("APIGatewayStage")) },
         { json: "cloudwatch_dashboard_url", js: "cloudwatch_dashboard_url", typ: a(r("APIGatewayStage")) },
+        { json: "codepipeline_e2e_arn", js: "codepipeline_e2e_arn", typ: a(r("APIGatewayStage")) },
+        { json: "codepipeline_e2e_console_url", js: "codepipeline_e2e_console_url", typ: a(r("APIGatewayStage")) },
+        { json: "device_farm_device_pool_arn", js: "device_farm_device_pool_arn", typ: a(r("APIGatewayStage")) },
+        { json: "device_farm_project_arn", js: "device_farm_project_arn", typ: a(r("APIGatewayStage")) },
+        { json: "device_farm_project_id", js: "device_farm_project_id", typ: a(r("APIGatewayStage")) },
         { json: "download_queue_arn", js: "download_queue_arn", typ: a(r("APIGatewayStage")) },
         { json: "download_queue_url", js: "download_queue_url", typ: a(r("APIGatewayStage")) },
         { json: "dsql_cluster_arn", js: "dsql_cluster_arn", typ: a(r("APIGatewayStage")) },
         { json: "dsql_cluster_endpoint", js: "dsql_cluster_endpoint", typ: a(r("APIGatewayStage")) },
+        { json: "e2e_test_artifacts_bucket", js: "e2e_test_artifacts_bucket", typ: a(r("APIGatewayStage")) },
         { json: "event_bus_arn", js: "event_bus_arn", typ: a(r("APIGatewayStage")) },
         { json: "event_bus_name", js: "event_bus_name", typ: a(r("APIGatewayStage")) },
         { json: "idempotency_table_arn", js: "idempotency_table_arn", typ: a(r("APIGatewayStage")) },
@@ -1586,6 +1787,7 @@ const typeMap: any = {
         { json: "aws_api_gateway_stage", js: "aws_api_gateway_stage", typ: r("AwsAPIGatewayStage") },
         { json: "aws_api_gateway_usage_plan", js: "aws_api_gateway_usage_plan", typ: r("AwsAPIGatewayUsagePlan") },
         { json: "aws_api_gateway_usage_plan_key", js: "aws_api_gateway_usage_plan_key", typ: r("AwsAPIGatewayUsagePlanKey") },
+        { json: "aws_budgets_budget", js: "aws_budgets_budget", typ: r("AwsBudgetsBudget") },
         { json: "aws_cloudfront_distribution", js: "aws_cloudfront_distribution", typ: r("AwsCloudfrontDistribution") },
         { json: "aws_cloudfront_origin_access_control", js: "aws_cloudfront_origin_access_control", typ: r("AwsCloudfrontOriginAccessControl") },
         { json: "aws_cloudwatch_dashboard", js: "aws_cloudwatch_dashboard", typ: r("AwsCloudwatchDashboard") },
@@ -1594,6 +1796,9 @@ const typeMap: any = {
         { json: "aws_cloudwatch_event_target", js: "aws_cloudwatch_event_target", typ: r("AwsCloudwatchEventTarget") },
         { json: "aws_cloudwatch_log_group", js: "aws_cloudwatch_log_group", typ: m(a(r("AwsCloudwatchLogGroup"))) },
         { json: "aws_cloudwatch_metric_alarm", js: "aws_cloudwatch_metric_alarm", typ: r("AwsCloudwatchMetricAlarm") },
+        { json: "aws_codepipeline", js: "aws_codepipeline", typ: r("AwsCodepipeline") },
+        { json: "aws_devicefarm_device_pool", js: "aws_devicefarm_device_pool", typ: r("AwsDevicefarmDevicePool") },
+        { json: "aws_devicefarm_project", js: "aws_devicefarm_project", typ: r("AwsDevicefarmProject") },
         { json: "aws_dsql_cluster", js: "aws_dsql_cluster", typ: r("AwsDsqlCluster") },
         { json: "aws_dynamodb_table", js: "aws_dynamodb_table", typ: r("AwsDynamodbTable") },
         { json: "aws_iam_policy", js: "aws_iam_policy", typ: m(a(r("AwsIamPolicy"))) },
@@ -1606,8 +1811,11 @@ const typeMap: any = {
         { json: "aws_lambda_permission", js: "aws_lambda_permission", typ: m(a(r("AwsLambdaPermission"))) },
         { json: "aws_s3_bucket", js: "aws_s3_bucket", typ: r("AwsS3Bucket") },
         { json: "aws_s3_bucket_intelligent_tiering_configuration", js: "aws_s3_bucket_intelligent_tiering_configuration", typ: r("AwsS3BucketIntelligentTieringConfiguration") },
+        { json: "aws_s3_bucket_lifecycle_configuration", js: "aws_s3_bucket_lifecycle_configuration", typ: r("AwsS3BucketLifecycleConfiguration") },
         { json: "aws_s3_bucket_notification", js: "aws_s3_bucket_notification", typ: r("AwsS3BucketNotification") },
         { json: "aws_s3_bucket_policy", js: "aws_s3_bucket_policy", typ: r("AwsS3BucketPolicy") },
+        { json: "aws_s3_bucket_public_access_block", js: "aws_s3_bucket_public_access_block", typ: r("AwsS3BucketPublicAccessBlock") },
+        { json: "aws_s3_bucket_versioning", js: "aws_s3_bucket_versioning", typ: r("AwsS3BucketVersioning") },
         { json: "aws_s3_object", js: "aws_s3_object", typ: r("AwsS3Object") },
         { json: "aws_sns_platform_application", js: "aws_sns_platform_application", typ: r("AwsSnsPlatformApplication") },
         { json: "aws_sns_topic", js: "aws_sns_topic", typ: r("AwsSnsTopic") },
@@ -1800,6 +2008,32 @@ const typeMap: any = {
         { json: "key_id", js: "key_id", typ: "" },
         { json: "key_type", js: "key_type", typ: "" },
         { json: "usage_plan_id", js: "usage_plan_id", typ: "" },
+    ], false),
+    "AwsBudgetsBudget": o([
+        { json: "device_farm", js: "device_farm", typ: a(r("DeviceFarm")) },
+    ], false),
+    "DeviceFarm": o([
+        { json: "budget_type", js: "budget_type", typ: "" },
+        { json: "cost_filter", js: "cost_filter", typ: a(r("CostFilter")) },
+        { json: "count", js: "count", typ: "" },
+        { json: "limit_amount", js: "limit_amount", typ: "" },
+        { json: "limit_unit", js: "limit_unit", typ: "" },
+        { json: "name", js: "name", typ: "" },
+        { json: "notification", js: "notification", typ: a(r("Notification")) },
+        { json: "tags", js: "tags", typ: "" },
+        { json: "time_period_start", js: "time_period_start", typ: "" },
+        { json: "time_unit", js: "time_unit", typ: "" },
+    ], false),
+    "CostFilter": o([
+        { json: "name", js: "name", typ: "" },
+        { json: "values", js: "values", typ: a("") },
+    ], false),
+    "Notification": o([
+        { json: "comparison_operator", js: "comparison_operator", typ: "" },
+        { json: "notification_type", js: "notification_type", typ: "" },
+        { json: "subscriber_email_addresses", js: "subscriber_email_addresses", typ: a("") },
+        { json: "threshold", js: "threshold", typ: 0 },
+        { json: "threshold_type", js: "threshold_type", typ: "" },
     ], false),
     "AwsCloudfrontDistribution": o([
         { json: "MediaFiles", js: "MediaFiles", typ: a(r("MediaFile")) },
@@ -2034,6 +2268,72 @@ const typeMap: any = {
         { json: "label", js: "label", typ: "" },
         { json: "return_data", js: "return_data", typ: true },
     ], false),
+    "AwsCodepipeline": o([
+        { json: "ios_e2e_tests", js: "ios_e2e_tests", typ: a(r("AwsCodepipelineIosE2ETest")) },
+    ], false),
+    "AwsCodepipelineIosE2ETest": o([
+        { json: "artifact_store", js: "artifact_store", typ: a(r("ArtifactStore")) },
+        { json: "name", js: "name", typ: "" },
+        { json: "pipeline_type", js: "pipeline_type", typ: "" },
+        { json: "role_arn", js: "role_arn", typ: "" },
+        { json: "stage", js: "stage", typ: a(r("Stage")) },
+        { json: "tags", js: "tags", typ: "" },
+    ], false),
+    "ArtifactStore": o([
+        { json: "location", js: "location", typ: "" },
+        { json: "type", js: "type", typ: "" },
+    ], false),
+    "Stage": o([
+        { json: "action", js: "action", typ: a(r("ActionElement")) },
+        { json: "name", js: "name", typ: "" },
+    ], false),
+    "ActionElement": o([
+        { json: "category", js: "category", typ: "" },
+        { json: "configuration", js: "configuration", typ: r("Configuration") },
+        { json: "name", js: "name", typ: "" },
+        { json: "output_artifacts", js: "output_artifacts", typ: u(undefined, a("")) },
+        { json: "owner", js: "owner", typ: "" },
+        { json: "provider", js: "provider", typ: "" },
+        { json: "version", js: "version", typ: "" },
+        { json: "input_artifacts", js: "input_artifacts", typ: u(undefined, a("")) },
+    ], false),
+    "Configuration": o([
+        { json: "PollForSourceChanges", js: "PollForSourceChanges", typ: u(undefined, "") },
+        { json: "S3Bucket", js: "S3Bucket", typ: u(undefined, "") },
+        { json: "S3ObjectKey", js: "S3ObjectKey", typ: u(undefined, "") },
+        { json: "CustomData", js: "CustomData", typ: u(undefined, "") },
+        { json: "ExternalEntityLink", js: "ExternalEntityLink", typ: u(undefined, "") },
+        { json: "App", js: "App", typ: u(undefined, "") },
+        { json: "AppType", js: "AppType", typ: u(undefined, "") },
+        { json: "DevicePoolArn", js: "DevicePoolArn", typ: u(undefined, "") },
+        { json: "ProjectId", js: "ProjectId", typ: u(undefined, "") },
+        { json: "Test", js: "Test", typ: u(undefined, "") },
+        { json: "TestType", js: "TestType", typ: u(undefined, "") },
+    ], false),
+    "AwsDevicefarmDevicePool": o([
+        { json: "latest_iphone", js: "latest_iphone", typ: a(r("LatestIphone")) },
+    ], false),
+    "LatestIphone": o([
+        { json: "description", js: "description", typ: "" },
+        { json: "max_devices", js: "max_devices", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+        { json: "project_arn", js: "project_arn", typ: "" },
+        { json: "rule", js: "rule", typ: a(r("LatestIphoneRule")) },
+        { json: "tags", js: "tags", typ: r("Tags") },
+    ], false),
+    "LatestIphoneRule": o([
+        { json: "attribute", js: "attribute", typ: "" },
+        { json: "operator", js: "operator", typ: "" },
+        { json: "value", js: "value", typ: "" },
+    ], false),
+    "AwsDevicefarmProject": o([
+        { json: "ios_e2e_tests", js: "ios_e2e_tests", typ: a(r("AwsDevicefarmProjectIosE2ETest")) },
+    ], false),
+    "AwsDevicefarmProjectIosE2ETest": o([
+        { json: "default_job_timeout_minutes", js: "default_job_timeout_minutes", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+        { json: "tags", js: "tags", typ: "" },
+    ], false),
     "AwsDsqlCluster": o([
         { json: "media_downloader", js: "media_downloader", typ: a(r("MediaDownloaderElement")) },
     ], false),
@@ -2162,17 +2462,18 @@ const typeMap: any = {
         { json: "source_code_hash", js: "source_code_hash", typ: "" },
     ], false),
     "AwsLambdaPermission": o([
-        { json: "action", js: "action", typ: r("Action") },
+        { json: "action", js: "action", typ: r("ActionEnum") },
         { json: "function_name", js: "function_name", typ: "" },
         { json: "principal", js: "principal", typ: r("PrincipalEnum") },
         { json: "source_arn", js: "source_arn", typ: u(undefined, "") },
     ], false),
     "AwsS3Bucket": o([
-        { json: "Files", js: "Files", typ: a(r("AwsS3BucketFile")) },
+        { json: "Files", js: "Files", typ: a(r("File")) },
+        { json: "e2e_test_artifacts", js: "e2e_test_artifacts", typ: a(r("File")) },
     ], false),
-    "AwsS3BucketFile": o([
+    "File": o([
         { json: "bucket", js: "bucket", typ: "" },
-        { json: "tags", js: "tags", typ: r("Tags") },
+        { json: "tags", js: "tags", typ: "" },
     ], false),
     "AwsS3BucketIntelligentTieringConfiguration": o([
         { json: "FilesTiering", js: "FilesTiering", typ: a(r("FilesTiering")) },
@@ -2185,6 +2486,29 @@ const typeMap: any = {
     "Tiering": o([
         { json: "access_tier", js: "access_tier", typ: "" },
         { json: "days", js: "days", typ: 0 },
+    ], false),
+    "AwsS3BucketLifecycleConfiguration": o([
+        { json: "e2e_test_artifacts", js: "e2e_test_artifacts", typ: a(r("AwsS3BucketLifecycleConfigurationE2ETestArtifact")) },
+    ], false),
+    "AwsS3BucketLifecycleConfigurationE2ETestArtifact": o([
+        { json: "bucket", js: "bucket", typ: "" },
+        { json: "rule", js: "rule", typ: a(r("E2ETestArtifactRule")) },
+    ], false),
+    "E2ETestArtifactRule": o([
+        { json: "expiration", js: "expiration", typ: a(r("Expiration")) },
+        { json: "filter", js: "filter", typ: a(r("Filter")) },
+        { json: "id", js: "id", typ: "" },
+        { json: "noncurrent_version_expiration", js: "noncurrent_version_expiration", typ: u(undefined, a(r("NoncurrentVersionExpiration"))) },
+        { json: "status", js: "status", typ: "" },
+    ], false),
+    "Expiration": o([
+        { json: "days", js: "days", typ: 0 },
+    ], false),
+    "Filter": o([
+        { json: "prefix", js: "prefix", typ: "" },
+    ], false),
+    "NoncurrentVersionExpiration": o([
+        { json: "noncurrent_days", js: "noncurrent_days", typ: 0 },
     ], false),
     "AwsS3BucketNotification": o([
         { json: "Files", js: "Files", typ: a(r("AwsS3BucketNotificationFile")) },
@@ -2203,6 +2527,26 @@ const typeMap: any = {
     "CloudfrontAccess": o([
         { json: "bucket", js: "bucket", typ: "" },
         { json: "policy", js: "policy", typ: "" },
+    ], false),
+    "AwsS3BucketPublicAccessBlock": o([
+        { json: "e2e_test_artifacts", js: "e2e_test_artifacts", typ: a(r("AwsS3BucketPublicAccessBlockE2ETestArtifact")) },
+    ], false),
+    "AwsS3BucketPublicAccessBlockE2ETestArtifact": o([
+        { json: "block_public_acls", js: "block_public_acls", typ: true },
+        { json: "block_public_policy", js: "block_public_policy", typ: true },
+        { json: "bucket", js: "bucket", typ: "" },
+        { json: "ignore_public_acls", js: "ignore_public_acls", typ: true },
+        { json: "restrict_public_buckets", js: "restrict_public_buckets", typ: true },
+    ], false),
+    "AwsS3BucketVersioning": o([
+        { json: "e2e_test_artifacts", js: "e2e_test_artifacts", typ: a(r("AwsS3BucketVersioningE2ETestArtifact")) },
+    ], false),
+    "AwsS3BucketVersioningE2ETestArtifact": o([
+        { json: "bucket", js: "bucket", typ: "" },
+        { json: "versioning_configuration", js: "versioning_configuration", typ: a(r("VersioningConfiguration")) },
+    ], false),
+    "VersioningConfiguration": o([
+        { json: "status", js: "status", typ: "" },
     ], false),
     "AwsS3Object": o([
         { json: "DefaultFile", js: "DefaultFile", typ: a(r("AwsS3ObjectDefaultFile")) },
@@ -2307,6 +2651,14 @@ const typeMap: any = {
         { json: "source", js: "source", typ: "" },
         { json: "version", js: "version", typ: "" },
     ], false),
+    "Variable": o([
+        { json: "budget_notification_email", js: "budget_notification_email", typ: a(r("BudgetNotificationEmail")) },
+    ], false),
+    "BudgetNotificationEmail": o([
+        { json: "default", js: "default", typ: "" },
+        { json: "description", js: "description", typ: "" },
+        { json: "type", js: "type", typ: "" },
+    ], false),
     "Type": [
         "zip",
     ],
@@ -2340,7 +2692,7 @@ const typeMap: any = {
     "Mode": [
         "Active",
     ],
-    "Action": [
+    "ActionEnum": [
         "lambda:InvokeFunction",
     ],
     "PrincipalEnum": [

--- a/terraform/device_farm.tf
+++ b/terraform/device_farm.tf
@@ -1,0 +1,372 @@
+# =============================================================================
+# AWS DEVICE FARM E2E TESTING INFRASTRUCTURE
+# =============================================================================
+# Provides end-to-end testing for iOS app on real devices via AWS Device Farm.
+# Uses CodePipeline for orchestration with manual trigger for cost control.
+#
+# Cost optimization:
+# - Single device pool (max_devices = 1)
+# - Manual trigger only (no automatic polling)
+# - 30-minute timeout prevents runaway tests
+# - S3 lifecycle rules for artifact cleanup
+# - AWS Budgets alert at $50/month
+#
+# Estimated cost: ~$10-26/month for 4-10 test runs (15 min each)
+
+locals {
+  e2e_test_project_name = "media-downloader-ios-e2e"
+}
+
+# -----------------------------------------------------------------------------
+# Device Farm Project
+# -----------------------------------------------------------------------------
+
+resource "aws_devicefarm_project" "ios_e2e_tests" {
+  name                        = local.e2e_test_project_name
+  default_job_timeout_minutes = 30
+
+  tags = merge(local.common_tags, {
+    Component   = "E2E-Testing"
+    Description = "iOS E2E testing for media downloader app"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Device Pool - Single Latest iPhone
+# -----------------------------------------------------------------------------
+
+resource "aws_devicefarm_device_pool" "latest_iphone" {
+  name        = "LatestIPhone-SingleDevice"
+  project_arn = aws_devicefarm_project.ios_e2e_tests.arn
+  description = "Single latest iPhone device for cost-effective E2E testing"
+
+  max_devices = 1
+
+  rule {
+    attribute = "PLATFORM"
+    operator  = "EQUALS"
+    value     = "\"IOS\""
+  }
+
+  rule {
+    attribute = "MANUFACTURER"
+    operator  = "EQUALS"
+    value     = "\"Apple\""
+  }
+
+  # Target iPhone 15 Pro or newer
+  rule {
+    attribute = "MODEL"
+    operator  = "CONTAINS"
+    value     = "\"iPhone 15 Pro\""
+  }
+
+  # iOS 17.0 or newer
+  rule {
+    attribute = "OS_VERSION"
+    operator  = "GREATER_THAN_OR_EQUALS"
+    value     = "\"17.0\""
+  }
+
+  rule {
+    attribute = "AVAILABILITY"
+    operator  = "EQUALS"
+    value     = "\"AVAILABLE\""
+  }
+
+  tags = local.common_tags
+}
+
+# -----------------------------------------------------------------------------
+# S3 Bucket for Test Artifacts
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "e2e_test_artifacts" {
+  bucket = "media-downloader-e2e-artifacts-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(local.common_tags, {
+    Component = "E2E-Testing"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "e2e_test_artifacts" {
+  bucket = aws_s3_bucket.e2e_test_artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "e2e_test_artifacts" {
+  bucket = aws_s3_bucket.e2e_test_artifacts.id
+
+  rule {
+    id     = "cleanup-old-test-artifacts"
+    status = "Enabled"
+
+    filter {
+      prefix = "builds/"
+    }
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+
+  rule {
+    id     = "cleanup-test-results"
+    status = "Enabled"
+
+    filter {
+      prefix = "results/"
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "e2e_test_artifacts" {
+  bucket = aws_s3_bucket.e2e_test_artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -----------------------------------------------------------------------------
+# IAM Role for CodePipeline
+# -----------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "codepipeline_e2e_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["codepipeline.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "codepipeline_e2e" {
+  name               = "codepipeline-e2e-service-role"
+  assume_role_policy = data.aws_iam_policy_document.codepipeline_e2e_assume_role.json
+
+  tags = local.common_tags
+}
+
+# S3 Access Policy for CodePipeline
+data "aws_iam_policy_document" "codepipeline_e2e_s3_access" {
+  statement {
+    sid = "S3Access"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetBucketVersioning",
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      aws_s3_bucket.e2e_test_artifacts.arn,
+      "${aws_s3_bucket.e2e_test_artifacts.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "codepipeline_e2e_s3" {
+  name   = "s3-access"
+  role   = aws_iam_role.codepipeline_e2e.id
+  policy = data.aws_iam_policy_document.codepipeline_e2e_s3_access.json
+}
+
+# Device Farm Access Policy for CodePipeline
+data "aws_iam_policy_document" "codepipeline_e2e_device_farm" {
+  statement {
+    sid = "DeviceFarmAccess"
+    actions = [
+      "devicefarm:ListProjects",
+      "devicefarm:ListDevicePools",
+      "devicefarm:GetRun",
+      "devicefarm:GetUpload",
+      "devicefarm:CreateUpload",
+      "devicefarm:ScheduleRun",
+      "devicefarm:ListArtifacts",
+      "devicefarm:GetDevice",
+      "devicefarm:ListDevices"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "codepipeline_e2e_device_farm" {
+  name   = "device-farm-access"
+  role   = aws_iam_role.codepipeline_e2e.id
+  policy = data.aws_iam_policy_document.codepipeline_e2e_device_farm.json
+}
+
+# -----------------------------------------------------------------------------
+# CodePipeline for E2E Testing
+# -----------------------------------------------------------------------------
+
+resource "aws_codepipeline" "ios_e2e_tests" {
+  name          = "ios-e2e-test-pipeline"
+  role_arn      = aws_iam_role.codepipeline_e2e.arn
+  pipeline_type = "V2"
+
+  artifact_store {
+    location = aws_s3_bucket.e2e_test_artifacts.bucket
+    type     = "S3"
+  }
+
+  # Source Stage: S3
+  stage {
+    name = "Source"
+
+    action {
+      name             = "S3-Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "S3"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        S3Bucket             = aws_s3_bucket.e2e_test_artifacts.bucket
+        S3ObjectKey          = "builds/ios-app.zip"
+        PollForSourceChanges = "false"
+      }
+    }
+  }
+
+  # Approval Stage: Manual Gate
+  stage {
+    name = "Approval"
+
+    action {
+      name     = "Manual-Approval"
+      category = "Approval"
+      owner    = "AWS"
+      provider = "Manual"
+      version  = "1"
+
+      configuration = {
+        CustomData         = "Approve to run E2E tests on iOS device. Estimated cost: $2.55 (15 min @ $0.17/min)"
+        ExternalEntityLink = "https://console.aws.amazon.com/devicefarm/home?region=us-west-2#/projects/${split("/", aws_devicefarm_project.ios_e2e_tests.arn)[1]}"
+      }
+    }
+  }
+
+  # Test Stage: Device Farm
+  stage {
+    name = "Test"
+
+    action {
+      name            = "Device-Farm-Test"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "DeviceFarm"
+      version         = "1"
+      input_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        AppType       = "iOS"
+        ProjectId     = split("/", aws_devicefarm_project.ios_e2e_tests.arn)[1]
+        App           = "app.ipa"
+        TestType      = "XCTEST_UI"
+        Test          = "tests.zip"
+        DevicePoolArn = aws_devicefarm_device_pool.latest_iphone.arn
+      }
+    }
+  }
+
+  tags = merge(local.common_tags, {
+    Component = "E2E-Testing"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# AWS Budgets Alert for Cost Monitoring
+# -----------------------------------------------------------------------------
+
+variable "budget_notification_email" {
+  description = "Email address for budget notifications"
+  type        = string
+  default     = ""
+}
+
+resource "aws_budgets_budget" "device_farm" {
+  count = var.budget_notification_email != "" ? 1 : 0
+
+  name              = "device-farm-e2e-testing"
+  budget_type       = "COST"
+  limit_amount      = "50"
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start = "2025-01-01_00:00"
+
+  cost_filter {
+    name   = "Service"
+    values = ["AWS Device Farm"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.budget_notification_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.budget_notification_email]
+  }
+
+  tags = merge(local.common_tags, {
+    Component = "E2E-Testing"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+
+output "device_farm_project_arn" {
+  description = "ARN of the Device Farm project"
+  value       = aws_devicefarm_project.ios_e2e_tests.arn
+}
+
+output "device_farm_project_id" {
+  description = "ID of the Device Farm project"
+  value       = split("/", aws_devicefarm_project.ios_e2e_tests.arn)[1]
+}
+
+output "device_farm_device_pool_arn" {
+  description = "ARN of the device pool"
+  value       = aws_devicefarm_device_pool.latest_iphone.arn
+}
+
+output "e2e_test_artifacts_bucket" {
+  description = "S3 bucket for test artifacts"
+  value       = aws_s3_bucket.e2e_test_artifacts.bucket
+}
+
+output "codepipeline_e2e_arn" {
+  description = "ARN of the E2E test pipeline"
+  value       = aws_codepipeline.ios_e2e_tests.arn
+}
+
+output "codepipeline_e2e_console_url" {
+  description = "URL to the CodePipeline console"
+  value       = "https://console.aws.amazon.com/codesuite/codepipeline/pipelines/${aws_codepipeline.ios_e2e_tests.name}/view?region=us-west-2"
+}


### PR DESCRIPTION
## Summary

Implements AWS Device Farm end-to-end testing infrastructure for iOS app testing against the production backend. This enables automated testing on real iOS devices with manual trigger for cost control.

- Add Device Farm project and single-device pool (latest iPhone)
- Add S3 bucket for test artifacts with lifecycle rules
- Add CodePipeline V2 with manual trigger (no automatic polling)
- Add IAM policies for CodePipeline to access Device Farm and S3
- Add optional AWS Budgets alert for cost monitoring

## Architecture

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         E2E Testing Architecture                            │
├─────────────────────────────────────────────────────────────────────────────┤
│   ┌──────────────┐         ┌───────────────┐         ┌──────────────────┐   │
│   │   GitHub     │ ───────▶│ AWS CodePipeline │─────▶│  AWS Device Farm │   │
│   │  (iOS App)   │ manual  │   (us-west-2)  │        │   (us-west-2)    │   │
│   └──────────────┘ trigger └───────────────┘        └────────┬─────────┘   │
│                                   │                          │              │
│                                   ▼                          ▼              │
│                         ┌───────────────┐          ┌──────────────────┐    │
│                         │  S3 Bucket    │          │  iPhone 15 Pro   │    │
│                         │ (Test IPAs)   │          │  (Latest iOS)    │    │
│                         └───────────────┘          └────────┬─────────┘    │
│                                                             │               │
│                                                             ▼               │
│   ┌─────────────────────────────────────────────────────────────────────┐  │
│   │                    Production Backend (us-west-2)                    │  │
│   │  API Gateway ──▶ Lambda Functions ──▶ Aurora DSQL                    │  │
│   └─────────────────────────────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Resources Created

| Resource | Name | Purpose |
|----------|------|---------|
| `aws_devicefarm_project` | `media-downloader-ios-e2e` | E2E testing project |
| `aws_devicefarm_device_pool` | `LatestIPhone-SingleDevice` | Single iPhone 15 Pro, max_devices=1 |
| `aws_s3_bucket` | `media-downloader-e2e-artifacts-*` | Test artifacts with 30/90-day lifecycle |
| `aws_codepipeline` | `ios-e2e-test-pipeline` | V2 pipeline with manual trigger |
| `aws_iam_role` | `codepipeline-e2e-service-role` | CodePipeline access to S3 and Device Farm |
| `aws_budgets_budget` | `device-farm-e2e-testing` | Optional $50/month alert (requires email variable) |

## Cost Analysis

### Pay-As-You-Go Pricing

| Component | Unit Cost | Notes |
|-----------|-----------|-------|
| Device Farm Testing | $0.17/device minute | 1,000 min free (one-time) |
| CodePipeline V2 | $0.002/action minute | 100 min/month free |
| S3 Storage | $0.023/GB/month | Minimal usage |

### Cost Scenarios

| Scenario | Runs/Month | Monthly Cost | Annual Cost |
|----------|------------|--------------|-------------|
| Pre-Release Only | 1 | ~$1 | ~$14 |
| Sprint Testing | 4 | ~$10 | ~$124 |
| Heavy Development | 20 | ~$51 | ~$617 |

**Recommendation:** Target 4-10 runs/month (~$10-26/month)

## Cost Optimization Features

- ✅ Single device pool (`max_devices = 1`)
- ✅ Manual trigger only (`PollForSourceChanges = false`)
- ✅ 30-minute job timeout prevents runaway tests
- ✅ S3 lifecycle rules (30-day artifact expiration)
- ✅ Optional AWS Budgets alert at $50/month

## Test Plan

- [ ] Run `tofu plan` to verify infrastructure changes
- [ ] Run `tofu apply` to create resources
- [ ] Verify Device Farm project in AWS Console
- [ ] Verify S3 bucket created with correct lifecycle rules
- [ ] Verify CodePipeline created with correct stages
- [ ] Upload test IPA and trigger pipeline manually
- [ ] Verify test runs on Device Farm

## Usage

### Trigger Pipeline Manually

```bash
aws codepipeline start-pipeline-execution     --name ios-e2e-test-pipeline     --region us-west-2
```

### Enable Budget Alerts

Add to `terraform.tfvars`:
```hcl
budget_notification_email = "your-email@example.com"
```

## Related Issues

Closes #320

## iOS App Integration

See related iOS issue: https://github.com/j0nathan-ll0yd/ios-OfflineMediaDownloader/issues/20

The iOS app will need:
- XCUITest target with accessibility identifiers
- Build scripts for Device Farm
- Test cases for authentication, file list, and settings