### PR TITLE
fix(ci): add generate-graph step to auto-update-graphrag workflow

### DIFF
--- a/.github/workflows/auto-update-graphrag.yml
+++ b/.github/workflows/auto-update-graphrag.yml
@@ -20,6 +20,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
+      - name: Generate dependency graph
+        run: pnpm run generate-graph
+
       - name: Update GraphRAG knowledge graph
         run: pnpm run graphrag:extract
 


### PR DESCRIPTION
## Summary
- Fix failing auto-update-graphrag GitHub Actions workflow
- Add missing `generate-graph` step before `graphrag:extract`

## Problem
The [auto-update-graphrag workflow](https://github.com/j0nathan-ll0yd/aws-cloudformation-media-downloader/actions/workflows/auto-update-graphrag.yml) has been failing on every run since January 2, 2026 with:

```
Error: ENOENT: no such file or directory, open '.../build/graph.json'
```

**Root cause:** The `graphrag:extract` script requires `build/graph.json` which is gitignored and must be generated by running `pnpm run generate-graph` first. The workflow was missing this step.

## Solution
Add `pnpm run generate-graph` step before the GraphRAG extraction step in the workflow:

```yaml
- name: Generate dependency graph
  run: pnpm run generate-graph

- name: Update GraphRAG knowledge graph
  run: pnpm run graphrag:extract
```

## Test Plan
- [x] Convention validation passes (`pnpm run validate:conventions`)
- [x] Precheck passes (`pnpm run precheck`)
- [x] CI pipeline passes
- [x] auto-update-graphrag workflow runs successfully on merge