### PR TITLE
refactor(graphrag): replace pgTable regex with ts-morph AST walk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # pnpm/action-setup v6.x silently installs pnpm v11 which breaks multi-repo
+      # CI lockfile parsing (ERR_PNPM_BROKEN_LOCKFILE). Verified v6.0.0 and v6.0.2
+      # both fail. See pnpm/action-setup#225, #227, #228.
+      - dependency-name: "pnpm/action-setup"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,7 +34,9 @@ jobs:
         run: GIT_SSH_COMMAND="ssh -i ~/.ssh/mantle_deploy_key -o StrictHostKeyChecking=no" git clone --depth 1 --branch "${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-main}}" git@github.com:j0nathan-ll0yd/mantle.git ../mantle || GIT_SSH_COMMAND="ssh -i ~/.ssh/mantle_deploy_key -o StrictHostKeyChecking=no" git clone --depth 1 --branch main git@github.com:j0nathan-ll0yd/mantle.git ../mantle
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb  # v6.0.0
+        # Pinned to v5 — v6.x silently installs pnpm v11 which cannot parse v10
+        # lockfiles in multi-repo CI (ERR_PNPM_BROKEN_LOCKFILE). See action-setup#225.
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/graphrag/extract.ts
+++ b/graphrag/extract.ts
@@ -13,6 +13,7 @@
 
 import fs from 'fs/promises'
 import path from 'path'
+import {Project, SyntaxKind} from 'ts-morph'
 import {fileURLToPath} from 'url'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -141,24 +142,34 @@ async function discoverLambdas(): Promise<LambdaEntry[]> {
 }
 
 /**
- * Discover Entity names dynamically from Drizzle schema
- * Parses src/lib/vendor/Drizzle/schema.ts to find all pgTable definitions
+ * Discover Entity names dynamically from Drizzle schema via ts-morph AST walk.
+ *
+ * Finds all exported VariableDeclarations whose initializer is a CallExpression
+ * to `pgTable`, then extracts the variable name and PascalCases it.
+ *
+ * Replaces the previous regex-based scanner per C1 compiler-API discipline.
  */
 async function discoverEntities(): Promise<string[]> {
   const schemaPath = path.join(projectRoot, 'src', 'db', 'schema.ts')
-  const content = await fs.readFile(schemaPath, 'utf-8')
+  const project = new Project({skipAddingFilesFromTsConfig: true, compilerOptions: {allowJs: true}})
+  const sourceFile = project.addSourceFileAtPath(schemaPath)
 
-  // Match pattern: export const tableName = pgTable('
-  const tableRegex = /export\s+const\s+(\w+)\s*=\s*pgTable\s*\(/g
   const entities: string[] = []
-
-  let match
-  while ((match = tableRegex.exec(content)) !== null) {
-    const varName = match[1]
-    // Convert camelCase to PascalCase (e.g., userFiles -> UserFiles, verification -> Verification)
-    const entityName = varName.charAt(0).toUpperCase() + varName.slice(1)
-    entities.push(entityName)
+  for (const varStmt of sourceFile.getVariableStatements()) {
+    if (!varStmt.isExported()) continue
+    for (const decl of varStmt.getDeclarations()) {
+      const init = decl.getInitializer()
+      if (!init || !init.isKind(SyntaxKind.CallExpression)) continue
+      const callTarget = init.getExpression()
+      if (callTarget.isKind(SyntaxKind.Identifier) && callTarget.getText() === 'pgTable') {
+        const varName = decl.getName()
+        const entityName = varName.charAt(0).toUpperCase() + varName.slice(1)
+        entities.push(entityName)
+      }
+    }
   }
+
+  project.removeSourceFile(sourceFile)
 
   // Map 'verification' table to 'VerificationTokens' for consistency with existing naming
   return entities.map((e) => (e === 'Verification' ? 'VerificationTokens' : e))


### PR DESCRIPTION
## Summary

- Replaces regex-based entity discovery in `graphrag/extract.ts` with ts-morph `VariableStatement` walk
- Part of the TypeScript Compiler API book alignment work (mantle PR #64 landed the framework changes)
- `knowledge-graph.json` output verified byte-identical to pre-change baseline

## Changes

`discoverEntities()` previously used a regex to find Drizzle table definitions. Now uses ts-morph to walk exported `VariableDeclaration`s and check if the initializer is a `CallExpression` to `pgTable`.

This handles edge cases the regex missed: multi-line declarations, type annotations on the variable, unusual whitespace.

## Verification

- Baseline captured before change, then `pnpm run graphrag:extract` after change
- `diff` of knowledge-graph.json: empty — byte-identical output

## Test plan

- [x] `pnpm run graphrag:extract` produces identical output (6 entities, 17 lambdas, 41 nodes, 38 edges)
- [x] Pre-commit hooks pass (secrets check, dependency-cruiser)
- [x] Pre-push hooks pass (typecheck, lint, format)
