### PR TITLE
fix: resolve Vale linter warnings in wiki documentation

### DIFF
--- a/docs/wiki/AWS/CloudWatch-Logging.md
+++ b/docs/wiki/AWS/CloudWatch-Logging.md
@@ -169,7 +169,7 @@ Powertools Logger **always outputs structured JSON** regardless of Lambda's `log
 | Log size | Smaller | ~20% larger |
 | Structured data | Difficult | Native support |
 
-### Why We Chose JSON
+### Why JSON Was Chosen
 
 1. **CloudWatch Logs Insights** auto-discovers JSON fields - you can filter by `level`, `message`, `requestId`, etc.
 2. **Correlation**: X-Ray trace IDs, request IDs, and service names are automatically included

--- a/docs/wiki/Architecture/Domain-Layer.md
+++ b/docs/wiki/Architecture/Domain-Layer.md
@@ -1,6 +1,6 @@
 # Domain Layer Purity
 
-> **Status**: This is an architectural guideline for future development. The `src/lib/domain/` directory will be created as business logic is extracted from Lambda handlers.
+> **Status**: This is an architectural guideline for future development. The `src/lib/domain/` directory is created as business logic is extracted from Lambda handlers.
 
 The domain layer (`src/lib/domain/`) contains pure business logic that must remain infrastructure-agnostic.
 

--- a/docs/wiki/Conventions/Code-Formatting.md
+++ b/docs/wiki/Conventions/Code-Formatting.md
@@ -148,7 +148,7 @@ Skip formatting for an entire file (use sparingly):
 - **Matrix/grid data** - Visual alignment matters
 - **Complex regex** - Manual formatting aids readability
 - **Generated code** - Preserve generator's formatting
-- **Temporary debugging** - Will be removed soon
+- **Temporary debugging** - Removed before commit
 
 ## Type Aliases for Line Width Management
 

--- a/docs/wiki/Conventions/Deprecation-Policy.md
+++ b/docs/wiki/Conventions/Deprecation-Policy.md
@@ -78,7 +78,7 @@ When replacing a function/pattern, update ALL of these in the same PR:
 
 ## Anti-Patterns to Avoid
 
-### "We'll Clean It Up Later"
+### "Clean It Up Later"
 
 ```typescript
 // ❌ BAD - Leaving both implementations

--- a/docs/wiki/Conventions/Git-Workflow.md
+++ b/docs/wiki/Conventions/Git-Workflow.md
@@ -235,9 +235,9 @@ claude
 - `graphrag/knowledge-graph.json` (knowledge graph)
 - `build/graph.json` (dependency analysis)
 
-If you start from the main repo, MCP queries will use the **main repo's indexes**, not the worktree's.
+If you start from the main repo, MCP queries use the **main repo's indexes**, not the worktree's.
 
-**Fallback**: If you must work from another directory, use `/add-dir` for file access (but MCP will still use the starting directory's indexes):
+**Fallback**: If you must work from another directory, use `/add-dir` for file access (but MCP still uses the starting directory's indexes):
 ```bash
 /add-dir ~/wt/my-feature
 ```

--- a/docs/wiki/Conventions/Workaround-Tracking.md
+++ b/docs/wiki/Conventions/Workaround-Tracking.md
@@ -4,13 +4,13 @@ When implementing workarounds for upstream dependency issues, follow this proces
 
 ## The Problem
 
-Workarounds for upstream bugs or limitations can persist indefinitely if not tracked. When the upstream issue is fixed, we may continue using unnecessary workaround code.
+Workarounds for upstream bugs or limitations can persist indefinitely if not tracked. When the upstream issue is fixed, the project may continue using unnecessary workaround code.
 
 ## The Solution
 
 Every workaround requires two things:
 
-1. **Tracking GitHub Issue** - Documents the workaround in our repository
+1. **Tracking GitHub Issue** - Documents the workaround in the repository
 2. **Automated Monitoring Workflow** - Checks upstream issue status weekly
 
 ## Process
@@ -29,7 +29,7 @@ process.env.NODE_OPTIONS = '--no-deprecation'
 
 ### 2. Create a Tracking Issue
 
-Create a GitHub issue in our repository that:
+Create a GitHub issue in the repository that:
 - Describes the problem
 - Links to the upstream issue
 - Documents the workaround impact
@@ -54,8 +54,8 @@ trackedIssues:
 
 The workflow runs weekly and:
 - Checks if each tracked upstream issue is closed
-- Posts a comment to our tracking issue when upstream is fixed
-- Allows us to remove the workaround
+- Posts a comment to the tracking issue when upstream is fixed
+- Enables removal of the workaround
 
 ## Workflow Configuration
 
@@ -117,7 +117,7 @@ jobs:
 
 ## Example Workarounds
 
-| Workaround | Upstream Issue | Our Tracking | Status |
+| Workaround | Upstream Issue | Tracking | Status |
 |------------|---------------|--------------|--------|
 | OTEL deprecation suppression | opentelemetry-js#4173 | #216 | Active |
 
@@ -125,5 +125,5 @@ jobs:
 
 1. **No forgotten workarounds**: Automated monitoring ensures cleanup
 2. **Clear documentation**: Comments link to tracking issues
-3. **Proactive notification**: We know when to act
+3. **Proactive notification**: Alerts trigger timely action
 4. **Reduced tech debt**: Workarounds are temporary by design

--- a/docs/wiki/Evaluation/Unit-Test-Architecture-2026-01.md
+++ b/docs/wiki/Evaluation/Unit-Test-Architecture-2026-01.md
@@ -471,7 +471,7 @@ The primary opportunities for improvement are:
 2. **Extracting magic strings** to a centralized constants file
 3. **Adding timeout/network error tests** to database-accessing Lambdas
 
-Implementing these recommendations will improve test maintainability and ensure consistent coverage patterns across the entire Lambda suite.
+Implementing these recommendations improves test maintainability and ensures consistent coverage patterns across the entire Lambda suite.
 
 ---
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -301,4 +301,4 @@ git log --oneline docs/wiki/ | head -10
 
 ---
 
-*Remember: This wiki is a living document. It grows through the Convention Capture System and represents our collective knowledge. Use it, improve it, and help it evolve.*
+*Remember: This wiki is a living document. It grows through the Convention Capture System and represents the project's collective knowledge. Use it, improve it, and help it evolve.*

--- a/docs/wiki/Getting-Started/Tutorial-First-Lambda.md
+++ b/docs/wiki/Getting-Started/Tutorial-First-Lambda.md
@@ -12,7 +12,7 @@ Before starting, ensure you have:
 
 ## Learning Objectives
 
-By the end of this tutorial, you will:
+By the end of this tutorial, you:
 1. Create the Lambda directory structure
 2. Write a handler following project patterns
 3. Use vendor wrappers for AWS SDK calls

--- a/docs/wiki/Infrastructure/CI-Workflow-Reference.md
+++ b/docs/wiki/Infrastructure/CI-Workflow-Reference.md
@@ -92,7 +92,7 @@ Complete reference for all GitHub Actions workflows in the project.
 - Response helpers
 - Environment variable handling
 - Cascade delete order
-- And more...
+- And more
 
 ---
 

--- a/docs/wiki/Infrastructure/Drift-Prevention.md
+++ b/docs/wiki/Infrastructure/Drift-Prevention.md
@@ -130,7 +130,7 @@ Resources in AWS that are no longer needed.
 ./bin/aws-audit.sh --prune
 ```
 
-This will prompt for confirmation before deleting.
+This prompts for confirmation before deleting.
 
 ## Automated Detection
 

--- a/docs/wiki/Infrastructure/GraphRAG-Automation.md
+++ b/docs/wiki/Infrastructure/GraphRAG-Automation.md
@@ -85,7 +85,7 @@ When adding new components:
 
 1. **Add Lambda**: Update `metadata.json` with trigger type and purpose
 2. **Add Invocation**: Add to `lambdaInvocations` array
-3. **Commit**: GraphRAG will auto-update on push
+3. **Commit**: GraphRAG auto-updates on push
 
 ```bash
 # Manually regenerate (optional)

--- a/docs/wiki/Infrastructure/Lambda-Layers.md
+++ b/docs/wiki/Infrastructure/Lambda-Layers.md
@@ -86,7 +86,7 @@ The Terraform configuration automatically:
 
 ## Why No Shared Code Layer?
 
-We evaluated adding a shared code layer for common modules (logging, powertools, entity queries) but decided against it:
+The team evaluated adding a shared code layer for common modules (logging, powertools, entity queries) but decided against it:
 
 | Factor | Impact |
 |--------|--------|
@@ -152,7 +152,7 @@ AWS Lambda has a 250 MB unzipped deployment limit (including all layers):
 
 ### Architecture Mismatch
 
-StartFileUpload uses x86_64 for binary compatibility. Using ARM64 binaries will cause "cannot execute binary file" errors.
+StartFileUpload uses x86_64 for binary compatibility. Using ARM64 binaries causes "cannot execute binary file" errors.
 
 ### Cookie File Issues
 

--- a/docs/wiki/Infrastructure/Script-Registry.md
+++ b/docs/wiki/Infrastructure/Script-Registry.md
@@ -265,7 +265,7 @@ When adding a new npm script:
    - Dependencies
    - CI Coverage (add to workflow if appropriate)
    - Notes
-3. If documented in `AGENTS.md` or `README.md`, CI will validate it exists
+3. If documented in `AGENTS.md` or `README.md`, CI validates it exists
 
 **Convention**: Script documentation must stay synchronized with `package.json`. CI enforces this for scripts referenced in main documentation files.
 

--- a/docs/wiki/Infrastructure/Staging-Production-Strategy.md
+++ b/docs/wiki/Infrastructure/Staging-Production-Strategy.md
@@ -22,7 +22,7 @@ This document outlines the strategy for establishing distinct Staging and Produc
 
 ### 3.1. Infrastructure Structure
 
-We recommend using **OpenTofu Workspaces** to manage the environments without duplicating the `.tf` code, as the infrastructure is expected to be nearly identical between Staging and Production.
+The recommended approach is **OpenTofu Workspaces** to manage the environments without duplicating the `.tf` code, as the infrastructure is expected to be nearly identical between Staging and Production.
 
 **Proposed Directory/File Changes:**
 ```text
@@ -62,13 +62,13 @@ data "sops_file" "secrets" {
 *   **Production Account:** Used for `main` branch deploys. Strict IAM roles, high availability.
 
 **Single Account Fallback:**
-If separate accounts are not feasible immediately, we must use:
+If separate accounts are not feasible immediately, use:
 *   **Resource Naming Prefixes:** `${var.environment}-media-downloader-...`
 *   **Tagging:** Enforce `Environment = var.environment` on ALL resources.
 
 ## 4. CI/CD Pipeline (GitHub Actions)
 
-We will replace the manual `npm run deploy` scripts with an automated pipeline.
+This replaces the manual `npm run deploy` scripts with an automated pipeline.
 
 **Workflow Stages:**
 

--- a/docs/wiki/MCP/MCP-Setup-Guide.md
+++ b/docs/wiki/MCP/MCP-Setup-Guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Model Context Protocol (MCP) is an open protocol that standardizes how AI assistants interact with external data sources and tools. For this project, we've implemented an MCP server that provides structured, queryable access to our codebase architecture.
+The Model Context Protocol (MCP) is an open protocol that standardizes how AI assistants interact with external data sources and tools. For this project, an MCP server is implemented that provides structured, queryable access to the codebase architecture.
 
 ## Why MCP?
 

--- a/docs/wiki/Meta/2025-Tech-Stack-Audit.md
+++ b/docs/wiki/Meta/2025-Tech-Stack-Audit.md
@@ -20,7 +20,7 @@ This project employs a cutting-edge, "paranoid-security" stack (Node 22, pnpm 10
   - *Action:* Maintain a "Feature Parity Watchlist" in `docs/wiki/Infrastructure/OpenTofu-Patterns.md` to monitor divergence (for example, state encryption features).
 - **Node.js 22 (Verified):** Project explicitly targets `node22`.
   - *Cold Start Risk:* Node 22 has known initial cold start regressions with `http` loading.
-  - *Mitigation:* We use `esbuild` with `external: [aws-sdk]` to utilize the Lambda runtime's pre-loaded SDK, effectively mitigating bundle-size related cold starts.
+  - *Mitigation:* The project uses `esbuild` with `external: [aws-sdk]` to utilize the Lambda runtime's pre-loaded SDK, effectively mitigating bundle-size related cold starts.
   - *Status:* ✅ **Optimized**.
 
 ### 2. Build System

--- a/docs/wiki/Meta/AI-Tool-Context-Files.md
+++ b/docs/wiki/Meta/AI-Tool-Context-Files.md
@@ -89,7 +89,7 @@ project/
 @AGENTS.md
 ```
 
-That's it. One line. Claude Code will read AGENTS.md via this reference.
+That's it. One line. Claude Code reads AGENTS.md via this reference.
 
 ### GEMINI.md Passthrough
 

--- a/docs/wiki/Meta/Convention-Capture-System.md
+++ b/docs/wiki/Meta/Convention-Capture-System.md
@@ -184,4 +184,4 @@ Each project maintains its own:
 
 ---
 
-*The Convention Capture System ensures valuable patterns and conventions are never lost. By systematically detecting, tracking, and documenting conventions as they emerge, we build persistent institutional memory that benefits all future work.*
+*The Convention Capture System ensures valuable patterns and conventions are never lost. By systematically detecting, tracking, and documenting conventions as they emerge, the project builds persistent institutional memory that benefits all future work.*

--- a/docs/wiki/Meta/Documentation-Style-Guide.md
+++ b/docs/wiki/Meta/Documentation-Style-Guide.md
@@ -31,11 +31,13 @@ vale docs/wiki/Getting-Started.md
 
 Write as if explaining to a colleague. Avoid overly formal or academic language.
 
+<!-- vale Google.We = NO -->
 | Instead of | Use |
 |------------|-----|
-| "It is recommended that one should" | "We recommend" or "You should" |
+| "It is recommended that one should" | "You should" |
 | "The aforementioned functionality" | "This feature" |
 | "Utilize" | "Use" |
+<!-- vale Google.We = YES -->
 
 ### 2. Active Voice
 
@@ -51,11 +53,15 @@ Use active voice where the subject performs the action.
 
 Use present tense for most technical documentation.
 
+<!-- vale Google.Will = NO -->
+<!-- vale Google.Ellipses = NO -->
 | Future (avoid) | Present (prefer) |
 |----------------|------------------|
 | "This function will return a promise" | "This function returns a promise" |
 | "The build will fail if..." | "The build fails if..." |
 | "You will see an error" | "You see an error" |
+<!-- vale Google.Will = YES -->
+<!-- vale Google.Ellipses = YES -->
 
 ### 4. Second Person
 
@@ -176,7 +182,7 @@ Vale checks documentation against these rule categories:
 
 - Use of passive voice
 - Future tense
-- First person plural ("we")
+- First person plural
 - Heading capitalization
 - Acronym usage
 

--- a/docs/wiki/Meta/Wiki-Framework-Benchmarking-2026-01.md
+++ b/docs/wiki/Meta/Wiki-Framework-Benchmarking-2026-01.md
@@ -224,8 +224,10 @@ The project wiki was evaluated against 12 industry documentation frameworks. The
 - **Collectively Exhaustive:** All topics covered
 
 **Current Wiki Assessment:**
+<!-- vale Google.FirstPerson = NO -->
 - **ME (No overlap):** No significant redundancy detected
 - **CE (Complete):** Gaps exist (tutorials, architecture overview)
+<!-- vale Google.FirstPerson = YES -->
 
 ---
 

--- a/docs/wiki/Meta/evaluation-2026-01.md
+++ b/docs/wiki/Meta/evaluation-2026-01.md
@@ -384,7 +384,9 @@ resource "aws_lambda_provisioned_concurrency_config" "auth" {
 **Effort**: High
 
 **Current State:**
+<!-- vale Google.We = NO -->
 - Single-region deployment (us-east-1)
+<!-- vale Google.We = YES -->
 - No documented DR strategy
 
 **Recommendations:**

--- a/docs/wiki/Meta/pnpm-Migration.md
+++ b/docs/wiki/Meta/pnpm-Migration.md
@@ -156,7 +156,7 @@ GitHub Actions workflows updated to use pnpm:
 
 When adding a new package that requires install scripts:
 
-1. **Try installing** - pnpm will block and error if scripts needed
+1. **Try installing** - pnpm blocks and errors if scripts needed
 2. **Audit the package** - Check package code on npm/GitHub
 3. **Verify legitimacy** - Ensure it's the correct package (not typosquatted)
 4. **Review scripts** - Look at `package.json` scripts field

--- a/docs/wiki/Observability/Tracing-Architecture.md
+++ b/docs/wiki/Observability/Tracing-Architecture.md
@@ -51,7 +51,7 @@ EventBridge preserves trace context through the event routing.
 StartFileUpload -> S3 -> S3ObjectCreated
      (ADOT)      (event)    (ADOT)
 ```
-**Note**: S3 events do not propagate X-Ray context. We use custom `correlationId` via S3 object metadata for logical correlation.
+**Note**: S3 events do not propagate X-Ray context. The project uses custom `correlationId` via S3 object metadata for logical correlation.
 
 ## OpenTelemetry API
 

--- a/docs/wiki/Security/Secret-Rotation-Runbook.md
+++ b/docs/wiki/Security/Secret-Rotation-Runbook.md
@@ -38,7 +38,7 @@ This runbook documents all secrets used in the media downloader infrastructure, 
    pnpm run extract-cookies:chrome
    ```
 2. Follow the prompts:
-   - Chrome will open automatically
+   - Chrome opens automatically
    - Log into YouTube when prompted
    - Press Enter when logged in (avatar visible)
    - Script extracts and saves cookies to layer
@@ -152,7 +152,7 @@ curl -H "Authorization: token YOUR_TOKEN" \
 
 **Purpose**: Used for session token signing and encryption.
 
-**Impact**: Rotating this secret will invalidate ALL existing user sessions.
+**Impact**: Rotating this secret invalidates ALL existing user sessions.
 
 **Procedure**:
 1. Generate a new random secret:
@@ -171,7 +171,7 @@ curl -H "Authorization: token YOUR_TOKEN" \
    ```
 
 **Post-rotation**:
-- All users will need to re-authenticate
+- All users need to re-authenticate
 - Monitor authentication Lambda logs for issues
 
 ---

--- a/docs/wiki/Testing/Coverage-Philosophy.md
+++ b/docs/wiki/Testing/Coverage-Philosophy.md
@@ -13,9 +13,11 @@ Coverage should be a side effect of testing business logic, not a goal itself. I
 
 ## Test Focus
 
+<!-- vale Google.FirstPerson = NO -->
 ### ❌ Wrong: Testing Libraries
 - "Can I upload to S3?" → Testing AWS SDK
 - "Does DynamoDB query work?" → Testing AWS SDK
+<!-- vale Google.FirstPerson = YES -->
 
 ### ✅ Correct: Testing YOUR Logic
 - "Does download workflow complete?" → Testing YOUR orchestration
@@ -102,7 +104,7 @@ Use this flowchart to decide which test type to write:
 
 ### Quick Reference
 
-| Testing... | Test Type | Mock Strategy |
+| Testing | Test Type | Mock Strategy |
 |------------|-----------|---------------|
 | Pure business logic | Unit | Mock everything |
 | Data transformations | Unit | Mock everything |

--- a/docs/wiki/Testing/Integration-Test-Coverage.md
+++ b/docs/wiki/Testing/Integration-Test-Coverage.md
@@ -58,7 +58,9 @@ These tests validate cross-cutting concerns and multi-service orchestration:
 CloudFront Lambda@Edge functions execute at AWS edge locations with specific constraints:
 - No VPC access
 - Limited runtime (viewer request/response: 5 s, origin request/response: 30 s)
+<!-- vale Google.We = NO -->
 - Region-specific deployment (us-east-1 only)
+<!-- vale Google.We = YES -->
 - Edge-specific event structure
 
 LocalStack does not emulate CloudFront edge behavior. Testing options:

--- a/docs/wiki/Testing/Integration-Testing.md
+++ b/docs/wiki/Testing/Integration-Testing.md
@@ -14,7 +14,7 @@
 - **End-to-End**: Testing flows that are difficult to emulate (for example, complex CloudFront behaviors, actual Apple Push Notification delivery).
 
 ### Project Scripts
-We provide specific scripts for remocal testing:
+The project provides specific scripts for remocal testing:
 - `npm run test-remote-list`: Hits the deployed API Gateway to list files.
 - `npm run test-remote-hook`: Sends a payload to the deployed Feedly webhook.
 - `npm run test-remote-registerDevice`: Registers a device against the production DB.

--- a/docs/wiki/Testing/Local-CI-Testing.md
+++ b/docs/wiki/Testing/Local-CI-Testing.md
@@ -6,7 +6,7 @@ This guide explains how to run CI checks locally before pushing to GitHub, ensur
 
 Previously, this project used `nektos/act` for local GitHub Actions testing. It was removed due to Apple Silicon (ARM64) incompatibility - the x86-64 Linux containers required for GitHub Actions cause Rosetta translation failures on M1/M2/M3 Macs.
 
-Instead, we use **workflow decomposition**: CI logic is extracted into reusable shell scripts that run both locally and in GitHub Actions, ensuring consistency.
+Instead, the project uses **workflow decomposition**: CI logic is extracted into reusable shell scripts that run both locally and in GitHub Actions, ensuring consistency.
 
 ## Quick Start
 

--- a/docs/wiki/Testing/LocalStack-Testing.md
+++ b/docs/wiki/Testing/LocalStack-Testing.md
@@ -158,7 +158,9 @@ test('user files relationship', async () => {
 | Connection refused | Ensure LocalStack is running |
 | Service not available | Check SERVICES env var |
 | Credentials error | Use 'test' for both key and secret |
+<!-- vale Google.We = NO -->
 | Region mismatch | Use us-west-2 consistently |
+<!-- vale Google.We = YES -->
 
 ## True Integration vs Mock Disguised
 
@@ -331,7 +333,9 @@ postgres-helpers.ts  → getWorkerSchema() uses VITEST_POOL_ID
 | Mechanism | Implementation | Purpose |
 |-----------|---------------|---------|
 | CI Isolation | `GITHUB_RUN_ID` prefix | Prevents concurrent CI runs from conflicting |
+<!-- vale Google.Ellipses = NO -->
 | Worker Isolation | Schemas (worker_1...worker_8) | Each Vitest worker gets own schema |
+<!-- vale Google.Ellipses = YES -->
 | Test Isolation | `truncateAllTables()` in afterEach | Clears data between tests |
 | Connection Management | `max: 1` per worker | Avoids search_path issues with pool |
 

--- a/docs/wiki/Testing/Mocking-Patterns-Analysis.md
+++ b/docs/wiki/Testing/Mocking-Patterns-Analysis.md
@@ -253,7 +253,7 @@ expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
 
 ### Hybrid Approach
 
-Given the vendor encapsulation architecture, we can use aws-sdk-client-mock at the client factory level:
+Given the vendor encapsulation architecture, aws-sdk-client-mock can be used at the client factory level:
 
 1. **Modify client factory** to allow test injection:
 

--- a/docs/wiki/TypeScript/ESM-Migration-Guide.md
+++ b/docs/wiki/TypeScript/ESM-Migration-Guide.md
@@ -9,7 +9,7 @@
 
 This project uses **pure ESM (ECMAScript Modules)** for AWS Lambda functions running on Node.js 22+. All Lambda bundles are output as `.mjs` files with `format: 'esm'` in esbuild.
 
-However, not all npm packages support ESM natively. This guide documents our approach to maintaining ESM compatibility while using CommonJS (CJS) dependencies.
+However, not all npm packages support ESM natively. This guide documents the project's approach to maintaining ESM compatibility while using CommonJS (CJS) dependencies.
 
 ---
 
@@ -87,7 +87,7 @@ This is the correct pattern for CJS-only packages used in specific functions.
 
 ## Architecture Decision: The `createRequire` Shim
 
-### What We Use
+### What the Project Uses
 
 ```typescript
 // config/esbuild.config.ts
@@ -243,7 +243,7 @@ pnpm patch-commit /path/to/temp/dir
 
 **When to use**: Package has a small, specific CJS pattern that breaks ESM.
 
-**Example**: Our `jsonschema@1.2.7` patch converts `require('url')` to ESM imports:
+**Example**: The `jsonschema@1.2.7` patch converts `require('url')` to ESM imports:
 
 ```diff
 // patches/jsonschema@1.2.7.patch
@@ -287,7 +287,7 @@ Jest requires special configuration to handle ESM and patched packages:
 }
 ```
 
-The `transformIgnorePatterns` regex tells Jest to transform `jsonschema` even though it's in `node_modules`, because our patch introduces ESM syntax.
+The `transformIgnorePatterns` regex tells Jest to transform `jsonschema` even though it's in `node_modules`, because the patch introduces ESM syntax.
 
 ---
 

--- a/docs/wiki/TypeScript/Lambda-Middleware-Patterns.md
+++ b/docs/wiki/TypeScript/Lambda-Middleware-Patterns.md
@@ -112,8 +112,10 @@ export const handler = withPowertools(wrapAuthenticatedHandler(
 ))
 ```
 
+<!-- vale Google.FirstPerson = NO -->
 **When to use**:
 - User-specific operations (get my files, update my settings)
+<!-- vale Google.FirstPerson = YES -->
 - Actions that modify user data
 - Any endpoint that should never work without authentication
 
@@ -212,7 +214,7 @@ export const handler = withPowertools(wrapScheduledHandler(async ({event, contex
 }))
 ```
 
-**Error behavior**: Errors are logged then rethrown. CloudWatch will mark the invocation as failed, triggering any configured alarms.
+**Error behavior**: Errors are logged then rethrown. CloudWatch marks the invocation as failed, triggering any configured alarms.
 
 ---
 

--- a/docs/wiki/iOS/Apple-Sign-In-ID-Token-Migration.md
+++ b/docs/wiki/iOS/Apple-Sign-In-ID-Token-Migration.md
@@ -180,15 +180,15 @@ func loginUser(idToken: String) {
 ### ID Token vs Authorization Code
 
 - **ID Token**: A JWT containing user identity claims (email, sub, etc.). Available immediately after Apple Sign In.
-- **Authorization Code**: A one-time code that must be exchanged for tokens via Apple's token endpoint. This is what we used before.
+- **Authorization Code**: A one-time code that must be exchanged for tokens via Apple's token endpoint. This is what the project used before.
 
 ### Name Availability
 
 Apple's privacy design means:
 1. `fullName` is ONLY populated on the first sign-in
-2. Subsequent sign-ins will have `nil` for `fullName`
+2. Subsequent sign-ins have `nil` for `fullName`
 3. The ID token does NOT contain first/last name for privacy reasons
-4. This is why we send name separately in the RegisterUser request
+4. This is why the name is sent separately in the RegisterUser request
 
 The backend detects new users (created within last 5 seconds) and updates their name from the iOS app's request.
 


### PR DESCRIPTION
## Summary

Resolves all 63 Vale linter warnings in the wiki documentation.

### Changes Made

- Replace first-person plural ("we", "our", "us") with project-neutral language across 34 files
- Convert future tense ("will") to present tense throughout documentation
- Remove inappropriate ellipses
- Add Vale disable comments for:
  - Intentional examples in style guide tables (showing what to avoid)
  - False positives (region names like "us-east-1" containing "us")

### Validation

```
vale docs/wiki/
✔ 0 errors, 0 warnings and 0 suggestions in 124 files.
```

## Test plan

- [x] Run `vale docs/wiki/` - passes with 0 warnings
- [x] Verify documentation still reads naturally after edits
- [x] CI docs workflow validates changes