### PR TITLE
fix(youtube): resolve ENOSPC and INT32 overflow in StartFileUpload Lambda

### DIFF
--- a/infra/generated_dsql_permissions.tf
+++ b/infra/generated_dsql_permissions.tf
@@ -3,7 +3,7 @@
 
 # Auto-generated from @RequiresTable decorators
 # Do not edit manually - run: mantle generate permissions
-# Generated at: 2026-03-29T21:36:47.473Z
+# Generated at: 2026-04-06T15:52:03.099Z
 
 locals {
   lambda_dsql_roles = {

--- a/infra/lambda_start_file_upload.tf
+++ b/infra/lambda_start_file_upload.tf
@@ -52,6 +52,7 @@ module "lambda_start_file_upload" {
   memory_size        = 2048
   reserved_concurrent_executions = var.reserved_concurrency_start_file_upload
   architecture       = "x86_64"
+  ephemeral_storage  = 10240
 
   api_gateway_enabled = false
 

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -7,7 +7,7 @@ locals {
   adot_layer_arn_x86_64 = "arn:aws:lambda:${module.core.region}:901920570463:layer:aws-otel-nodejs-amd64-ver-1-30-2:1"
 
   # EventBridge event bus name
-  event_bus_name = "${module.core.name_prefix}-MediaDownloader"
+  event_bus_name = module.eventbridge.bus_name
 
   # Custom Lambda layer ARNs
   layer_yt_dlp_arn = aws_lambda_layer_version.yt_dlp.arn

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,7 +2,7 @@
 # To customize, remove the first line and this file will be skipped on re-generation.
 
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     aws = {

--- a/migrations/0003_widen_file_size.sql
+++ b/migrations/0003_widen_file_size.sql
@@ -1,0 +1,7 @@
+-- Widen files.size from integer (max ~2GB) to bigint (max ~9.2 exabytes)
+-- Aurora DSQL does not support ALTER COLUMN TYPE, DROP COLUMN, SET DEFAULT, or SET NOT NULL.
+-- Strategy: add nullable bigint column and backfill from old column.
+-- Drizzle schema maps property 'size' to column 'file_size' with app-level default(0) and notNull().
+-- The old 'size' integer column remains but is unused.
+ALTER TABLE files ADD COLUMN IF NOT EXISTS file_size BIGINT;
+UPDATE files SET file_size = size WHERE file_size IS NULL;

--- a/permissions/permissions.sql
+++ b/permissions/permissions.sql
@@ -1,6 +1,6 @@
 -- Per-Lambda PostgreSQL roles with fine-grained table permissions
 -- Auto-generated from @RequiresTable decorators
--- Generated at: 2026-03-29T21:36:47.473Z
+-- Generated at: 2026-04-06T15:52:03.099Z
 
 -- CREATE ROLES
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,7 +14,7 @@
  * - Single-table design becomes normalized relational tables
  * - TTL attribute becomes scheduled cleanup Lambda
  */
-import {boolean, index, integer, pgTable, primaryKey, text, timestamp, uuid} from 'drizzle-orm/pg-core'
+import {bigint, boolean, index, integer, pgTable, primaryKey, text, timestamp, uuid} from 'drizzle-orm/pg-core'
 
 /**
  * Users table - Core user account management (Better Auth).
@@ -50,7 +50,7 @@ export const users = pgTable('users', {
  */
 export const files = pgTable('files', {
   fileId: text('file_id').primaryKey(),
-  size: integer('size').notNull().default(0),
+  size: bigint('file_size', {mode: 'number'}).notNull().default(0),
   authorName: text('author_name').notNull(),
   authorUser: text('author_user').notNull(),
   publishDate: text('publish_date').notNull(),

--- a/src/domain/video/errorClassifier.ts
+++ b/src/domain/video/errorClassifier.ts
@@ -25,7 +25,9 @@ const PERMANENT_ERROR_PATTERNS = [
   'join this channel to get access',
   'members-only content',
   'this live event will begin',
-  'premiere will begin'
+  'premiere will begin',
+  'no space left on device',
+  'errno 28'
 ]
 
 /** Patterns indicating transient/network errors that should be retried with backoff */

--- a/src/lambdas/sqs/StartFileUpload/index.ts
+++ b/src/lambdas/sqs/StartFileUpload/index.ts
@@ -44,7 +44,8 @@ defineLambda({
     YTDLP_COOKIES_PATH: '/opt/cookies/youtube-cookies.txt',
     YTDLP_SLEEP_REQUESTS: '1',
     YTDLP_SLEEP_INTERVAL: '2',
-    YTDLP_MAX_SLEEP_INTERVAL: '5'
+    YTDLP_MAX_SLEEP_INTERVAL: '5',
+    AWS_SDK_UA_APP_ID: 'StartFileUpload'
   }
 })
 
@@ -488,7 +489,14 @@ async function processDownloadRequest(message: ValidatedDownloadQueueMessage, re
   }
 
   const videoInfo = videoInfoResult.value
-  logDebug('fetchVideoInfo =>', videoInfo as unknown as Record<string, unknown>)
+  logDebug('fetchVideoInfo =>', {
+    id: videoInfo.id,
+    title: videoInfo.title,
+    duration: videoInfo.duration,
+    formatCount: videoInfo.formats?.length,
+    upload_date: videoInfo.upload_date,
+    view_count: videoInfo.view_count
+  })
 
   // Dispatch MetadataNotification to all users waiting for this file
   await dispatchMetadataNotifications(fileId, videoInfo)

--- a/src/lambdas/sqs/StartFileUpload/index.ts
+++ b/src/lambdas/sqs/StartFileUpload/index.ts
@@ -35,6 +35,7 @@ defineLambda({
   dockerfile: 'Dockerfile.download',
   architecture: 'x86_64',
   memorySize: 2048,
+  ephemeralStorage: 10240,
   timeout: 900,
   reservedConcurrency: 1,
   secrets: {GITHUB_PERSONAL_TOKEN: 'github.issue.token'},

--- a/src/services/youtube/youtube.ts
+++ b/src/services/youtube/youtube.ts
@@ -1,6 +1,6 @@
 import {execSync, spawn} from 'child_process'
 import {createReadStream, existsSync, readdirSync, statSync} from 'fs'
-import {copyFile, stat, unlink} from 'fs/promises'
+import {copyFile, readdir, stat, unlink} from 'fs/promises'
 import type {YtDlpVideoInfo} from '#types/youtube'
 import {metrics, MetricUnit} from '@mantleframework/observability'
 import {logDebug, logError} from '@mantleframework/observability'
@@ -103,6 +103,28 @@ function getYtdlpConfig() {
     SLEEP_INTERVAL: getOptionalEnv('YTDLP_SLEEP_INTERVAL', '2'),
     /** Maximum sleep between downloads (seconds) - random delay between min and max */
     MAX_SLEEP_INTERVAL: getOptionalEnv('YTDLP_MAX_SLEEP_INTERVAL', '5')
+  }
+}
+
+/** Video file extensions that yt-dlp may leave in /tmp (intermediates + output) */
+const VIDEO_FILE_EXTENSIONS = ['.mp4', '.m4a', '.webm', '.mkv', '.part', '.ytdl']
+
+/**
+ * Remove stale video files from /tmp left by previous invocations.
+ * Lambda containers are reused — crashed/timed-out downloads leave
+ * intermediate files (.f137.mp4, .f140.m4a, .part) that accumulate.
+ * Preserves the cookies file.
+ */
+async function cleanupStaleTempFiles(): Promise<void> {
+  try {
+    const files = await readdir('/tmp')
+    const staleFiles = files.filter((f) => VIDEO_FILE_EXTENSIONS.some((ext) => f.endsWith(ext)))
+    if (staleFiles.length > 0) {
+      logDebug('Cleaning up stale temp files', {count: staleFiles.length, files: staleFiles})
+      await Promise.all(staleFiles.map((f) => unlink(`/tmp/${f}`).catch(() => {})))
+    }
+  } catch {
+    // /tmp may not be listable in some environments
   }
 }
 
@@ -462,6 +484,9 @@ export async function downloadVideoToS3(uri: string, bucket: string, key: string
   const startTime = Date.now()
 
   try {
+    // Clean up stale files from previous invocations (container reuse)
+    await cleanupStaleTempFiles()
+
     // Prepare cookies from Lambda layer
     await prepareCookies()
 

--- a/src/services/youtube/youtube.ts
+++ b/src/services/youtube/youtube.ts
@@ -62,7 +62,7 @@ function runLayerDiagnostics(binaryPath: string): void {
 
   // Check if deno is executable
   try {
-    checks['deno-version'] = execSync('/opt/bin/deno --version 2>&1 | head -1', {timeout: 5000, shell: '/bin/sh'}).toString().trim()
+    checks['deno-version'] = execSync('/opt/bin/deno --version', {timeout: 5000}).toString().split('\n')[0]?.trim()
   } catch (e) {
     checks['deno-version'] = `error: ${String(e).substring(0, 200)}`
   }
@@ -405,9 +405,9 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[]): Promise<void> {
     const ytdlp = spawn(ytdlpBinaryPath, args, {cwd: '/tmp'})
 
     let stderr = ''
-    let lastLoggedPercent = -10 // Log every 10% progress
+    let lastLoggedPercent = -25 // Log every 25% progress
     let lastLogTime = Date.now()
-    const LOG_INTERVAL_MS = 30000 // Also log at least every 30 seconds
+    const LOG_INTERVAL_MS = 60000 // Also log at least every 60 seconds
 
     ytdlp.stderr.on('data', (chunk) => {
       const data = chunk.toString()
@@ -421,14 +421,14 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[]): Promise<void> {
           const now = Date.now()
           const timeSinceLastLog = now - lastLogTime
 
-          // Log if: 10% progress milestone, 30s elapsed, or merging started
-          const shouldLog = (progress.percent !== undefined && progress.percent >= lastLoggedPercent + 10) ||
+          // Log if: 25% progress milestone, 60s elapsed, or download complete
+          const shouldLog = (progress.percent !== undefined && progress.percent >= lastLoggedPercent + 25) ||
             timeSinceLastLog >= LOG_INTERVAL_MS ||
             (progress.percent === 100)
 
           if (shouldLog && progress.percent !== undefined) {
             logDebug('yt-dlp progress', {percent: `${progress.percent.toFixed(1)}%`, size: progress.size, speed: progress.speed, eta: progress.eta})
-            lastLoggedPercent = Math.floor(progress.percent / 10) * 10
+            lastLoggedPercent = Math.floor(progress.percent / 25) * 25
             lastLogTime = now
           }
         }

--- a/test/domain/video/error-classifier.test.ts
+++ b/test/domain/video/error-classifier.test.ts
@@ -152,7 +152,10 @@ describe('errorClassifier', () => {
         ['The uploader has not made this video available'],
         ['Video is unavailable'],
         ['Join this channel to get access'],
-        ['Members-only content']
+        ['Members-only content'],
+        ['No space left on device'],
+        ['[Errno 28] No space left on device'],
+        ['yt-dlp exited with code 1: ERROR: unable to write data: [Errno 28] No space left on device']
       ])('should classify "%s" as permanent', (errorMessage) => {
         const error = new Error(errorMessage)
 

--- a/test/integration/globalSetup.ts
+++ b/test/integration/globalSetup.ts
@@ -39,7 +39,7 @@ function getSchemaPrefix(): string {
  * - UUID → TEXT for test simplicity with regular PostgreSQL
  *
  * DO NOT add DEFAULT NULL or other schema modifications here.
- * All schema definitions belong in migrations/0001_schema.sql.
+ * All schema definitions belong in migrations/*.sql files.
  */
 function adaptMigrationForSchema(migrationSql: string, schema: string): string {
   let adapted = migrationSql
@@ -60,13 +60,17 @@ function adaptMigrationForSchema(migrationSql: string, schema: string): string {
 
   // Add schema prefix to table references (for worker isolation)
   for (const table of tables) {
-    // Match table name in CREATE TABLE, CREATE INDEX, ON clauses
+    // Match table name in CREATE TABLE, ALTER TABLE, CREATE INDEX, UPDATE, ON clauses
     // Use word boundaries to avoid partial matches
     const createTablePattern = new RegExp(`CREATE TABLE IF NOT EXISTS ${table}`, 'g')
+    const alterTablePattern = new RegExp(`ALTER TABLE ${table} `, 'g')
+    const updateTablePattern = new RegExp(`UPDATE ${table} `, 'g')
     const onParenPattern = new RegExp(`ON ${table}\\(`, 'g')
     const onSpacePattern = new RegExp(`ON ${table} `, 'g')
 
     adapted = adapted.replace(createTablePattern, `CREATE TABLE IF NOT EXISTS ${schema}.${table}`)
+    adapted = adapted.replace(alterTablePattern, `ALTER TABLE ${schema}.${table} `)
+    adapted = adapted.replace(updateTablePattern, `UPDATE ${schema}.${table} `)
     adapted = adapted.replace(onParenPattern, `ON ${schema}.${table}(`)
     adapted = adapted.replace(onSpacePattern, `ON ${schema}.${table} `)
   }
@@ -171,9 +175,10 @@ export async function setup(): Promise<void> {
   log(`[globalSetup] Starting schema creation with prefix: "${prefix}"`)
   log(`[globalSetup] MAX_WORKERS: ${MAX_WORKERS}`)
 
-  // Read migration files (0001_schema.sql contains both schema and indexes)
+  // Read schema migration files in order (excludes DSQL-specific role migrations)
   const migrationsDir = path.join(process.cwd(), 'migrations')
-  const schemaMigration = fs.readFileSync(path.join(migrationsDir, '0001_schema.sql'), 'utf8')
+  const migrationFiles = fs.readdirSync(migrationsDir).filter((f: string) => f.endsWith('.sql') && !f.includes('lambda_roles')).sort()
+  const schemaMigration = migrationFiles.map((f: string) => fs.readFileSync(path.join(migrationsDir, f), 'utf8')).join('\n')
 
   // Wait for PostgreSQL to be ready with retry logic (handles CI startup delays)
   const sql = await waitForPostgres(databaseUrl)


### PR DESCRIPTION
## Summary
StartFileUpload Lambda was failing to download and persist large videos due to three cascading issues:
- **ENOSPC**: Lambda `/tmp` ephemeral storage was 512MB (default), too small for ffmpeg merge step (~2.5-3x video size)
- **INT32 overflow**: `files.size` column was `integer` (max 2GB), videos >2GB caused Zod validation failure
- **Error misclassification**: ENOSPC was classified as `transient`, burning 5 retries over hours
- **Log noise**: Four distinct warnings cluttered CloudWatch logs

## Changes

### ENOSPC Fix
- Increased ephemeral storage to 10240MB (AWS max) via `defineLambda` — cost negligible with `reservedConcurrency: 1`
- Added `no space left on device` and `errno 28` to `PERMANENT_ERROR_PATTERNS` in `errorClassifier.ts`
- Added `cleanupStaleTempFiles()` — removes stale `.mp4/.m4a/.webm/.part/.ytdl` from `/tmp` before each download (handles Lambda container reuse)

### INT32 Overflow Fix
- Added `file_size BIGINT` column via DSQL-compatible migration (ADD COLUMN + backfill, since DSQL doesn't support ALTER COLUMN TYPE)
- Updated Drizzle schema to map `size` property to new `file_size` column with `bigint({mode: 'number'})`
- Old `size` integer column remains unused (DSQL doesn't support DROP COLUMN)

### Log Noise Cleanup
- Fixed `head: No such file or directory` — replaced shell pipe with `split('\n')[0]` in diagnostics
- Fixed `timestamp is a reserved key` — stopped logging full yt-dlp videoInfo object (has `timestamp` field); now logs selected fields only
- Fixed `userAgentAppId exceeds max length` — set `AWS_SDK_UA_APP_ID=StartFileUpload` as static env var
- Throttled download progress logs from 10%/30s to 25%/60s intervals

### Integration Test Fix
- Updated `globalSetup.ts` to read all schema migrations (was hardcoded to `0001_schema.sql` only)
- Added `ALTER TABLE` and `UPDATE` patterns to schema adapter for worker isolation
- Excluded DSQL-specific `lambda_roles` migration from test setup

## Test plan
- [x] Unit tests pass (220 tests, including 3 new ENOSPC cases)
- [x] Integration tests pass (all CI green)
- [x] TypeScript + ESLint clean
- [x] Staging deployment verified — video `aDkj0WHVSdk` (2.5GB) downloads successfully
- [x] Lambda config shows 10240MB ephemeral storage
- [x] Migration 0003 applied on staging