### PR TITLE
feat(infra): complete arm64/Graviton2 migration for Lambda functions

### DIFF
--- a/terraform/cloudfront_middleware.tf
+++ b/terraform/cloudfront_middleware.tf
@@ -49,6 +49,7 @@ resource "aws_lambda_function" "CloudfrontMiddleware" {
   role             = aws_iam_role.CloudfrontMiddleware.arn
   handler          = "index.handler"
   runtime          = "nodejs24.x"
+  architectures    = [local.lambda_architecture]
   publish          = true
   provider         = aws.us_east_1
   filename         = data.archive_file.CloudfrontMiddleware.output_path


### PR DESCRIPTION
## Summary

Completes the arm64/Graviton2 architecture migration for all Lambda functions.

### Changes
- Added `architectures = [local.lambda_architecture]` to CloudfrontMiddleware Lambda
- This was the only Lambda function missing the architecture specification

### Architecture Overview
| Lambda Functions | Architecture | Notes |
|------------------|--------------|-------|
| 17 functions | arm64 | Via `local.lambda_architecture` |
| StartFileUpload | x86_64 | Required for yt-dlp/ffmpeg binary compatibility |

### Expected Benefits
- **30% cost reduction** - Graviton2 pricing advantage
- **13-24% faster cold starts** - ARM architecture efficiency
- **10-20% higher throughput** - Better performance per vCPU

### Constraints Met
- ✅ Maintains <$15/month budget goal (cost reduction helps)
- ✅ All 1524 unit tests pass
- ✅ StartFileUpload correctly remains x86_64 for binary layer compatibility

## Test plan

- [x] All unit tests pass (`pnpm test`)
- [x] CI checks pass
- [x] Deploy to staging and validate
- [x] Deploy to production

Closes ma-neh