### PR TITLE
fix: update stale documentation paths and imports

### DIFF
--- a/docs/wiki/AWS/X-Ray-Integration.md
+++ b/docs/wiki/AWS/X-Ray-Integration.md
@@ -54,12 +54,12 @@ Use `withPowertools` wrapper for observability (handles logging, metrics):
 ```typescript
 import {withPowertools} from '#lib/lambda/middleware/powertools'
 import {wrapApiHandler} from '#lib/lambda/middleware/api'
-import {response} from '#util/lambda-helpers'
+import {buildValidatedResponse} from '#lib/lambda/responses'
 
 export const handler = withPowertools(wrapApiHandler(async ({event, context, metadata}) => {
   // metadata.traceId available for correlation
   // ADOT automatically traces AWS SDK calls
-  return response(context, 200, data)
+  return buildValidatedResponse(context, 200, data)
 }))
 ```
 

--- a/docs/wiki/Bash/Script-Index.md
+++ b/docs/wiki/Bash/Script-Index.md
@@ -55,7 +55,6 @@ Complete reference for all shell scripts in the project.
 |--------|---------|-------|
 | `bin/aws-audit.sh` | Comprehensive AWS infrastructure audit | `./bin/aws-audit.sh` |
 | `bin/auto-update-graphrag.sh` | Auto-update knowledge graph | `./bin/auto-update-graphrag.sh` |
-| `bin/sync-examples.sh` | Sync example configurations | `./bin/sync-examples.sh` |
 
 ## Script Details
 

--- a/docs/wiki/Conventions/Database-Migrations.md
+++ b/docs/wiki/Conventions/Database-Migrations.md
@@ -103,7 +103,7 @@ CREATE TABLE user_files (
 );
 ```
 
-Use application-layer validation in `src/lib/vendor/Drizzle/fk-enforcement.ts`.
+Use application-layer validation in `src/lib/vendor/Drizzle/fkEnforcement.ts`.
 
 ## Integration Testing
 

--- a/docs/wiki/Conventions/Import-Organization.md
+++ b/docs/wiki/Conventions/Import-Organization.md
@@ -36,13 +36,14 @@ Imports must follow this exact order with **NO blank lines between groups**:
 ```typescript
 import {randomUUID} from 'node:crypto'
 import type {APIGatewayProxyResult, Context} from 'aws-lambda'
-import {Files} from '#entities/Files'
-import {UserFiles} from '#entities/UserFiles'
+import {getFilesForUser, createUserFile} from '#entities/queries'
 import {sendMessage} from '#lib/vendor/AWS/SQS'
+import {withPowertools} from '#lib/lambda/middleware/powertools'
+import {wrapAuthenticatedHandler} from '#lib/lambda/middleware/api'
+import {buildValidatedResponse} from '#lib/lambda/responses'
 import type {File} from '#types/domainModels'
 import {FileStatus} from '#types/enums'
-import {buildApiResponse, withPowertools, wrapAuthenticatedHandler} from '#util/lambda-helpers'
-import {logDebug, logInfo} from '#util/logging'
+import {logDebug, logInfo} from '#lib/system/logging'
 ```
 
 Note: All imports in a single contiguous block with no blank lines.

--- a/docs/wiki/Conventions/Vendor-Encapsulation-Policy.md
+++ b/docs/wiki/Conventions/Vendor-Encapsulation-Policy.md
@@ -7,7 +7,7 @@
 
 ## The Rule
 
-**NEVER import third-party libraries directly in Lambda handlers or business logic. Always use vendor wrappers in `lib/vendor/`.**
+**NEVER import third-party libraries directly in Lambda handlers or business logic. Always use vendor wrappers in `src/lib/vendor/`.**
 
 This applies to:
 - AWS SDK (`@aws-sdk/*`)
@@ -20,10 +20,10 @@ This applies to:
 
 | Library | Wrapper Location | Purpose |
 |---------|------------------|---------|
-| AWS SDK | `lib/vendor/AWS/` | S3, DynamoDB, SNS, SQS, Lambda |
-| Drizzle ORM | `lib/vendor/Drizzle/` | Aurora DSQL database access |
-| Better Auth | `lib/vendor/BetterAuth/` | Authentication framework |
-| yt-dlp | `lib/vendor/YouTube.ts` | Video download wrapper |
+| AWS SDK | `src/lib/vendor/AWS/` | S3, DynamoDB, SNS, SQS, Lambda |
+| Drizzle ORM | `src/lib/vendor/Drizzle/` | Aurora DSQL database access |
+| Better Auth | `src/lib/vendor/BetterAuth/` | Authentication framework |
+| yt-dlp | `src/lib/vendor/YouTube.ts` | Video download wrapper |
 
 ## Examples
 
@@ -100,7 +100,7 @@ import {users, files} from '#lib/vendor/Drizzle/schema'
 import {eq, and} from '#lib/vendor/Drizzle/types'
 
 // FK checks: Import foreign key enforcement
-import {assertUserExists} from '#lib/vendor/Drizzle/fk-enforcement'
+import {assertUserExists} from '#lib/vendor/Drizzle/fkEnforcement'
 ```
 
 #### Type Utilities
@@ -124,7 +124,7 @@ type UpdateUserInput = Partial<Omit<InsertModel<typeof users>, 'userId'>>
 ## Vendor Wrapper Pattern
 
 ```typescript
-// lib/vendor/AWS/S3.ts
+// src/lib/vendor/AWS/S3.ts
 import {S3Client, PutObjectCommand} from '@aws-sdk/client-s3'
 import {captureAWSClient} from './XRay'
 
@@ -184,7 +184,7 @@ jest.unstable_mockModule('#lib/vendor/AWS/S3', () => ({
 
 ## Adding New Vendors
 
-1. Create wrapper in `lib/vendor/{VendorName}/`
+1. Create wrapper in `src/lib/vendor/{VendorName}/`
 2. Implement lazy initialization pattern
 3. Add environment detection if needed
 4. Add X-Ray instrumentation for AWS services

--- a/docs/wiki/MCP/Auto-Fix.md
+++ b/docs/wiki/MCP/Auto-Fix.md
@@ -82,7 +82,7 @@ return buildApiResponse(200, {data})
 const config = process.env.CONFIG
 
 // With this:
-import {getRequiredEnv} from '#util/env-validation'
+import {getRequiredEnv} from '#lib/system/env'
 const config = getRequiredEnv('CONFIG')
 ```
 
@@ -95,7 +95,7 @@ const config = getRequiredEnv('CONFIG')
 **Guidance**:
 ```typescript
 // Wrap handler with:
-import {withPowertools} from '#util/lambda-helpers'
+import {withPowertools} from '#lib/lambda/middleware/powertools'
 
 export const handler = withPowertools(async (event, context) => {
   // Handler logic

--- a/docs/wiki/Meta/Documentation-Coverage-Matrix.md
+++ b/docs/wiki/Meta/Documentation-Coverage-Matrix.md
@@ -67,7 +67,7 @@ All 18 Lambda functions have TSDoc comments in their handlers. Wiki references a
 
 | File | Purpose | TSDoc | Wiki Page |
 |------|---------|-------|-----------|
-| circuit-breaker.ts | Resilience pattern | Yes | Resilience-Patterns (partial) |
+| circuitBreaker.ts | Resilience pattern | Yes | Resilience-Patterns (partial) |
 | retry.ts | Retry utilities | Yes | None (GAP) |
 | errors.ts | Error types | Yes | TypeScript-Error-Handling (partial) |
 | env.ts | Environment utilities | Yes | Lambda-Environment-Variables (partial) |

--- a/docs/wiki/Testing/Mocking-Patterns-Analysis.md
+++ b/docs/wiki/Testing/Mocking-Patterns-Analysis.md
@@ -89,31 +89,33 @@ vi.mocked(updateFileDownload).mockResolvedValue(mockFileDownloadRow())
 - Requires importing mocked functions after vi.mock
 - Order-dependent setup
 
-### Pattern 3: Drizzle Entity Mock Factory
+### Pattern 3: Query Function Mocking (RECOMMENDED)
 
-**When to use:** Tests that need full entity behavior (get/create/update/delete)
+**When to use:** Tests that need entity query behavior (get/create/update/delete)
 
 ```typescript
-// Using createDrizzleEntityMock from test/helpers/drizzle-mock.ts
-const usersMock = createDrizzleEntityMock<UserItem>({
-  queryIndexes: ['byEmail', 'byAppleDeviceId']
-})
+// Mock the queries module
+vi.mock('#entities/queries', () => ({
+  getUser: vi.fn(),
+  createUser: vi.fn(),
+  updateUser: vi.fn()
+}))
 
-vi.mock('#entities/Users', () => ({Users: usersMock.entity}))
+import {getUser, createUser} from '#entities/queries'
 
-// Set up return values
-usersMock.mocks.get.mockResolvedValue({data: mockUser})
-usersMock.mocks.query.byEmail!.go.mockResolvedValue({data: [mockUser]})
+// Set up return values using mocked functions
+vi.mocked(getUser).mockResolvedValue(mockUser)
+vi.mocked(createUser).mockResolvedValue(mockUser)
 ```
 
 **Pros:**
-- Comprehensive entity mocking
-- Type-safe generic factory
-- Supports all entity operations
+- Simple, direct function mocking
+- Type-safe via `vi.mocked()`
+- Aligns with current Drizzle ORM architecture
 
 **Cons:**
-- More complex setup
-- Requires understanding of factory structure
+- Requires importing mocked functions after vi.mock
+- Order-dependent setup
 
 ### Pattern 4: Better Auth Mocking
 

--- a/docs/wiki/TypeScript/Drizzle-Patterns.md
+++ b/docs/wiki/TypeScript/Drizzle-Patterns.md
@@ -88,14 +88,14 @@ afterAll(async () => {
 
 **Use for**: Runtime validation of database insert and update operations.
 
-**File**: `src/lib/vendor/Drizzle/zod-schemas.ts`
+**File**: `src/lib/vendor/Drizzle/zodSchemas.ts`
 
 The project uses `drizzle-zod` to generate Zod validation schemas from Drizzle table definitions. All entity query functions validate input before database operations.
 
 ### Importing Schemas
 
 ```typescript
-import {userInsertSchema, fileSelectSchema} from '#lib/vendor/Drizzle/zod-schemas'
+import {userInsertSchema, fileSelectSchema} from '#lib/vendor/Drizzle/zodSchemas'
 
 // Validate insert data
 const validatedUser = userInsertSchema.parse(userData)
@@ -119,7 +119,7 @@ Each table has three schema variants:
 Use factory functions for custom validation rules:
 
 ```typescript
-import {createInsertSchema} from '#lib/vendor/Drizzle/zod-schemas'
+import {createInsertSchema} from '#lib/vendor/Drizzle/zodSchemas'
 import {files} from '#lib/vendor/Drizzle/schema'
 
 const customFileSchema = createInsertSchema(files, {

--- a/docs/wiki/TypeScript/Entity-Query-Patterns.md
+++ b/docs/wiki/TypeScript/Entity-Query-Patterns.md
@@ -199,7 +199,7 @@ const user = await withTransaction(async (tx) => {
 All create/update functions validate input against Zod schemas:
 
 ```typescript
-import {userInsertSchema, userUpdateSchema} from '#lib/vendor/Drizzle/zod-schemas'
+import {userInsertSchema, userUpdateSchema} from '#lib/vendor/Drizzle/zodSchemas'
 
 // Validation happens automatically in query functions
 const user = await createUser(input)  // Throws ZodError if invalid

--- a/docs/wiki/TypeScript/Lambda-Middleware-Patterns.md
+++ b/docs/wiki/TypeScript/Lambda-Middleware-Patterns.md
@@ -590,7 +590,7 @@ export const handler = middy(wrapApiHandler(async ({event, context}) => {
 
 **Use for**: Adding CORS and security headers to all responses.
 
-**File**: `src/lib/lambda/middleware/security-headers.ts`
+**File**: `src/lib/lambda/middleware/securityHeaders.ts`
 
 **What it provides**:
 - Default CORS headers (configurable)
@@ -605,7 +605,7 @@ export const handler = middy(wrapApiHandler(async ({event, context}) => {
 **Example**:
 ```typescript
 import middy from '@middy/core'
-import {securityHeaders} from '#lib/lambda/middleware/security-headers'
+import {securityHeaders} from '#lib/lambda/middleware/securityHeaders'
 import {wrapApiHandler} from '#lib/lambda/middleware/api'
 
 export const handler = middy(wrapApiHandler(async ({event, context}) => {
@@ -752,7 +752,7 @@ export const handler = withPowertools(wrapApiHandler(async ({context}) => {
 
 ### Type exports
 
-**File**: `src/lib/lambda/middleware/api-gateway.ts`
+**File**: `src/lib/lambda/middleware/apiGateway.ts`
 
 **Exports**:
 ```typescript
@@ -837,9 +837,8 @@ function wrapEventHandler<TRecord>(
 
 **Example**:
 ```typescript
-import {wrapEventHandler} from '#lib/lambda/middleware/legacy'
+import {wrapEventHandler, s3Records, sqsRecords} from '#lib/lambda/middleware/legacy'
 import {withPowertools} from '#lib/lambda/middleware/powertools'
-import {s3Records, sqsRecords} from '#util/lambda-helpers'
 
 // S3 event handler
 export const handler = withPowertools(wrapEventHandler(
@@ -867,10 +866,10 @@ export const handler = withPowertools(wrapEventHandler(
 | File | Purpose | Key Exports |
 |------|---------|-------------|
 | `api.ts` | API handler wrappers | `wrapApiHandler`, `wrapAuthenticatedHandler`, `wrapOptionalAuthHandler` |
-| `api-gateway.ts` | Type definitions | `CustomAPIGatewayRequestAuthorizerEvent` |
+| `apiGateway.ts` | Type definitions | `CustomAPIGatewayRequestAuthorizerEvent` |
 | `validation.ts` | Request validation | `wrapValidatedHandler`, `wrapAuthenticatedValidatedHandler` |
 | `sanitization.ts` | XSS/injection protection | `sanitizeInput` |
-| `security-headers.ts` | CORS and security | `securityHeaders` |
+| `securityHeaders.ts` | CORS and security | `securityHeaders` |
 | `sqs.ts` | SQS batch processing | `wrapSqsBatchHandler` |
 | `powertools.ts` | Observability | `withPowertools`, `metrics`, `MetricUnit` |
 | `correlation.ts` | Correlation IDs | `correlationMiddleware`, `getCorrelationId` |

--- a/docs/wiki/TypeScript/PII-Protection.md
+++ b/docs/wiki/TypeScript/PII-Protection.md
@@ -27,7 +27,7 @@ This centralized function:
 
 ### Integration Points
 
-1. **Runtime Debug Logging** (`src/util/logging.ts`)
+1. **Runtime Debug Logging** (`src/lib/system/logging.ts`)
    ```typescript
    export function logDebug(message: string, data?: string | object): void {
      // Automatically sanitizes objects
@@ -35,7 +35,7 @@ This centralized function:
    }
    ```
 
-2. **Test Fixture Generation** (`src/util/lambda-helpers.ts`)
+2. **Test Fixture Generation** (`src/lib/lambda/middleware/api.ts`)
    ```typescript
    export function logIncomingFixture(event: unknown): void {
      console.log(JSON.stringify({
@@ -69,7 +69,7 @@ The following fields are **automatically redacted** (case-insensitive):
 ### ✅ Automatic Protection (All Logging Functions)
 
 ```typescript
-import {logInfo, logDebug, logError} from '#util/logging'
+import {logInfo, logDebug, logError} from '#lib/system/logging'
 
 // PII is automatically sanitized in ALL logging functions
 logInfo('User data', {

--- a/docs/wiki/TypeScript/Resilience-Patterns.md
+++ b/docs/wiki/TypeScript/Resilience-Patterns.md
@@ -2,7 +2,7 @@
 
 ## Quick Reference
 - **When to use**: Protecting against cascading failures from external services
-- **Location**: `src/lib/system/circuit-breaker.ts`
+- **Location**: `src/lib/system/circuitBreaker.ts`
 - **Related**: [Lambda Function Patterns](Lambda-Function-Patterns.md)
 
 ## Overview
@@ -15,7 +15,7 @@ Resilience patterns prevent cascading failures when external services (YouTube, 
 
 **Use for**: Protecting calls to external services that may fail or become slow.
 
-**File**: `src/lib/system/circuit-breaker.ts`
+**File**: `src/lib/system/circuitBreaker.ts`
 
 **Signature**:
 ```typescript
@@ -29,7 +29,7 @@ class CircuitBreaker {
 
 **Example**:
 ```typescript
-import {CircuitBreaker, CircuitBreakerOpenError} from '#lib/system/circuit-breaker'
+import {CircuitBreaker, CircuitBreakerOpenError} from '#lib/system/circuitBreaker'
 
 // Create a circuit breaker for an external service
 const apiBreaker = new CircuitBreaker({
@@ -62,10 +62,10 @@ try {
 
 **Use for**: YouTube/yt-dlp operations (pre-configured).
 
-**File**: `src/lib/system/circuit-breaker.ts`
+**File**: `src/lib/system/circuitBreaker.ts`
 
 ```typescript
-import {youtubeCircuitBreaker} from '#lib/system/circuit-breaker'
+import {youtubeCircuitBreaker} from '#lib/system/circuitBreaker'
 
 // Use the pre-configured YouTube circuit breaker
 const videoInfo = await youtubeCircuitBreaker.execute(() => fetchVideoInfo(videoId))

--- a/docs/wiki/TypeScript/Schema-Consolidation-Research.md
+++ b/docs/wiki/TypeScript/Schema-Consolidation-Research.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document analyzes the relationship between TypeSpec-generated API schemas (`src/types/api-schema/schemas.ts`) and Drizzle-Zod entity schemas (`src/lib/vendor/Drizzle/zod-schemas.ts`) to determine consolidation opportunities.
+This document analyzes the relationship between TypeSpec-generated API schemas (`src/types/api-schema/schemas.ts`) and Drizzle-Zod entity schemas (`src/lib/vendor/Drizzle/zodSchemas.ts`) to determine consolidation opportunities.
 
 ## Current Schema Sources
 
@@ -14,7 +14,7 @@ This document analyzes the relationship between TypeSpec-generated API schemas (
 ### Drizzle-Zod Entity Schemas
 - **Source**: Auto-generated from Drizzle table definitions
 - **Purpose**: Database insert/update validation
-- **Location**: `src/lib/vendor/Drizzle/zod-schemas.ts`
+- **Location**: `src/lib/vendor/Drizzle/zodSchemas.ts`
 
 ## Schema Comparison
 
@@ -130,7 +130,7 @@ z.object({
 Use `.pick()` and `.extend()` on drizzle-zod schemas to create API schemas:
 
 ```typescript
-import {fileSelectSchema} from '#lib/vendor/Drizzle/zod-schemas'
+import {fileSelectSchema} from '#lib/vendor/Drizzle/zodSchemas'
 
 export const fileApiSchema = fileSelectSchema
   .partial()  // Make all optional
@@ -221,7 +221,7 @@ The following actions were taken to improve schema validation:
 
 1. **Response validation added** - Lambda handlers now validate responses using TypeSpec-generated API schemas via `buildValidatedResponse()`
 
-2. **Shared primitives created** - `src/types/shared-primitives.ts` derives Zod schemas from TypeScript enums, eliminating duplication:
+2. **Shared primitives created** - `src/types/sharedPrimitives.ts` derives Zod schemas from TypeScript enums, eliminating duplication:
    - `fileStatusZodSchema` from `FileStatus` enum
    - `downloadStatusZodSchema` from `DownloadStatus` enum
    - `responseStatusZodSchema` from `ResponseStatus` enum
@@ -239,7 +239,7 @@ The following actions were taken to improve schema validation:
 | API Requests | TypeSpec (`api-schema/schemas.ts`) | Validate incoming request payloads |
 | API Responses | TypeSpec (`api-schema/schemas.ts`) | Validate outgoing response shapes |
 | Database Writes | Drizzle-Zod + Enum refinements | Validate entity inserts/updates |
-| Status Enums | Shared primitives (`shared-primitives.ts`) | Single source of truth for enum values |
+| Status Enums | Shared primitives (`sharedPrimitives.ts`) | Single source of truth for enum values |
 
 ## Future Considerations
 


### PR DESCRIPTION
## Summary

This PR fixes 80+ documentation sync validation warnings from `ci:local:full`. The wiki documentation had drifted from the actual codebase structure, with stale import aliases, incorrect file paths, and outdated file naming conventions.

### Changes

**1. Import Alias Fixes (19 stale imports fixed)**
- `#util/lambda-helpers` → `#lib/lambda/responses`, `#lib/lambda/middleware/api`
- `#util/env-validation` → `#lib/system/env`
- `#util/logging` → `#lib/system/logging`
- `#entities/Users`, `#entities/Files` → `#entities/queries`

**2. File Path Fixes (50+ stale paths fixed)**
- kebab-case → camelCase: `circuit-breaker.ts` → `circuitBreaker.ts`
- kebab-case → camelCase: `zod-schemas.ts` → `zodSchemas.ts`
- kebab-case → camelCase: `fk-enforcement.ts` → `fkEnforcement.ts`
- kebab-case → camelCase: `security-headers.ts` → `securityHeaders.ts`
- kebab-case → camelCase: `api-gateway.ts` → `apiGateway.ts`
- Added `src/` prefix where missing for vendor paths

**3. Validation Script Improvements (`bin/validate-doc-sync.sh`)**
- Skip glob patterns (`*`, `**`) - valid documentation examples
- Skip template patterns (`[name]`, `{name}`) - valid placeholders
- Skip line number references (`file.ts:123`) - may drift naturally
- Skip generated files (`build/graph.json`) - in `.gitignore`
- Skip planned test files in audit documentation
- Add `.d.ts` file checking for import validation (fixes false positives)
- Fix TypeSpec operationId matching (use `awk` for portable case conversion)
- Skip legacy example imports marked with `LEGACY`/`WRONG`/`❌`
- Handle non-standard TypeSpec naming (DeviceEvent → logClientEvent, etc.)

**4. Removed References**
- Removed non-existent `bin/sync-examples.sh` from Script-Index.md

## Test plan

- [x] `pnpm run validate:conventions` passes (0 violations)
- [x] `pnpm run precheck` passes (TypeScript, ESLint, dprint)
- [x] `./bin/validate-doc-sync.sh` passes with 0 warnings (was 80+)
- [x] All 11 documentation sync checks show OK

## Files changed (17 files)

| Category | Files |
|----------|-------|
| Validation script | `bin/validate-doc-sync.sh` |
| TypeScript docs | `Lambda-Function-Patterns.md`, `Lambda-Middleware-Patterns.md`, `System-Library.md`, `Entity-Query-Patterns.md`, `Drizzle-Patterns.md`, `Schema-Consolidation-Research.md`, `Resilience-Patterns.md`, `PII-Protection.md` |
| Conventions docs | `Import-Organization.md`, `Vendor-Encapsulation-Policy.md`, `Database-Migrations.md` |
| Other docs | `X-Ray-Integration.md`, `Auto-Fix.md`, `Script-Index.md`, `Documentation-Coverage-Matrix.md`, `Mocking-Patterns-Analysis.md` |