### PR TITLE
chore(infra): cleanup after S3 remote state migration

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -8,7 +8,6 @@
 #   - secrets.yaml           (Decrypted secrets - gitignored)
 #   - .sops.yaml             (SOPS configuration)
 #   - .env                   (Environment variables for SOPS)
-#   - terraform/terraform.tfstate*  (Terraform state files)
 #
 # Auto-setup for fresh worktrees:
 #   - pnpm install
@@ -42,34 +41,9 @@ for item in $SHARED_ITEMS; do
   fi
 done
 
-# Symlink terraform state files (nested paths)
-for state_file in "terraform/terraform.tfstate" "terraform/terraform.tfstate.backup"; do
-  if [ ! -e "$state_file" ] && [ ! -L "$state_file" ]; then
-    if [ -e "$MAIN_REPO/$state_file" ]; then
-      ln -s "$MAIN_REPO/$state_file" "$state_file"
-      if [ $? -eq 0 ]; then
-        LINKED="$LINKED $state_file"
-      fi
-    fi
-  fi
-done
-
 # Print summary if anything was linked
 if [ -n "$LINKED" ]; then
   echo "Linked from main repo:$LINKED"
-fi
-
-# Validate state file integrity
-if [ -L "terraform/terraform.tfstate" ]; then
-  STATE_TARGET=$(readlink "terraform/terraform.tfstate")
-  if [ ! -f "$STATE_TARGET" ]; then
-    echo ""
-    echo "WARNING: State file symlink target does not exist: $STATE_TARGET"
-    echo "Run 'tofu init' from main repository first, then re-run post-checkout."
-  else
-    RESOURCE_COUNT=$(grep -c '"type":' "$STATE_TARGET" 2>/dev/null || echo "0")
-    echo "State file linked: $RESOURCE_COUNT resources"
-  fi
 fi
 
 # --- Auto-setup: Only run for fresh worktrees (no node_modules) ---

--- a/bin/verify-state.sh
+++ b/bin/verify-state.sh
@@ -121,12 +121,7 @@ main() {
   echo "Summary"
   echo "-------"
   echo "  Total managed resources: $((AWS_RESOURCES + DATA_SOURCES + LOCAL_RESOURCES))"
-  echo "  State file location: ${TERRAFORM_DIR}/terraform.tfstate"
-
-  if [[ -L "${TERRAFORM_DIR}/terraform.tfstate" ]]; then
-    echo "  State symlinked to: $(readlink "${TERRAFORM_DIR}/terraform.tfstate")"
-  fi
-
+  echo "  State backend: S3 (remote)"
   echo ""
 }
 

--- a/docs/wiki/Conventions/Git-Workflow.md
+++ b/docs/wiki/Conventions/Git-Workflow.md
@@ -182,7 +182,8 @@ git worktree add -b feature/my-feature ~/wt/my-feature master
 
 # 2. Navigate to worktree (auto-setup runs via post-checkout hook)
 cd ~/wt/my-feature
-# Symlinks created automatically (.env, terraform state, etc.)
+# Symlinks created automatically (.env, secrets, etc.)
+# Terraform state is remote (S3) - no symlinks needed
 # Dependencies installed (pnpm install)
 # Terraform initialized (tofu init)
 
@@ -211,9 +212,8 @@ The `.husky/post-checkout` hook automatically configures worktrees:
 | `.claude/` | Symlinked from main repo |
 | `secrets.yaml` | Symlinked from main repo |
 | `.sops.yaml` | Symlinked from main repo |
-| `terraform/terraform.tfstate*` | Symlinked from main repo |
 | Dependencies | `pnpm install` runs automatically |
-| Terraform | `tofu init` runs automatically |
+| Terraform | `tofu init` runs automatically (state is remote) |
 | GraphRAG | `graphrag:extract` generates knowledge graph |
 | Semantic search | `index:codebase` runs in background |
 | Repomix | `pack:context` generates AI context (background) |


### PR DESCRIPTION
## Summary

Cleanup after PR #dbd79a02 which migrated Terraform state to S3 backend with DynamoDB locking.

## Changes Made

- **Post-checkout hook**: Removed terraform state symlink logic (no longer needed with remote state)
- **pre-deploy-check.sh**: Simplified to require remote backend, removed local state fallback
- **verify-state.sh**: Updated summary to reference S3 backend instead of local file paths
- **Git-Workflow.md**: Removed terraform state from worktree setup table
- **Drift-Prevention.md**: Updated to reflect remote state architecture with S3/DynamoDB details

## Test Plan

- [x] All 1524 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes (warnings only)
- [x] Shell scripts pass syntax validation
- [x] No terraform.tfstate references in modified files
- [x] Pre-commit hooks pass (dependency architecture, docs structure)

## Notes

The local state files (terraform/terraform.tfstate*) were already gitignored so their deletion does not appear in this diff.