### PR TITLE
fix(ci): replace broken third-party action with gh CLI in mutation tests

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -28,13 +29,20 @@ jobs:
       - uses: ./.github/actions/build-project
 
       - name: Download previous incremental file
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275957ba8f3ef8401e6f8  # v19
-        with:
-          workflow: mutation-tests.yml
-          name: stryker-incremental
-          path: reports/
-          if_no_artifact_found: warn
-        continue-on-error: true
+        run: |
+          RUN_ID=$(gh run list --workflow mutation-tests.yml --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::warning::No previous successful mutation test run found. Running full mutation test."
+            exit 0
+          fi
+          echo "Downloading incremental file from run $RUN_ID"
+          if ! gh run download "$RUN_ID" -n stryker-incremental -D reports/; then
+            echo "::warning::Failed to download incremental file (artifact may have expired). Running full mutation test."
+            exit 0
+          fi
+          echo "Successfully downloaded incremental file"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run mutation tests
         run: pnpm run test:mutation:incremental


### PR DESCRIPTION
## Summary

- Replace `dawidd6/action-download-artifact` (broken SHA from upstream force-push) with `gh run download` script
- Add `actions: read` permission for `gh run list`/`gh run download` API calls
- Remove `continue-on-error: true` since the script handles all failure paths internally with `exit 0`

## Why

The weekly mutation tests workflow fails at job setup because the third-party action was SHA-pinned at a commit that no longer exists. Replacing with `gh` CLI eliminates the third-party dependency entirely — no future breakage from upstream tag movements.

## Test plan

- [ ] Manual workflow dispatch succeeds (`gh workflow run mutation-tests.yml`)
- [ ] Download step shows green (or `::warning::` annotation if no prior artifact)
- [ ] Stryker mutation tests execute
- [ ] Both artifacts (`mutation-report`, `stryker-incremental`) are uploaded