### PR TITLE
feat: add S3 file recovery for StartFileUpload

### DIFF
--- a/graphrag/knowledge-graph.json
+++ b/graphrag/knowledge-graph.json
@@ -1011,6 +1011,11 @@
     },
     {
       "source": "lambda:StartFileUpload",
+      "target": "service:S3",
+      "relationship": "uses"
+    },
+    {
+      "source": "lambda:StartFileUpload",
       "target": "service:SQS",
       "relationship": "uses"
     },


### PR DESCRIPTION
## Summary
- Add S3 existence check at the start of download processing
- Recover database records from S3 metadata + YouTube info when file exists
- Send notifications to users after recovery
- Emit CloudWatch metrics for observability
- Skip redundant downloads

## Problem
When the database is refreshed or records are lost, files may exist in S3 but have no corresponding File/FileDownload database records. Previously, this caused redundant downloads.

## Solution
Check S3 first using `headObject`. If file exists, recover database state and notify users without re-downloading.

### Key Behaviors
- **S3 file exists, YouTube succeeds**: Full metadata recovery with notifications
- **S3 file exists, YouTube fails**: Minimal metadata recovery (fileId as title, "Unknown" author)
- **S3 file zero-size**: Treated as corrupted, proceeds with normal download
- **S3 file not found**: Normal download path (existing behavior)

## Metrics Added
- `S3FileRecoveryAttempt`: Count of recovery attempts
- `S3FileRecoverySuccess`: Count of successful recoveries

## Test Plan
- [x] Unit tests cover recovery path (5 new tests)
- [x] Unit tests cover fallback to minimal metadata
- [x] Unit tests cover zero-size file handling
- [x] All 1436 unit tests pass
- [x] All 144 integration tests pass
- [x] TypeScript compiles, linting passes, formatting correct