### PR TITLE
fix(ci): generate dependency graph before GraphRAG extract, bump aws-credentials

### DIFF
--- a/.github/workflows/auto-update-graphrag.yml
+++ b/.github/workflows/auto-update-graphrag.yml
@@ -25,6 +25,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
+      - name: Generate dependency graph
+        run: npx mantle generate graph
+
       - name: Update GraphRAG knowledge graph
         run: pnpm run graphrag:extract
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Configure AWS credentials (Production)
         if: steps.check-creds.outputs.configured == 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_PRODUCTION }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -71,7 +71,7 @@ jobs:
           tofu_version: ${{ env.TOFU_VERSION }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6
         with:
           role-to-assume: ${{ inputs.environment == 'production' && secrets.AWS_ROLE_PRODUCTION || secrets.AWS_ROLE_STAGING }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary
- **Fix GraphRAG CI failure**: The auto-update-graphrag workflow was missing a mantle generate graph step before graphrag:extract, causing ENOENT on build/graph.json ([failed run](https://github.com/j0nathan-ll0yd/mantle-OfflineMediaDownloader/actions/runs/24060263184/job/70174921676))
- **Bump aws-actions/configure-aws-credentials** from 6.0.0 to 6.1.0 (SHA-pinned, subsumes #460)

## Test plan
- [ ] Verify auto-update-graphrag workflow passes on merge
- [ ] Verify deploy-production and rollback workflows still reference valid action SHA

Closes #460