### PR TITLE
test: raise mutation test coverage (phases 1-3)

### DIFF
--- a/test/entities/queries/cascadeOperations.test.ts
+++ b/test/entities/queries/cascadeOperations.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for Cascade Operations
+ *
+ * Tests mutable logic: conditional branching in deleteFileCascade
+ * (!existing -> early return, remaining.length > 0 -> partial return).
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockUserFile} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({
+  userFiles: {userId: 'userId', fileId: 'fileId'},
+  userDevices: {userId: 'userId', deviceId: 'deviceId'},
+  sessions: {userId: 'userId'},
+  accounts: {userId: 'userId'},
+  users: {id: 'id'},
+  files: {fileId: 'fileId'},
+  fileDownloads: {fileId: 'fileId'}
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition')
+}))
+
+const {deleteUserCascade, deleteUserRelationships, deleteUserAuthRecords, deleteFileCascade} = await import(
+  '#entities/queries/cascadeOperations'
+)
+
+describe('Cascade Operations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('deleteUserCascade', () => {
+    it('should delete all related records', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteUserCascade('user-1')).resolves.toBeUndefined()
+
+      // Should call delete 5 times: userFiles, userDevices, sessions, accounts, users
+      expect(mockDb.delete).toHaveBeenCalledTimes(5)
+    })
+  })
+
+  describe('deleteUserRelationships', () => {
+    it('should delete junction table records', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteUserRelationships('user-1')).resolves.toBeUndefined()
+
+      // Should call delete 2 times: userFiles, userDevices
+      expect(mockDb.delete).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('deleteUserAuthRecords', () => {
+    it('should delete auth records', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteUserAuthRecords('user-1')).resolves.toBeUndefined()
+
+      // Should call delete 2 times: sessions, accounts
+      expect(mockDb.delete).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('deleteFileCascade', () => {
+    it('should return existed:false when user-file link does not exist', async () => {
+      // First select returns empty (no existing link)
+      mockDb._setSelectResult([])
+
+      const result = await deleteFileCascade('user-1', 'file-1')
+
+      expect(result).toEqual({existed: false, fileRemoved: false})
+      // Should not call delete since link doesn't exist
+      expect(mockDb.delete).not.toHaveBeenCalled()
+    })
+
+    it('should return fileRemoved:false when other users still linked', async () => {
+      const existingLink = createMockUserFile()
+      const otherLink = createMockUserFile({userId: 'user-2'})
+
+      // Track select call count to return different results
+      let selectCallCount = 0
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++
+        const result = selectCallCount === 1
+          ? [existingLink] // First: existing link found
+          : [otherLink]    // Third: remaining links
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(result).then(resolve, reject)
+              }),
+              then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(result).then(resolve, reject)
+            }),
+            then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(result).then(resolve, reject)
+          })
+        }
+      })
+      mockDb._setDeleteResult([])
+
+      const result = await deleteFileCascade('user-1', 'file-1')
+
+      expect(result).toEqual({existed: true, fileRemoved: false})
+    })
+
+    it('should return fileRemoved:true when file becomes orphaned', async () => {
+      const existingLink = createMockUserFile()
+
+      // Track select call count to return different results
+      let selectCallCount = 0
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++
+        const result = selectCallCount === 1
+          ? [existingLink] // First: existing link found
+          : []             // Third: no remaining links (orphaned)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(result).then(resolve, reject)
+              }),
+              then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(result).then(resolve, reject)
+            }),
+            then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(result).then(resolve, reject)
+          })
+        }
+      })
+      mockDb._setDeleteResult([])
+
+      const result = await deleteFileCascade('user-1', 'file-1')
+
+      expect(result).toEqual({existed: true, fileRemoved: true})
+    })
+  })
+})

--- a/test/entities/queries/deviceQueries.test.ts
+++ b/test/entities/queries/deviceQueries.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for Device Queries
+ *
+ * Tests mutable logic: null coalescing (result[0] ?? null),
+ * empty array early return (deviceIds.length === 0),
+ * and non-null assertions on returning().
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockDevice} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({devices: {deviceId: 'deviceId'}}))
+vi.mock('#db/zodSchemas', () => ({
+  deviceInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  deviceUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
+  inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
+}))
+
+const {getDevice, getDevicesBatch, createDevice, upsertDevice, updateDevice, deleteDevice, getAllDevices} = await import(
+  '#entities/queries/deviceQueries'
+)
+
+describe('Device Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getDevice', () => {
+    it('should return device when found', async () => {
+      const mockDevice = createMockDevice()
+      mockDb._setSelectResult([mockDevice])
+
+      const result = await getDevice('device-1')
+
+      expect(result).toEqual(mockDevice)
+    })
+
+    it('should return null when device not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getDevice('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getDevicesBatch', () => {
+    it('should return empty array for empty input (early return)', async () => {
+      const result = await getDevicesBatch([])
+
+      expect(result).toEqual([])
+      expect(mockDb.select).not.toHaveBeenCalled()
+    })
+
+    it('should return devices for non-empty input', async () => {
+      const devices = [createMockDevice(), createMockDevice({deviceId: 'device-2'})]
+      mockDb._setSelectResult(devices)
+
+      const result = await getDevicesBatch(['device-1', 'device-2'])
+
+      expect(result).toEqual(devices)
+    })
+  })
+
+  describe('createDevice', () => {
+    it('should return the created device', async () => {
+      const mockDevice = createMockDevice()
+      mockDb._setInsertResult([mockDevice])
+
+      const result = await createDevice({
+        deviceId: 'device-1',
+        name: 'iPhone',
+        token: 'token-1',
+        systemVersion: '17.0',
+        systemName: 'iOS',
+        endpointArn: 'arn:endpoint'
+      })
+
+      expect(result).toEqual(mockDevice)
+    })
+  })
+
+  describe('upsertDevice', () => {
+    it('should return the upserted device', async () => {
+      const mockDevice = createMockDevice()
+      mockDb._setInsertResult([mockDevice])
+
+      const result = await upsertDevice({
+        deviceId: 'device-1',
+        name: 'iPhone',
+        token: 'token-1',
+        systemVersion: '17.0',
+        systemName: 'iOS',
+        endpointArn: 'arn:endpoint'
+      })
+
+      expect(result).toEqual(mockDevice)
+    })
+  })
+
+  describe('updateDevice', () => {
+    it('should return the updated device', async () => {
+      const mockDevice = createMockDevice({name: 'Updated iPhone'})
+      mockDb._setUpdateResult([mockDevice])
+
+      const result = await updateDevice('device-1', {name: 'Updated iPhone'})
+
+      expect(result).toEqual(mockDevice)
+    })
+  })
+
+  describe('deleteDevice', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteDevice('device-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('getAllDevices', () => {
+    it('should return all devices', async () => {
+      const devices = [createMockDevice(), createMockDevice({deviceId: 'device-2'})]
+      mockDb._setSelectResult(devices)
+
+      const result = await getAllDevices()
+
+      expect(result).toEqual(devices)
+    })
+
+    it('should return empty array when no devices exist', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getAllDevices()
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/test/entities/queries/fileQueries.test.ts
+++ b/test/entities/queries/fileQueries.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for File Queries
+ *
+ * Tests mutable logic: null coalescing (result[0] ?? null, result[0]?.status ?? null),
+ * empty array early return (fileIds.length === 0), size default (input.size ?? 0),
+ * and non-null assertions on returning().
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockFile, createMockFileDownload} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({
+  files: {fileId: 'fileId', key: 'key', status: 'status'},
+  fileDownloads: {fileId: 'fileId'}
+}))
+vi.mock('#db/zodSchemas', () => ({
+  fileInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  fileUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))},
+  fileDownloadInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  fileDownloadUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
+  inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
+}))
+
+const {
+  getFile, getFileStatus, getFilesBatch, getFilesByKey,
+  createFile, upsertFile, updateFile, deleteFile,
+  getFileDownload, createFileDownload, upsertFileDownload, updateFileDownload, deleteFileDownload
+} = await import('#entities/queries/fileQueries')
+
+describe('File Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // File Operations
+
+  describe('getFile', () => {
+    it('should return file when found', async () => {
+      const mockFile = createMockFile()
+      mockDb._setSelectResult([mockFile])
+
+      const result = await getFile('file-1')
+
+      expect(result).toEqual(mockFile)
+    })
+
+    it('should return null when file not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getFile('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getFileStatus', () => {
+    it('should return status when file found', async () => {
+      mockDb._setSelectResult([{status: 'Downloaded'}])
+
+      const result = await getFileStatus('file-1')
+
+      expect(result).toBe('Downloaded')
+    })
+
+    it('should return null when file not found (optional chaining + null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getFileStatus('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getFilesBatch', () => {
+    it('should return empty array for empty input (early return)', async () => {
+      const result = await getFilesBatch([])
+
+      expect(result).toEqual([])
+      expect(mockDb.select).not.toHaveBeenCalled()
+    })
+
+    it('should return files for non-empty input', async () => {
+      const files = [createMockFile(), createMockFile({fileId: 'file-2'})]
+      mockDb._setSelectResult(files)
+
+      const result = await getFilesBatch(['file-1', 'file-2'])
+
+      expect(result).toEqual(files)
+    })
+  })
+
+  describe('getFilesByKey', () => {
+    it('should return matching files', async () => {
+      const files = [createMockFile()]
+      mockDb._setSelectResult(files)
+
+      const result = await getFilesByKey('test.mp4')
+
+      expect(result).toEqual(files)
+    })
+  })
+
+  describe('createFile', () => {
+    it('should return the created file', async () => {
+      const mockFile = createMockFile()
+      mockDb._setInsertResult([mockFile])
+
+      const result = await createFile({
+        fileId: 'file-1', authorName: 'Author', authorUser: 'user',
+        publishDate: '2021-01-01', description: 'desc', key: 'file.mp4',
+        url: null, contentType: 'video/mp4', title: 'Test', status: 'Queued'
+      })
+
+      expect(result).toEqual(mockFile)
+    })
+  })
+
+  describe('upsertFile', () => {
+    it('should return the upserted file', async () => {
+      const mockFile = createMockFile()
+      mockDb._setInsertResult([mockFile])
+
+      const result = await upsertFile({
+        fileId: 'file-1', authorName: 'Author', authorUser: 'user',
+        publishDate: '2021-01-01', description: 'desc', key: 'file.mp4',
+        url: null, contentType: 'video/mp4', title: 'Test', status: 'Queued'
+      })
+
+      expect(result).toEqual(mockFile)
+    })
+  })
+
+  describe('updateFile', () => {
+    it('should return the updated file', async () => {
+      const mockFile = createMockFile({title: 'Updated'})
+      mockDb._setUpdateResult([mockFile])
+
+      const result = await updateFile('file-1', {title: 'Updated'})
+
+      expect(result).toEqual(mockFile)
+    })
+  })
+
+  describe('deleteFile', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteFile('file-1')).resolves.toBeUndefined()
+    })
+  })
+
+  // FileDownload Operations
+
+  describe('getFileDownload', () => {
+    it('should return file download when found', async () => {
+      const mockDownload = createMockFileDownload()
+      mockDb._setSelectResult([mockDownload])
+
+      const result = await getFileDownload('file-1')
+
+      expect(result).toEqual(mockDownload)
+    })
+
+    it('should return null when not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getFileDownload('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('createFileDownload', () => {
+    it('should return the created file download', async () => {
+      const mockDownload = createMockFileDownload()
+      mockDb._setInsertResult([mockDownload])
+
+      const result = await createFileDownload({
+        fileId: 'file-1', status: 'Pending', retryCount: 0, maxRetries: 5
+      })
+
+      expect(result).toEqual(mockDownload)
+    })
+  })
+
+  describe('upsertFileDownload', () => {
+    it('should return the upserted file download', async () => {
+      const mockDownload = createMockFileDownload()
+      mockDb._setInsertResult([mockDownload])
+
+      const result = await upsertFileDownload({
+        fileId: 'file-1', status: 'Pending', retryCount: 0, maxRetries: 5
+      })
+
+      expect(result).toEqual(mockDownload)
+    })
+  })
+
+  describe('updateFileDownload', () => {
+    it('should return the updated file download', async () => {
+      const mockDownload = createMockFileDownload({status: 'Downloading'})
+      mockDb._setUpdateResult([mockDownload])
+
+      const result = await updateFileDownload('file-1', {status: 'Downloading'})
+
+      expect(result).toEqual(mockDownload)
+    })
+  })
+
+  describe('deleteFileDownload', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteFileDownload('file-1')).resolves.toBeUndefined()
+    })
+  })
+})

--- a/test/entities/queries/preparedQueries.test.ts
+++ b/test/entities/queries/preparedQueries.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for Prepared Queries
+ *
+ * Tests mutable logic: null coalescing (results[0] ?? null)
+ * and map transform (results.map(r => r.file)).
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockFile, createMockSession} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({
+  files: {fileId: 'fileId', key: 'key'},
+  sessions: {id: 'id', token: 'token'},
+  userFiles: {userId: 'userId', fileId: 'fileId'}
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
+  sql: {placeholder: vi.fn((name: string) => ({placeholder: name}))}
+}))
+
+const {getFileByKeyPrepared, getUserFilesPrepared, getSessionByTokenPrepared} = await import(
+  '#entities/queries/preparedQueries'
+)
+
+describe('Prepared Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getFileByKeyPrepared', () => {
+    it('should return file when found', async () => {
+      const mockFile = createMockFile()
+      // Prepared queries call db.select().from().where().prepare() then execute()
+      // Our mock needs to handle the prepare+execute chain
+      const executeMock = vi.fn().mockResolvedValue([mockFile])
+      const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            prepare: prepareMock
+          })
+        })
+      }))
+
+      const result = await getFileByKeyPrepared('test.mp4')
+
+      expect(result).toEqual(mockFile)
+    })
+
+    it('should return null when file not found (null coalescing)', async () => {
+      const executeMock = vi.fn().mockResolvedValue([])
+      const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            prepare: prepareMock
+          })
+        })
+      }))
+
+      const result = await getFileByKeyPrepared('nonexistent.mp4')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getUserFilesPrepared', () => {
+    it('should return mapped file objects from join', async () => {
+      const file1 = createMockFile({fileId: 'file-1'})
+      const file2 = createMockFile({fileId: 'file-2'})
+      const executeMock = vi.fn().mockResolvedValue([{file: file1}, {file: file2}])
+      const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              prepare: prepareMock
+            })
+          })
+        })
+      }))
+
+      const result = await getUserFilesPrepared('user-1')
+
+      expect(result).toEqual([file1, file2])
+    })
+
+    it('should return empty array when user has no files', async () => {
+      const executeMock = vi.fn().mockResolvedValue([])
+      const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              prepare: prepareMock
+            })
+          })
+        })
+      }))
+
+      const result = await getUserFilesPrepared('user-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getSessionByTokenPrepared', () => {
+    it('should return session when found', async () => {
+      const mockSession = createMockSession()
+      const executeMock = vi.fn().mockResolvedValue([mockSession])
+      const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              prepare: prepareMock
+            })
+          })
+        })
+      }))
+
+      const result = await getSessionByTokenPrepared('valid-token')
+
+      expect(result).toEqual(mockSession)
+    })
+
+    it('should return null when token not found (null coalescing)', async () => {
+      const executeMock = vi.fn().mockResolvedValue([])
+      const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              prepare: prepareMock
+            })
+          })
+        })
+      }))
+
+      const result = await getSessionByTokenPrepared('invalid-token')
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/test/entities/queries/relationshipQueries.test.ts
+++ b/test/entities/queries/relationshipQueries.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Unit tests for Relationship Queries
+ *
+ * Tests mutable logic: null coalescing (result[0] ?? null),
+ * map transforms (result.map(r => r.file)), empty array early returns,
+ * and upsert branching (result.length === 0 -> fetch existing).
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockUserFile, createMockUserDevice, createMockFile, createMockDevice} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({
+  userFiles: {userId: 'userId', fileId: 'fileId'},
+  userDevices: {userId: 'userId', deviceId: 'deviceId'},
+  files: {fileId: 'fileId'},
+  devices: {deviceId: 'deviceId'},
+  users: {id: 'id'}
+}))
+vi.mock('#db/zodSchemas', () => ({
+  userFileInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  userDeviceInsertSchema: {parse: vi.fn((v: unknown) => v)}
+}))
+vi.mock('#db/fkEnforcement', () => ({
+  assertUserExists: vi.fn().mockResolvedValue(undefined),
+  assertFileExists: vi.fn().mockResolvedValue(undefined),
+  assertDeviceExists: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
+  or: vi.fn((...args: unknown[]) => args),
+  inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
+}))
+
+const {
+  getUserFile, getUserFilesByUserId, getUserFileIdsByUserId, getUserFilesByFileId,
+  getFilesForUser, createUserFile, upsertUserFile, deleteUserFile,
+  deleteUserFilesByUserId, deleteUserFilesBatch,
+  getUserDevice, getUserDevicesByUserId, getUserDeviceIdsByUserId, getUserDevicesByDeviceId,
+  getDevicesForUser, getDeviceIdsForUsers, createUserDevice, upsertUserDevice,
+  deleteUserDevice, deleteUserDevicesByUserId, deleteUserDevicesByDeviceId
+} = await import('#entities/queries/relationshipQueries')
+
+describe('Relationship Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // UserFile Operations
+
+  describe('getUserFile', () => {
+    it('should return user-file when found', async () => {
+      const mockUf = createMockUserFile()
+      mockDb._setSelectResult([mockUf])
+
+      const result = await getUserFile('user-1', 'file-1')
+
+      expect(result).toEqual(mockUf)
+    })
+
+    it('should return null when not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getUserFile('user-1', 'nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getUserFilesByUserId', () => {
+    it('should return user files', async () => {
+      const ufs = [createMockUserFile(), createMockUserFile({fileId: 'file-2'})]
+      mockDb._setSelectResult(ufs)
+
+      const result = await getUserFilesByUserId('user-1')
+
+      expect(result).toEqual(ufs)
+    })
+  })
+
+  describe('getUserFileIdsByUserId', () => {
+    it('should return mapped file IDs', async () => {
+      mockDb._setSelectResult([{fileId: 'file-1'}, {fileId: 'file-2'}])
+
+      const result = await getUserFileIdsByUserId('user-1')
+
+      expect(result).toEqual(['file-1', 'file-2'])
+    })
+
+    it('should return empty array when no files', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getUserFileIdsByUserId('user-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getUserFilesByFileId', () => {
+    it('should return user files for file', async () => {
+      const ufs = [createMockUserFile()]
+      mockDb._setSelectResult(ufs)
+
+      const result = await getUserFilesByFileId('file-1')
+
+      expect(result).toEqual(ufs)
+    })
+  })
+
+  describe('getFilesForUser', () => {
+    it('should return mapped file objects from join', async () => {
+      const file1 = createMockFile({fileId: 'file-1'})
+      const file2 = createMockFile({fileId: 'file-2'})
+      mockDb._setSelectResult([{file: file1}, {file: file2}])
+
+      const result = await getFilesForUser('user-1')
+
+      expect(result).toEqual([file1, file2])
+    })
+
+    it('should return empty array when user has no files', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getFilesForUser('user-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('createUserFile', () => {
+    it('should return the created user-file', async () => {
+      const mockUf = createMockUserFile()
+      mockDb._setInsertResult([mockUf])
+
+      const result = await createUserFile({userId: 'user-1', fileId: 'file-1'})
+
+      expect(result).toEqual(mockUf)
+    })
+  })
+
+  describe('upsertUserFile', () => {
+    it('should return new row when insert succeeds (no conflict)', async () => {
+      const mockUf = createMockUserFile()
+      mockDb._setInsertResult([mockUf])
+
+      const result = await upsertUserFile({userId: 'user-1', fileId: 'file-1'})
+
+      expect(result).toEqual(mockUf)
+    })
+
+    it('should fetch existing row when conflict occurs (empty insert result)', async () => {
+      const existingUf = createMockUserFile()
+      // Insert returns empty (conflict, DO NOTHING)
+      mockDb._setInsertResult([])
+      // Select returns the existing record
+      mockDb._setSelectResult([existingUf])
+
+      const result = await upsertUserFile({userId: 'user-1', fileId: 'file-1'})
+
+      expect(result).toEqual(existingUf)
+    })
+  })
+
+  describe('deleteUserFile', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteUserFile('user-1', 'file-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteUserFilesByUserId', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteUserFilesByUserId('user-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteUserFilesBatch', () => {
+    it('should return early for empty keys array (early return)', async () => {
+      await deleteUserFilesBatch([])
+
+      expect(mockDb.delete).not.toHaveBeenCalled()
+    })
+
+    it('should delete for non-empty keys', async () => {
+      mockDb._setDeleteResult([])
+
+      await deleteUserFilesBatch([{userId: 'user-1', fileId: 'file-1'}])
+
+      expect(mockDb.delete).toHaveBeenCalled()
+    })
+  })
+
+  // UserDevice Operations
+
+  describe('getUserDevice', () => {
+    it('should return user-device when found', async () => {
+      const mockUd = createMockUserDevice()
+      mockDb._setSelectResult([mockUd])
+
+      const result = await getUserDevice('user-1', 'device-1')
+
+      expect(result).toEqual(mockUd)
+    })
+
+    it('should return null when not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getUserDevice('user-1', 'nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getUserDevicesByUserId', () => {
+    it('should return user devices', async () => {
+      const uds = [createMockUserDevice()]
+      mockDb._setSelectResult(uds)
+
+      const result = await getUserDevicesByUserId('user-1')
+
+      expect(result).toEqual(uds)
+    })
+  })
+
+  describe('getUserDeviceIdsByUserId', () => {
+    it('should return mapped device IDs', async () => {
+      mockDb._setSelectResult([{deviceId: 'device-1'}, {deviceId: 'device-2'}])
+
+      const result = await getUserDeviceIdsByUserId('user-1')
+
+      expect(result).toEqual(['device-1', 'device-2'])
+    })
+
+    it('should return empty array when no devices', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getUserDeviceIdsByUserId('user-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getUserDevicesByDeviceId', () => {
+    it('should return user devices for device', async () => {
+      const uds = [createMockUserDevice()]
+      mockDb._setSelectResult(uds)
+
+      const result = await getUserDevicesByDeviceId('device-1')
+
+      expect(result).toEqual(uds)
+    })
+  })
+
+  describe('getDevicesForUser', () => {
+    it('should return mapped device objects from join', async () => {
+      const device1 = createMockDevice({deviceId: 'device-1'})
+      const device2 = createMockDevice({deviceId: 'device-2'})
+      mockDb._setSelectResult([{device: device1}, {device: device2}])
+
+      const result = await getDevicesForUser('user-1')
+
+      expect(result).toEqual([device1, device2])
+    })
+
+    it('should return empty array when user has no devices', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getDevicesForUser('user-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getDeviceIdsForUsers', () => {
+    it('should return empty array for empty input (early return)', async () => {
+      const result = await getDeviceIdsForUsers([])
+
+      expect(result).toEqual([])
+      expect(mockDb.select).not.toHaveBeenCalled()
+    })
+
+    it('should return mapped device IDs for non-empty input', async () => {
+      mockDb._setSelectResult([{deviceId: 'device-1'}, {deviceId: 'device-2'}])
+
+      const result = await getDeviceIdsForUsers(['user-1', 'user-2'])
+
+      expect(result).toEqual(['device-1', 'device-2'])
+    })
+  })
+
+  describe('createUserDevice', () => {
+    it('should return the created user-device', async () => {
+      const mockUd = createMockUserDevice()
+      mockDb._setInsertResult([mockUd])
+
+      const result = await createUserDevice({userId: 'user-1', deviceId: 'device-1'})
+
+      expect(result).toEqual(mockUd)
+    })
+  })
+
+  describe('upsertUserDevice', () => {
+    it('should return new row when insert succeeds (no conflict)', async () => {
+      const mockUd = createMockUserDevice()
+      mockDb._setInsertResult([mockUd])
+
+      const result = await upsertUserDevice({userId: 'user-1', deviceId: 'device-1'})
+
+      expect(result).toEqual(mockUd)
+    })
+
+    it('should fetch existing row when conflict occurs (empty insert result)', async () => {
+      const existingUd = createMockUserDevice()
+      // Insert returns empty (conflict, DO NOTHING)
+      mockDb._setInsertResult([])
+      // Select returns the existing record
+      mockDb._setSelectResult([existingUd])
+
+      const result = await upsertUserDevice({userId: 'user-1', deviceId: 'device-1'})
+
+      expect(result).toEqual(existingUd)
+    })
+  })
+
+  describe('deleteUserDevice', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteUserDevice('user-1', 'device-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteUserDevicesByUserId', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteUserDevicesByUserId('user-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteUserDevicesByDeviceId', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteUserDevicesByDeviceId('device-1')).resolves.toBeUndefined()
+    })
+  })
+})

--- a/test/entities/queries/sessionQueries.test.ts
+++ b/test/entities/queries/sessionQueries.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for Session Queries
+ *
+ * Tests mutable logic: null coalescing (result[0] ?? null)
+ * and non-null assertions on returning().
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockSession, createMockAccount, createMockVerification} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({
+  sessions: {id: 'id', token: 'token', userId: 'userId', expiresAt: 'expiresAt'},
+  accounts: {id: 'id', userId: 'userId'},
+  verification: {id: 'id', identifier: 'identifier', expiresAt: 'expiresAt'}
+}))
+vi.mock('#db/zodSchemas', () => ({
+  sessionInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  sessionUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))},
+  accountInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  verificationInsertSchema: {parse: vi.fn((v: unknown) => v)}
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
+  lt: vi.fn((_col: unknown, _val: unknown) => 'lt-condition')
+}))
+
+const {
+  getSession, getSessionByToken, getSessionsByUserId,
+  createSession, updateSession, deleteSession, deleteSessionsByUserId, deleteExpiredSessions,
+  getAccount, getAccountsByUserId, createAccount, deleteAccount, deleteAccountsByUserId,
+  getVerificationByIdentifier, createVerification, deleteVerification, deleteExpiredVerifications
+} = await import('#entities/queries/sessionQueries')
+
+describe('Session Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Session Operations
+
+  describe('getSession', () => {
+    it('should return session when found', async () => {
+      const mockSession = createMockSession()
+      mockDb._setSelectResult([mockSession])
+
+      const result = await getSession('session-1')
+
+      expect(result).toEqual(mockSession)
+    })
+
+    it('should return null when session not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getSession('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getSessionByToken', () => {
+    it('should return session when found by token', async () => {
+      const mockSession = createMockSession()
+      mockDb._setSelectResult([mockSession])
+
+      const result = await getSessionByToken('valid-token')
+
+      expect(result).toEqual(mockSession)
+    })
+
+    it('should return null when token not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getSessionByToken('invalid-token')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getSessionsByUserId', () => {
+    it('should return sessions for user', async () => {
+      const sessions = [createMockSession(), createMockSession({id: 'session-2'})]
+      mockDb._setSelectResult(sessions)
+
+      const result = await getSessionsByUserId('user-1')
+
+      expect(result).toEqual(sessions)
+    })
+
+    it('should return empty array when user has no sessions', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getSessionsByUserId('user-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('createSession', () => {
+    it('should return the created session', async () => {
+      const mockSession = createMockSession()
+      mockDb._setInsertResult([mockSession])
+
+      const result = await createSession({
+        userId: 'user-1', token: 'token-1', expiresAt: new Date()
+      })
+
+      expect(result).toEqual(mockSession)
+    })
+  })
+
+  describe('updateSession', () => {
+    it('should return the updated session', async () => {
+      const mockSession = createMockSession()
+      mockDb._setUpdateResult([mockSession])
+
+      const result = await updateSession('session-1', {token: 'new-token'})
+
+      expect(result).toEqual(mockSession)
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteSession('session-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteSessionsByUserId', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteSessionsByUserId('user-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteExpiredSessions', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteExpiredSessions()).resolves.toBeUndefined()
+    })
+  })
+
+  // Account Operations
+
+  describe('getAccount', () => {
+    it('should return account when found', async () => {
+      const mockAccount = createMockAccount()
+      mockDb._setSelectResult([mockAccount])
+
+      const result = await getAccount('account-1')
+
+      expect(result).toEqual(mockAccount)
+    })
+
+    it('should return null when account not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getAccount('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getAccountsByUserId', () => {
+    it('should return accounts for user', async () => {
+      const accounts = [createMockAccount()]
+      mockDb._setSelectResult(accounts)
+
+      const result = await getAccountsByUserId('user-1')
+
+      expect(result).toEqual(accounts)
+    })
+  })
+
+  describe('createAccount', () => {
+    it('should return the created account', async () => {
+      const mockAccount = createMockAccount()
+      mockDb._setInsertResult([mockAccount])
+
+      const result = await createAccount({
+        userId: 'user-1', accountId: 'apple-1', providerId: 'apple'
+      })
+
+      expect(result).toEqual(mockAccount)
+    })
+  })
+
+  describe('deleteAccount', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteAccount('account-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteAccountsByUserId', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteAccountsByUserId('user-1')).resolves.toBeUndefined()
+    })
+  })
+
+  // Verification Operations
+
+  describe('getVerificationByIdentifier', () => {
+    it('should return verification when found', async () => {
+      const mockVerification = createMockVerification()
+      mockDb._setSelectResult([mockVerification])
+
+      const result = await getVerificationByIdentifier('test@example.com')
+
+      expect(result).toEqual(mockVerification)
+    })
+
+    it('should return null when verification not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getVerificationByIdentifier('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('createVerification', () => {
+    it('should return the created verification', async () => {
+      const mockVerification = createMockVerification()
+      mockDb._setInsertResult([mockVerification])
+
+      const result = await createVerification({
+        identifier: 'test@example.com', value: 'token-abc', expiresAt: new Date()
+      })
+
+      expect(result).toEqual(mockVerification)
+    })
+  })
+
+  describe('deleteVerification', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteVerification('verification-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteExpiredVerifications', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+      await expect(deleteExpiredVerifications()).resolves.toBeUndefined()
+    })
+  })
+})

--- a/test/entities/queries/userQueries.test.ts
+++ b/test/entities/queries/userQueries.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for User Queries
+ *
+ * Tests mutable logic: null coalescing (result[0] ?? null),
+ * non-null assertions on returning(), and Zod validation passthrough.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createMockUser} from '#test/helpers/entity-fixtures'
+
+const mockDb = createMockDrizzleDb()
+
+vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
+vi.mock('#db/schema', () => ({users: {id: 'id', email: 'email'}}))
+vi.mock('#db/zodSchemas', () => ({
+  userInsertSchema: {parse: vi.fn((v: unknown) => v)},
+  userUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
+}))
+vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
+vi.mock('@mantleframework/database/orm', () => ({
+  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition')
+}))
+
+const {getUser, getUsersByEmail, createUser, updateUser, deleteUser} = await import('#entities/queries/userQueries')
+
+describe('User Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getUser', () => {
+    it('should return user when found', async () => {
+      const mockUser = createMockUser()
+      mockDb._setSelectResult([mockUser])
+
+      const result = await getUser('user-1')
+
+      expect(result).toEqual(mockUser)
+    })
+
+    it('should return null when user not found (null coalescing)', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getUser('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getUsersByEmail', () => {
+    it('should return matching users', async () => {
+      const users = [createMockUser(), createMockUser({id: 'user-2'})]
+      mockDb._setSelectResult(users)
+
+      const result = await getUsersByEmail('test@example.com')
+
+      expect(result).toEqual(users)
+    })
+
+    it('should return empty array when no users match', async () => {
+      mockDb._setSelectResult([])
+
+      const result = await getUsersByEmail('nobody@example.com')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('createUser', () => {
+    it('should return the created user', async () => {
+      const mockUser = createMockUser()
+      mockDb._setInsertResult([mockUser])
+
+      const result = await createUser({email: 'test@example.com', emailVerified: true, name: 'Test'})
+
+      expect(result).toEqual(mockUser)
+    })
+  })
+
+  describe('updateUser', () => {
+    it('should return the updated user', async () => {
+      const mockUser = createMockUser({name: 'Updated'})
+      mockDb._setUpdateResult([mockUser])
+
+      const result = await updateUser('user-1', {name: 'Updated'})
+
+      expect(result).toEqual(mockUser)
+    })
+  })
+
+  describe('deleteUser', () => {
+    it('should complete without error', async () => {
+      mockDb._setDeleteResult([])
+
+      await expect(deleteUser('user-1')).resolves.toBeUndefined()
+    })
+  })
+})

--- a/test/helpers/defineQuery-mock.ts
+++ b/test/helpers/defineQuery-mock.ts
@@ -1,0 +1,148 @@
+/**
+ * Mock utilities for defineQuery/definePreparedQuery testing.
+ *
+ * Provides a fully chainable mock Drizzle db that supports all query patterns
+ * used in entity queries: select, insert, update, delete with chaining.
+ *
+ * @see src/db/defineQuery.ts for the real factory
+ */
+import {vi} from 'vitest'
+
+/**
+ * Terminal mock that resolves to a configurable result.
+ * Used as the final step in any chain (where, returning, limit, execute).
+ */
+export function createTerminalMock(defaultValue: unknown = []) {
+  const mock = vi.fn().mockResolvedValue(defaultValue)
+  // Make it thenable so `await db.select().from(table).where(cond)` works
+  const thenableMock = Object.assign(mock, {
+    then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) => mock().then(resolve, reject),
+    limit: vi.fn().mockImplementation(() => thenableMock),
+    returning: vi.fn().mockImplementation(() => thenableMock),
+    where: vi.fn().mockImplementation(() => thenableMock)
+  })
+  return thenableMock
+}
+
+export interface MockDrizzleDb {
+  select: ReturnType<typeof vi.fn>
+  insert: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+  _selectResult: unknown[]
+  _insertResult: unknown[]
+  _updateResult: unknown[]
+  _deleteResult: unknown[]
+  _setSelectResult: (result: unknown[]) => void
+  _setInsertResult: (result: unknown[]) => void
+  _setUpdateResult: (result: unknown[]) => void
+  _setDeleteResult: (result: unknown[]) => void
+}
+
+/**
+ * Creates a fully chainable mock Drizzle db.
+ *
+ * Supports chains like:
+ * - db.select().from(table).where(cond).limit(n)
+ * - db.select({col}).from(table).where(cond)
+ * - db.insert(table).values(data).returning()
+ * - db.insert(table).values(data).onConflictDoUpdate({...}).returning()
+ * - db.insert(table).values(data).onConflictDoNothing({...}).returning()
+ * - db.update(table).set(data).where(cond).returning()
+ * - db.delete(table).where(cond)
+ *
+ * Configure results via `_setSelectResult`, `_setInsertResult`, etc.
+ */
+export function createMockDrizzleDb(): MockDrizzleDb {
+  let selectResult: unknown[] = []
+  let insertResult: unknown[] = []
+  let updateResult: unknown[] = []
+  let deleteResult: unknown[] = []
+
+  // Select chain: select() -> from() -> where() -> limit() -> [resolves]
+  // Also: select() -> from() -> innerJoin() -> where() -> [resolves]
+  const selectChain = () => {
+    const terminal = {
+      then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(selectResult).then(resolve, reject),
+      limit: vi.fn().mockImplementation(() => terminal),
+      where: vi.fn().mockImplementation(() => terminal)
+    }
+    const fromResult = {
+      where: vi.fn().mockImplementation(() => terminal),
+      innerJoin: vi.fn().mockImplementation(() => fromResult),
+      limit: vi.fn().mockImplementation(() => terminal),
+      then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(selectResult).then(resolve, reject)
+    }
+    return {
+      from: vi.fn().mockImplementation(() => fromResult)
+    }
+  }
+
+  // Insert chain: insert() -> values() -> returning() / onConflictDoUpdate().returning() / onConflictDoNothing().returning()
+  const insertChain = () => {
+    const returningFn = vi.fn().mockImplementation(() =>
+      Promise.resolve(insertResult)
+    )
+    const conflictResult = {returning: returningFn}
+    return {
+      values: vi.fn().mockImplementation(() => ({
+        returning: returningFn,
+        onConflictDoUpdate: vi.fn().mockImplementation(() => conflictResult),
+        onConflictDoNothing: vi.fn().mockImplementation(() => conflictResult)
+      }))
+    }
+  }
+
+  // Update chain: update() -> set() -> where() -> returning()
+  const updateChain = () => {
+    const returningFn = vi.fn().mockImplementation(() =>
+      Promise.resolve(updateResult)
+    )
+    return {
+      set: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => ({
+          returning: returningFn
+        }))
+      }))
+    }
+  }
+
+  // Delete chain: delete() -> where()
+  const deleteChain = () => ({
+    where: vi.fn().mockImplementation(() => Promise.resolve(deleteResult))
+  })
+
+  const db: MockDrizzleDb = {
+    select: vi.fn().mockImplementation(() => selectChain()),
+    insert: vi.fn().mockImplementation(() => insertChain()),
+    update: vi.fn().mockImplementation(() => updateChain()),
+    delete: vi.fn().mockImplementation(() => deleteChain()),
+    _selectResult: selectResult,
+    _insertResult: insertResult,
+    _updateResult: updateResult,
+    _deleteResult: deleteResult,
+    _setSelectResult: (result: unknown[]) => { selectResult = result },
+    _setInsertResult: (result: unknown[]) => { insertResult = result },
+    _setUpdateResult: (result: unknown[]) => { updateResult = result },
+    _setDeleteResult: (result: unknown[]) => { deleteResult = result }
+  }
+
+  return db
+}
+
+/**
+ * Creates the mock factory for `#db/defineQuery`.
+ *
+ * Returns a mock module where defineQuery(config, fn) returns (...args) => fn(mockDb, ...args).
+ * This allows tests to control what the mock db returns and verify query logic.
+ */
+export function createDefineQueryMock(db: MockDrizzleDb) {
+  return {
+    defineQuery: vi.fn().mockImplementation((_config: unknown, fn: (...args: unknown[]) => unknown) => {
+      return (...args: unknown[]) => fn(db, ...args)
+    }),
+    definePreparedQuery: vi.fn().mockImplementation((_config: unknown, fn: (...args: unknown[]) => unknown) => {
+      return (...args: unknown[]) => fn(db, ...args)
+    })
+  }
+}

--- a/test/helpers/drizzle-mock.ts
+++ b/test/helpers/drizzle-mock.ts
@@ -103,8 +103,68 @@ export function createDrizzleOperatorMocks() {
 }
 
 /**
- * Creates a combined Drizzle client mock with delete and execute capabilities.
- * This is the most common pattern for Lambdas that use multiple operations.
+ * Creates a chainable Drizzle insert mock.
+ * Supports: insert(table).values(data).returning()
+ * Also supports: insert(table).values(data).onConflictDoUpdate(...).returning()
+ * Also supports: insert(table).values(data).onConflictDoNothing(...).returning()
+ *
+ * @example
+ * ```typescript
+ * const {insertMock, mocks} = createDrizzleInsertMock()
+ * vi.mock('#lib/vendor/Drizzle/client', () => ({
+ *   getDrizzleClient: vi.fn(async () => ({insert: insertMock}))
+ * }))
+ *
+ * // In tests:
+ * mocks.returning.mockResolvedValueOnce([{id: 'new-1'}])
+ * ```
+ */
+export function createDrizzleInsertMock() {
+  const returningMock = vi.fn<() => Promise<Array<Record<string, unknown>>>>()
+  const onConflictDoUpdateMock = vi.fn(() => ({returning: returningMock}))
+  const onConflictDoNothingMock = vi.fn(() => ({returning: returningMock}))
+  const valuesMock = vi.fn(() => ({returning: returningMock, onConflictDoUpdate: onConflictDoUpdateMock, onConflictDoNothing: onConflictDoNothingMock}))
+  const insertMock = vi.fn(() => ({values: valuesMock}))
+
+  return {
+    insertMock,
+    mocks: {
+      insert: insertMock,
+      values: valuesMock,
+      returning: returningMock,
+      onConflictDoUpdate: onConflictDoUpdateMock,
+      onConflictDoNothing: onConflictDoNothingMock
+    }
+  }
+}
+
+/**
+ * Creates a chainable Drizzle update mock.
+ * Supports: update(table).set(data).where(condition).returning()
+ *
+ * @example
+ * ```typescript
+ * const {updateMock, mocks} = createDrizzleUpdateMock()
+ * vi.mock('#lib/vendor/Drizzle/client', () => ({
+ *   getDrizzleClient: vi.fn(async () => ({update: updateMock}))
+ * }))
+ *
+ * // In tests:
+ * mocks.returning.mockResolvedValueOnce([{id: 'updated-1'}])
+ * ```
+ */
+export function createDrizzleUpdateMock() {
+  const returningMock = vi.fn<() => Promise<Array<Record<string, unknown>>>>()
+  const whereMock = vi.fn(() => ({returning: returningMock}))
+  const setMock = vi.fn(() => ({where: whereMock, returning: returningMock}))
+  const updateMock = vi.fn(() => ({set: setMock}))
+
+  return {updateMock, mocks: {update: updateMock, set: setMock, where: whereMock, returning: returningMock}}
+}
+
+/**
+ * Creates a combined Drizzle client mock with all operation capabilities.
+ * Supports select, insert, update, delete, and execute operations.
  *
  * @example
  * ```typescript
@@ -122,10 +182,12 @@ export function createDrizzleClientMock() {
   const {deleteMock, mocks: deleteMocks} = createDrizzleDeleteMock()
   const {executeMock, mocks: executeMocks} = createDrizzleExecuteMock()
   const {selectMock, mocks: selectMocks} = createDrizzleSelectMock()
+  const {insertMock, mocks: insertMocks} = createDrizzleInsertMock()
+  const {updateMock, mocks: updateMocks} = createDrizzleUpdateMock()
 
-  const clientMock = {delete: deleteMock, execute: executeMock, select: selectMock}
+  const clientMock = {delete: deleteMock, execute: executeMock, select: selectMock, insert: insertMock, update: updateMock}
 
-  return {clientMock, mocks: {...deleteMocks, ...executeMocks, ...selectMocks}}
+  return {clientMock, mocks: {...deleteMocks, ...executeMocks, ...selectMocks, ...insertMocks, ...updateMocks}}
 }
 
 /**
@@ -149,6 +211,8 @@ export function createMockSchemaTable(columns: string[]): Record<string, string>
 export type DrizzleDeleteMock = ReturnType<typeof createDrizzleDeleteMock>
 export type DrizzleExecuteMock = ReturnType<typeof createDrizzleExecuteMock>
 export type DrizzleSelectMock = ReturnType<typeof createDrizzleSelectMock>
+export type DrizzleInsertMock = ReturnType<typeof createDrizzleInsertMock>
+export type DrizzleUpdateMock = ReturnType<typeof createDrizzleUpdateMock>
 export type DrizzleClientMock = ReturnType<typeof createDrizzleClientMock>
 export type DrizzleOperatorMocks = ReturnType<typeof createDrizzleOperatorMocks>
 export type { Mock }

--- a/test/integrations/github/errorFingerprint.test.ts
+++ b/test/integrations/github/errorFingerprint.test.ts
@@ -65,6 +65,44 @@ describe('generateErrorFingerprint', () => {
 
       expect(result.summary).toContain('ctx:video-download')
     })
+
+    it('should include all optional fields in summary when all provided', () => {
+      const result = generateErrorFingerprint({
+        errorType: 'CustomError',
+        errorCode: 'E001',
+        stackFrame: 'index.ts',
+        lambdaName: 'MyLambda',
+        context: 'upload'
+      })
+
+      expect(result.summary).toContain('type:CustomError')
+      expect(result.summary).toContain('code:E001')
+      expect(result.summary).toContain('frame:index.ts')
+      expect(result.summary).toContain('lambda:MyLambda')
+      expect(result.summary).toContain('ctx:upload')
+    })
+
+    it('should produce different fingerprint when context differs', () => {
+      const base = {errorType: 'Error', lambdaName: 'Lambda1'}
+      const r1 = generateErrorFingerprint({...base, context: 'ctx-a'})
+      const r2 = generateErrorFingerprint({...base, context: 'ctx-b'})
+
+      expect(r1.fingerprint).not.toBe(r2.fingerprint)
+    })
+
+    it('should produce different fingerprint with and without errorCode', () => {
+      const withCode = generateErrorFingerprint({errorType: 'Error', errorCode: 'E001'})
+      const withoutCode = generateErrorFingerprint({errorType: 'Error'})
+
+      expect(withCode.fingerprint).not.toBe(withoutCode.fingerprint)
+    })
+
+    it('should produce different fingerprint with and without stackFrame', () => {
+      const withFrame = generateErrorFingerprint({errorType: 'Error', stackFrame: 'file.ts'})
+      const withoutFrame = generateErrorFingerprint({errorType: 'Error'})
+
+      expect(withFrame.fingerprint).not.toBe(withoutFrame.fingerprint)
+    })
   })
 })
 
@@ -144,6 +182,37 @@ describe('extractFingerprintFromError', () => {
       // Should have some stack frame (may vary by environment)
       // Just verify we get something or undefined
       expect(typeof input.stackFrame === 'string' || input.stackFrame === undefined).toBe(true)
+    })
+
+    it('should handle error with no stack trace', () => {
+      const error = new Error('test')
+      error.stack = undefined
+      const input = extractFingerprintFromError(error)
+
+      expect(input.stackFrame).toBeUndefined()
+    })
+
+    it('should skip node_modules frames', () => {
+      const error = new Error('test')
+      error.stack = `Error: test
+    at node_modules/some-lib/index.js:10:5
+    at myFunction (src/handler.ts:42:10)`
+      const input = extractFingerprintFromError(error)
+
+      // Should skip the node_modules frame and get the app frame
+      expect(input.stackFrame).toBeDefined()
+      expect(input.stackFrame).not.toContain('node_modules')
+    })
+
+    it('should skip node:internal frames', () => {
+      const error = new Error('test')
+      error.stack = `Error: test
+    at node:internal/process/task_queues:95:5
+    at myHandler (src/index.ts:10:3)`
+      const input = extractFingerprintFromError(error)
+
+      expect(input.stackFrame).toBeDefined()
+      expect(input.stackFrame).not.toContain('node:internal')
     })
   })
 

--- a/test/integrations/github/issue-service.test.ts
+++ b/test/integrations/github/issue-service.test.ts
@@ -2,30 +2,40 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import type {Device} from '#types/domainModels'
 
 // Use vi.hoisted() to define mocks before vi.mock hoists
-const {mockIssuesCreate, mockIssuesListForRepo, mockIssuesCreateComment, MockOctokit, mockRenderGithubIssueTemplate} = vi.hoisted(() => {
+const {mockIssuesCreate, mockIssuesListForRepo, mockIssuesCreateComment, mockIssuesUpdate, MockOctokit, mockRenderGithubIssueTemplate} = vi.hoisted(() => {
   const mockIssuesCreate = vi.fn<(params: object) => Promise<{status: number; data: {id: number; number: number; html_url: string}}>>()
   const mockIssuesListForRepo = vi.fn<
     (params: object) => Promise<{data: Array<{number: number; title: string; labels: Array<{name: string}>}>}>
   >()
   const mockIssuesCreateComment = vi.fn<(params: object) => Promise<{data: {id: number}}>>()
+  const mockIssuesUpdate = vi.fn<(params: object) => Promise<{data: {number: number}}>>()
 
   class MockOctokit {
-    public rest: {issues: {create: typeof mockIssuesCreate; listForRepo: typeof mockIssuesListForRepo; createComment: typeof mockIssuesCreateComment}}
+    public rest: {
+      issues: {
+        create: typeof mockIssuesCreate
+        listForRepo: typeof mockIssuesListForRepo
+        createComment: typeof mockIssuesCreateComment
+        update: typeof mockIssuesUpdate
+      }
+    }
     constructor() {
-      this.rest = {issues: {create: mockIssuesCreate, listForRepo: mockIssuesListForRepo, createComment: mockIssuesCreateComment}}
+      this.rest = {issues: {create: mockIssuesCreate, listForRepo: mockIssuesListForRepo, createComment: mockIssuesCreateComment, update: mockIssuesUpdate}}
     }
   }
 
   const mockRenderGithubIssueTemplate = vi.fn<(templateName: string, data: object) => string>()
   mockRenderGithubIssueTemplate.mockImplementation((templateName: string) => `Rendered template: ${templateName}`)
 
-  return {mockIssuesCreate, mockIssuesListForRepo, mockIssuesCreateComment, MockOctokit, mockRenderGithubIssueTemplate}
+  return {mockIssuesCreate, mockIssuesListForRepo, mockIssuesCreateComment, mockIssuesUpdate, MockOctokit, mockRenderGithubIssueTemplate}
 })
 
 vi.mock('@octokit/rest', () => ({Octokit: MockOctokit}))
 vi.mock('#integrations/github/templates.js', () => ({renderGithubIssueTemplate: mockRenderGithubIssueTemplate}))
 
-const {createFailedUserDeletionIssue, createVideoDownloadFailureIssue, createCookieExpirationIssue} = await import('#integrations/github/issueService.js')
+const {createFailedUserDeletionIssue, createVideoDownloadFailureIssue, createCookieExpirationIssue, closeCookieExpirationIssueIfResolved} = await import(
+  '#integrations/github/issueService.js'
+)
 
 describe('#Util:GithubHelper', () => {
   beforeEach(() => {
@@ -237,6 +247,71 @@ describe('#Util:GithubHelper', () => {
       const response = await createCookieExpirationIssue(fileId, fileUrl, error)
 
       expect(response).toBeNull()
+    })
+  })
+
+  describe('#closeCookieExpirationIssueIfResolved', () => {
+    test('should close existing cookie issue and add comment', async () => {
+      mockIssuesListForRepo.mockResolvedValue({data: [{number: 55, title: 'Cookie issue', labels: []}]})
+      mockIssuesCreateComment.mockResolvedValue({data: {id: 999}})
+      mockIssuesUpdate.mockResolvedValue({data: {number: 55}})
+
+      await closeCookieExpirationIssueIfResolved()
+
+      expect(mockIssuesCreateComment).toHaveBeenCalledWith(
+        expect.objectContaining({issue_number: 55, body: expect.stringContaining('Automatically Resolved')})
+      )
+      expect(mockIssuesUpdate).toHaveBeenCalledWith(expect.objectContaining({issue_number: 55, state: 'closed'}))
+    })
+
+    test('should do nothing when no existing cookie issue found', async () => {
+      mockIssuesListForRepo.mockResolvedValue({data: []})
+
+      await closeCookieExpirationIssueIfResolved()
+
+      expect(mockIssuesCreateComment).not.toHaveBeenCalled()
+      expect(mockIssuesUpdate).not.toHaveBeenCalled()
+    })
+
+    test('should not throw when GitHub API fails', async () => {
+      mockIssuesListForRepo.mockRejectedValue(new Error('API down'))
+
+      await expect(closeCookieExpirationIssueIfResolved()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('#createFailedUserDeletionIssue edge cases', () => {
+    test('should create issue with empty devices array', async () => {
+      mockIssuesCreate.mockResolvedValue({status: 201, data: {id: 1, number: 50, html_url: 'https://github.com/owner/repo/issues/50'}})
+
+      const response = await createFailedUserDeletionIssue('user-empty', [], new Error('Cascade failed'), 'req-456')
+
+      expect(response).not.toBeNull()
+      expect(response?.issueNumber).toEqual(50)
+      expect(response?.isDuplicate).toBe(false)
+    })
+
+    test('should handle error with no stack trace', async () => {
+      const error = new Error('No stack')
+      error.stack = undefined
+      mockIssuesCreate.mockResolvedValue({status: 201, data: {id: 2, number: 51, html_url: 'https://github.com/owner/repo/issues/51'}})
+
+      const response = await createFailedUserDeletionIssue('user-nostack', [], error, 'req-789')
+
+      expect(response).not.toBeNull()
+      expect(mockRenderGithubIssueTemplate).toHaveBeenCalledWith('user-deletion-failure', expect.objectContaining({errorStack: 'No stack trace available'}))
+    })
+
+    test('should handle comment failure on duplicate gracefully', async () => {
+      mockIssuesListForRepo.mockResolvedValue({data: [{number: 60, title: 'Existing', labels: []}]})
+      mockIssuesCreateComment.mockRejectedValue(new Error('Comment API error'))
+
+      const response = await createFailedUserDeletionIssue('user-1', [], new Error('fail'), 'req-1')
+
+      // Should still return the duplicate result even if comment fails
+      expect(response).not.toBeNull()
+      expect(response?.issueNumber).toEqual(60)
+      expect(response?.isDuplicate).toBe(true)
     })
   })
 })

--- a/test/lambdas/api/device/event.post.test.ts
+++ b/test/lambdas/api/device/event.post.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for DeviceEvent Lambda (POST /device/event)
+ *
+ * Tests event logging, metrics, and tracing span management.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code) => ({statusCode: code}))}))
+
+vi.mock('@mantleframework/observability',
+  () => ({
+    addAnnotation: vi.fn(),
+    endSpan: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => 'mock-span')
+  }))
+
+vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler)}))
+
+const {handler} = await import('#lambdas/api/device/event.post.js')
+import {addAnnotation, endSpan, logInfo, metrics, startSpan} from '@mantleframework/observability'
+
+describe('DeviceEvent Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should log event with deviceId from header', async () => {
+    const result = await handler({event: {headers: {'x-device-uuid': 'dev-123'}, body: '{"action":"download_started"}'}, context: {awsRequestId: 'req-1'}})
+
+    expect(logInfo).toHaveBeenCalledWith('Event received', {deviceId: 'dev-123', message: '{"action":"download_started"}'})
+    expect(addAnnotation).toHaveBeenCalledWith('mock-span', 'deviceId', 'dev-123')
+    expect(result.statusCode).toBe(204)
+  })
+
+  it('should handle missing deviceId header', async () => {
+    await handler({event: {headers: {}, body: 'test message'}, context: {awsRequestId: 'req-1'}})
+
+    expect(addAnnotation).not.toHaveBeenCalled()
+    expect(logInfo).toHaveBeenCalledWith('Event received', {deviceId: undefined, message: 'test message'})
+  })
+
+  it('should track DeviceEventReceived metric', async () => {
+    await handler({event: {headers: {}, body: 'test'}, context: {awsRequestId: 'req-1'}})
+
+    expect(metrics.addMetric).toHaveBeenCalledWith('DeviceEventReceived', 'Count', 1)
+  })
+
+  it('should start and end tracing span', async () => {
+    await handler({event: {headers: {}, body: 'test'}, context: {awsRequestId: 'req-1'}})
+
+    expect(startSpan).toHaveBeenCalledWith('device-event-log')
+    expect(endSpan).toHaveBeenCalledWith('mock-span')
+  })
+})

--- a/test/lambdas/api/device/register.post.test.ts
+++ b/test/lambdas/api/device/register.post.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for RegisterDevice Lambda (POST /device/register)
+ *
+ * Tests platform endpoint creation, user device registration, subscription management.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/aws', () => ({createPlatformEndpoint: vi.fn(), listSubscriptionsByTopic: vi.fn()}))
+
+vi.mock('@mantleframework/core',
+  () => ({
+    buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})),
+    UserStatus: {Authenticated: 'Authenticated', Anonymous: 'Anonymous'}
+  }))
+
+vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'arn:aws:sns:us-west-2:123456789012:app/APNS/MediaDownloader')}))
+
+vi.mock('@mantleframework/errors', () => {
+  class ServiceUnavailableError extends Error {
+    statusCode = 503
+    constructor(message: string) {
+      super(message)
+      this.name = 'ServiceUnavailableError'
+    }
+  }
+  class UnexpectedError extends Error {
+    statusCode = 500
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnexpectedError'
+    }
+  }
+  return {ServiceUnavailableError, UnexpectedError}
+})
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn()}))
+
+vi.mock('@mantleframework/validation',
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({optional: vi.fn(() => ({}))}))}
+  }))
+
+vi.mock('#entities/queries', () => ({upsertDevice: vi.fn(), upsertUserDevice: vi.fn()}))
+
+vi.mock('#errors/custom-errors', () => ({providerFailureErrorMessage: 'AWS request failed'}))
+
+vi.mock('#services/device/deviceService', () => ({getUserDevices: vi.fn(), subscribeEndpointToTopic: vi.fn(), unsubscribeEndpointToTopic: vi.fn()}))
+
+vi.mock('#types/api-schema', () => ({deviceRegistrationResponseSchema: {}}))
+
+vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
+
+const {handler} = await import('#lambdas/api/device/register.post.js')
+import {createPlatformEndpoint, listSubscriptionsByTopic} from '@mantleframework/aws'
+import {upsertDevice, upsertUserDevice} from '#entities/queries'
+import {getUserDevices, subscribeEndpointToTopic, unsubscribeEndpointToTopic} from '#services/device/deviceService'
+import {verifyPlatformConfiguration} from '#utils/platform-config'
+
+describe('RegisterDevice Lambda', () => {
+  const baseBody = {deviceId: 'dev-1', token: 'apns-token', name: 'iPhone', systemVersion: '17.0', systemName: 'iOS'}
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(createPlatformEndpoint).mockResolvedValue({EndpointArn: 'arn:aws:sns:endpoint/dev-1'})
+    vi.mocked(upsertDevice).mockResolvedValue(undefined as never)
+    vi.mocked(upsertUserDevice).mockResolvedValue(undefined as never)
+  })
+
+  it('should call verifyPlatformConfiguration', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([{userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()}])
+
+    await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})
+
+    expect(verifyPlatformConfiguration).toHaveBeenCalled()
+  })
+
+  it('should throw ServiceUnavailableError when createPlatformEndpoint returns null', async () => {
+    vi.mocked(createPlatformEndpoint).mockResolvedValue(null as never)
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})).rejects.toThrow(
+      'AWS failed to respond'
+    )
+  })
+
+  it('should return 200 for first device of authenticated user', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([{userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()}])
+
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})
+
+    expect(result.statusCode).toBe(200)
+    expect(result.endpointArn).toBe('arn:aws:sns:endpoint/dev-1')
+    expect(upsertUserDevice).toHaveBeenCalled()
+  })
+
+  it('should unsubscribe and return 201 for subsequent devices of authenticated user', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([
+      {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
+      {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
+    ])
+    vi.mocked(listSubscriptionsByTopic).mockResolvedValue({
+      Subscriptions: [{
+        Endpoint: 'arn:aws:sns:endpoint/dev-1',
+        SubscriptionArn: 'arn:aws:sns:sub/1',
+        Protocol: 'application',
+        Owner: '123',
+        TopicArn: 'arn:aws:sns:topic'
+      }]
+    })
+    vi.mocked(unsubscribeEndpointToTopic).mockResolvedValue(undefined as never)
+
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})
+
+    expect(result.statusCode).toBe(201)
+    expect(unsubscribeEndpointToTopic).toHaveBeenCalled()
+  })
+
+  it('should subscribe anonymous user to push notification topic', async () => {
+    vi.mocked(subscribeEndpointToTopic).mockResolvedValue({} as never)
+
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: undefined, userStatus: 'Anonymous', body: baseBody})
+
+    expect(subscribeEndpointToTopic).toHaveBeenCalledWith('arn:aws:sns:endpoint/dev-1', expect.any(String))
+    expect(result.statusCode).toBe(200)
+  })
+
+  it('should throw ServiceUnavailableError when listSubscriptionsByTopic has no subscriptions', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([
+      {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
+      {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
+    ])
+    vi.mocked(listSubscriptionsByTopic).mockResolvedValue({Subscriptions: undefined})
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})).rejects.toThrow(
+      'AWS request failed'
+    )
+  })
+
+  it('should throw UnexpectedError when no matching subscription found for endpoint', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([
+      {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
+      {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
+    ])
+    vi.mocked(listSubscriptionsByTopic).mockResolvedValue({
+      Subscriptions: [{
+        Endpoint: 'arn:aws:sns:endpoint/OTHER',
+        SubscriptionArn: 'arn:aws:sns:sub/99',
+        Protocol: 'application',
+        Owner: '123',
+        TopicArn: 'arn:aws:sns:topic'
+      }]
+    })
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})).rejects.toThrow(
+      'Invalid subscription response'
+    )
+  })
+
+  it('should always upsert device regardless of user status', async () => {
+    vi.mocked(subscribeEndpointToTopic).mockResolvedValue({} as never)
+
+    await handler({context: {awsRequestId: 'req-1'}, userId: undefined, userStatus: 'Anonymous', body: baseBody})
+
+    expect(upsertDevice).toHaveBeenCalled()
+  })
+})

--- a/test/lambdas/api/feedly/webhook.post.test.ts
+++ b/test/lambdas/api/feedly/webhook.post.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for WebhookFeedly Lambda (POST /feedly/webhook)
+ *
+ * Tests auth validation, video ID extraction, idempotency, and error paths.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/aws', () => ({sendMessage: vi.fn()}))
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})), emitEvent: vi.fn()}))
+
+vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'https://sqs.us-west-2.amazonaws.com/123/queue')}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnauthorizedError extends Error {
+    statusCode = 401
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnauthorizedError'
+    }
+  }
+  return {UnauthorizedError}
+})
+
+vi.mock('@mantleframework/observability',
+  () => ({
+    addAnnotation: vi.fn(),
+    addMetadata: vi.fn(),
+    endSpan: vi.fn(),
+    logDebug: vi.fn(),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => 'mock-span')
+  }))
+
+vi.mock('@mantleframework/resilience', () => {
+  class MockIdempotencyConfig {
+    registerLambdaContext = vi.fn()
+    constructor() {}
+  }
+  return {createIdempotencyStore: vi.fn(() => ({})), IdempotencyConfig: MockIdempotencyConfig, makeIdempotent: vi.fn((fn: Function) => fn)}
+})
+
+vi.mock('@mantleframework/validation',
+  () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler), z: {object: vi.fn(() => ({})), string: vi.fn(() => ({}))}}))
+
+vi.mock('#domain/user/userFileService', () => ({associateFileToUser: vi.fn()}))
+
+vi.mock('#entities/queries', () => ({createFile: vi.fn(), createFileDownload: vi.fn(), getFile: vi.fn()}))
+
+vi.mock('#services/notification/transformers', () => ({createDownloadReadyNotification: vi.fn(() => ({messageBody: '{}', messageAttributes: {}}))}))
+
+vi.mock('#services/youtube/youtube', () => ({getVideoID: vi.fn()}))
+
+vi.mock('#types/api-schema', () => ({webhookResponseSchema: {}}))
+
+vi.mock('#types/enums',
+  () => ({
+    DownloadStatus: {Pending: 'Pending'},
+    FileStatus: {Queued: 'Queued', Downloaded: 'Downloaded', Failed: 'Failed'},
+    ResponseStatus: {Dispatched: 'Dispatched', Accepted: 'Accepted', Initiated: 'Initiated'}
+  }))
+
+const {handler} = await import('#lambdas/api/feedly/webhook.post.js')
+import {getVideoID} from '#services/youtube/youtube'
+import {createFile, createFileDownload, getFile} from '#entities/queries'
+import {associateFileToUser} from '#domain/user/userFileService'
+import {emitEvent} from '@mantleframework/core'
+import {sendMessage} from '@mantleframework/aws'
+import {metrics} from '@mantleframework/observability'
+
+describe('WebhookFeedly Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getVideoID).mockReturnValue('dQw4w9WgXcQ')
+  })
+
+  it('should throw UnauthorizedError when userId is missing', async () => {
+    await expect(
+      handler({
+        context: {awsRequestId: 'req-1'},
+        userId: undefined,
+        body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+        metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+      })
+    ).rejects.toThrow('Authentication required')
+  })
+
+  it('should emit DownloadRequested event for new file', async () => {
+    vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
+    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(createFile).mockResolvedValue(undefined as never)
+    vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
+    vi.mocked(emitEvent).mockResolvedValue(undefined as never)
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    expect(createFile).toHaveBeenCalled()
+    expect(createFileDownload).toHaveBeenCalled()
+    expect(emitEvent).toHaveBeenCalledWith(expect.objectContaining({detailType: 'DownloadRequested'}))
+    expect(result.statusCode).toBe(202)
+    expect(result.status).toBe('Accepted')
+  })
+
+  it('should send notification and return Dispatched for already-downloaded file', async () => {
+    vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
+    vi.mocked(getFile).mockResolvedValue(
+      {
+        fileId: 'dQw4w9WgXcQ',
+        size: 1000,
+        authorName: 'A',
+        authorUser: 'a',
+        publishDate: '2024-01-01',
+        description: 'D',
+        key: 'dQw4w9WgXcQ.mp4',
+        contentType: 'video/mp4',
+        title: 'Test',
+        status: 'Downloaded',
+        url: 'https://cdn/file.mp4'
+      } as never
+    )
+    vi.mocked(sendMessage).mockResolvedValue({MessageId: 'msg-1'} as never)
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    expect(sendMessage).toHaveBeenCalled()
+    expect(createFile).not.toHaveBeenCalled()
+    expect(result.statusCode).toBe(200)
+    expect(result.status).toBe('Dispatched')
+  })
+
+  it('should emit event without creating file when file exists but not downloaded', async () => {
+    vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
+    vi.mocked(getFile).mockResolvedValue(
+      {
+        fileId: 'dQw4w9WgXcQ',
+        size: 0,
+        authorName: 'A',
+        authorUser: 'a',
+        publishDate: '2024-01-01',
+        description: 'D',
+        key: 'dQw4w9WgXcQ.mp4',
+        contentType: 'video/mp4',
+        title: 'Test',
+        status: 'Queued'
+      } as never
+    )
+    vi.mocked(emitEvent).mockResolvedValue(undefined as never)
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    expect(createFile).not.toHaveBeenCalled()
+    expect(emitEvent).toHaveBeenCalled()
+    expect(result.statusCode).toBe(202)
+  })
+
+  it('should track WebhookReceived and WebhookProcessed metrics', async () => {
+    vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
+    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(createFile).mockResolvedValue(undefined as never)
+    vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
+    vi.mocked(emitEvent).mockResolvedValue(undefined as never)
+
+    await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    expect(metrics.addMetric).toHaveBeenCalledWith('WebhookReceived', 'Count', 1)
+    expect(metrics.addMetric).toHaveBeenCalledWith('WebhookProcessed', 'Count', 1)
+  })
+
+  it('should handle associateFileToUser failure gracefully', async () => {
+    vi.mocked(associateFileToUser).mockRejectedValue(new Error('DB error'))
+    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(createFile).mockResolvedValue(undefined as never)
+    vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
+    vi.mocked(emitEvent).mockResolvedValue(undefined as never)
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    // Should still process successfully despite association failure
+    expect(result.statusCode).toBe(202)
+  })
+
+  it('should extract videoID from article URL', async () => {
+    vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
+    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(createFile).mockResolvedValue(undefined as never)
+    vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
+    vi.mocked(emitEvent).mockResolvedValue(undefined as never)
+
+    await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=xyzABC12345'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    expect(getVideoID).toHaveBeenCalledWith('https://www.youtube.com/watch?v=xyzABC12345')
+  })
+})

--- a/test/lambdas/api/files/fileId/index.delete.test.ts
+++ b/test/lambdas/api/files/fileId/index.delete.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for FileDelete Lambda (DELETE /files/{fileId})
+ *
+ * Tests cascade deletion, S3 cleanup, not-found errors, and S3 failure resilience.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/core', () => ({
+  buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})),
+  defineLambda: vi.fn(),
+  S3BucketName: vi.fn((name: string) => name)
+}))
+
+vi.mock('@mantleframework/aws', () => ({
+  deleteObject: vi.fn()
+}))
+
+vi.mock('@mantleframework/errors', () => {
+  class NotFoundError extends Error {
+    statusCode = 404
+    constructor(message: string) {
+      super(message)
+      this.name = 'NotFoundError'
+    }
+  }
+  return {NotFoundError}
+})
+
+vi.mock('@mantleframework/observability', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn()
+}))
+
+vi.mock('@mantleframework/validation', () => ({
+  defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+  z: {object: vi.fn(() => ({})), string: vi.fn(() => ({})), boolean: vi.fn(() => ({}))}
+}))
+
+vi.mock('@mantleframework/env', () => ({
+  getRequiredEnv: vi.fn(() => 'test-bucket')
+}))
+
+vi.mock('#entities/queries', () => ({
+  deleteFileCascade: vi.fn()
+}))
+
+const {handler} = await import('#lambdas/api/files/[fileId]/index.delete.js')
+import {deleteFileCascade} from '#entities/queries'
+import {deleteObject} from '@mantleframework/aws'
+import {logError, logInfo} from '@mantleframework/observability'
+
+describe('FileDelete Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw NotFoundError when file does not exist for user', async () => {
+    vi.mocked(deleteFileCascade).mockResolvedValue({existed: false, fileRemoved: false})
+
+    await expect(handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      path: {fileId: 'abc123'}
+    })).rejects.toThrow('File not found for this user')
+  })
+
+  it('should delete file link without S3 cleanup when other users linked', async () => {
+    vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: false})
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      path: {fileId: 'abc123'}
+    })
+
+    expect(deleteObject).not.toHaveBeenCalled()
+    expect(result.deleted).toBe(true)
+    expect(result.fileRemoved).toBe(false)
+  })
+
+  it('should delete S3 object when file is orphaned', async () => {
+    vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: true})
+    vi.mocked(deleteObject).mockResolvedValue(undefined as never)
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      path: {fileId: 'abc123'}
+    })
+
+    expect(deleteObject).toHaveBeenCalledWith({Bucket: 'test-bucket', Key: 'abc123.mp4'})
+    expect(logInfo).toHaveBeenCalledWith('Deleted orphaned S3 object', {fileId: 'abc123', key: 'abc123.mp4'})
+    expect(result.deleted).toBe(true)
+    expect(result.fileRemoved).toBe(true)
+  })
+
+  it('should continue successfully when S3 deletion fails (orphaned object)', async () => {
+    vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: true})
+    vi.mocked(deleteObject).mockRejectedValue(new Error('S3 access denied'))
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      path: {fileId: 'abc123'}
+    })
+
+    expect(logError).toHaveBeenCalledWith(
+      'Failed to delete S3 object (orphaned)',
+      expect.objectContaining({fileId: 'abc123', error: 'S3 access denied'})
+    )
+    expect(result.deleted).toBe(true)
+    expect(result.fileRemoved).toBe(true)
+  })
+
+  it('should handle non-Error S3 failures gracefully', async () => {
+    vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: true})
+    vi.mocked(deleteObject).mockRejectedValue('string error')
+
+    const result = await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      path: {fileId: 'abc123'}
+    })
+
+    expect(logError).toHaveBeenCalledWith(
+      'Failed to delete S3 object (orphaned)',
+      expect.objectContaining({error: 'string error'})
+    )
+    expect(result.deleted).toBe(true)
+  })
+
+  it('should propagate database errors from deleteFileCascade', async () => {
+    vi.mocked(deleteFileCascade).mockRejectedValue(new Error('DB connection failed'))
+
+    await expect(handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      path: {fileId: 'abc123'}
+    })).rejects.toThrow('DB connection failed')
+  })
+})

--- a/test/lambdas/api/files/index.get.test.ts
+++ b/test/lambdas/api/files/index.get.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for ListFiles Lambda (GET /files)
+ *
+ * Tests the toFile helper, anonymous demo mode, status filtering, and sorting.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/core',
+  () => ({
+    buildValidatedResponse: vi.fn((_ctx, _code, data) => data),
+    defineLambda: vi.fn(),
+    UserStatus: {Authenticated: 'Authenticated', Anonymous: 'Anonymous'},
+    getStaticAsset: vi.fn(() => ({size: 100, key: 'default.mp4', url: 'https://cdn.example.com/default.mp4', contentType: 'video/mp4'}))
+  }))
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), metrics: {addMetric: vi.fn()}, MetricUnit: {Count: 'Count'}}))
+
+vi.mock('@mantleframework/validation',
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    z: {object: vi.fn(() => ({optional: vi.fn(() => ({default: vi.fn()}))})), string: vi.fn(() => ({optional: vi.fn(() => ({default: vi.fn()}))}))}
+  }))
+
+vi.mock('#config/constants',
+  () => ({
+    getDefaultFile: vi.fn(() => ({
+      fileId: 'default',
+      size: 100,
+      authorName: 'Lifegames',
+      authorUser: 'sxephil',
+      publishDate: new Date().toISOString(),
+      description: 'Description',
+      key: 'default.mp4',
+      url: 'https://cdn.example.com/default.mp4',
+      contentType: 'video/mp4',
+      title: 'Welcome! Tap to download.',
+      status: 'Downloaded'
+    }))
+  }))
+
+vi.mock('#entities/queries', () => ({getFilesForUser: vi.fn()}))
+
+vi.mock('#types/api-schema', () => ({fileListResponseSchema: {}}))
+
+vi.mock('#types/enums', () => ({FileStatus: {Queued: 'Queued', Downloading: 'Downloading', Downloaded: 'Downloaded', Failed: 'Failed'}}))
+
+const {handler} = await import('#lambdas/api/files/index.get.js')
+import {getFilesForUser} from '#entities/queries'
+import {getDefaultFile} from '#config/constants'
+import {buildValidatedResponse} from '@mantleframework/core'
+import {metrics} from '@mantleframework/observability'
+
+describe('ListFiles Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('toFile helper (via handler)', () => {
+    it('should convert null optional fields to undefined', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue([{
+        fileId: 'abc123',
+        size: 1000,
+        authorName: 'Author',
+        authorUser: 'author',
+        publishDate: '2024-01-01',
+        description: 'Desc',
+        key: 'abc123.mp4',
+        contentType: 'video/mp4',
+        title: 'Title',
+        status: 'Downloaded',
+        url: null,
+        duration: null,
+        uploadDate: null,
+        viewCount: null,
+        thumbnailUrl: null
+      }])
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
+
+      expect(result.contents[0].url).toBeUndefined()
+      expect(result.contents[0].duration).toBeUndefined()
+      expect(result.contents[0].uploadDate).toBeUndefined()
+      expect(result.contents[0].viewCount).toBeUndefined()
+      expect(result.contents[0].thumbnailUrl).toBeUndefined()
+    })
+
+    it('should preserve non-null optional fields', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue([{
+        fileId: 'abc123',
+        size: 1000,
+        authorName: 'Author',
+        authorUser: 'author',
+        publishDate: '2024-01-01',
+        description: 'Desc',
+        key: 'abc123.mp4',
+        contentType: 'video/mp4',
+        title: 'Title',
+        status: 'Downloaded',
+        url: 'https://cdn.example.com/abc123.mp4',
+        duration: 300,
+        uploadDate: '20240101',
+        viewCount: 5000,
+        thumbnailUrl: 'https://i.ytimg.com/vi/abc123/maxresdefault.jpg'
+      }])
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
+
+      expect(result.contents[0].url).toBe('https://cdn.example.com/abc123.mp4')
+      expect(result.contents[0].duration).toBe(300)
+      expect(result.contents[0].uploadDate).toBe('20240101')
+      expect(result.contents[0].viewCount).toBe(5000)
+      expect(result.contents[0].thumbnailUrl).toBe('https://i.ytimg.com/vi/abc123/maxresdefault.jpg')
+    })
+
+    it('should cast status to File status type', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue([{
+        fileId: 'abc123',
+        size: 0,
+        authorName: 'Author',
+        authorUser: 'author',
+        publishDate: '2024-01-01',
+        description: 'Desc',
+        key: 'abc123.mp4',
+        contentType: 'video/mp4',
+        title: 'Title',
+        status: 'Queued',
+        url: null,
+        duration: null,
+        uploadDate: null,
+        viewCount: null,
+        thumbnailUrl: null
+      }])
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'all'}})
+
+      expect(result.contents[0].status).toBe('Queued')
+    })
+  })
+
+  describe('anonymous user', () => {
+    it('should return default file for anonymous users', async () => {
+      await handler({context: {awsRequestId: 'req-1'}, userId: undefined, userStatus: 'Anonymous', query: {status: 'downloaded'}})
+
+      expect(getDefaultFile).toHaveBeenCalled()
+      expect(getFilesForUser).not.toHaveBeenCalled()
+      expect(buildValidatedResponse).toHaveBeenCalledWith({awsRequestId: 'req-1'}, 200, expect.objectContaining({keyCount: 1}), expect.anything())
+    })
+  })
+
+  describe('status filtering', () => {
+    const mockFiles = [
+      {
+        fileId: 'file-1',
+        size: 1000,
+        authorName: 'A',
+        authorUser: 'a',
+        publishDate: '2024-01-02',
+        description: 'D',
+        key: 'file-1.mp4',
+        contentType: 'video/mp4',
+        title: 'Downloaded Video',
+        status: 'Downloaded',
+        url: null,
+        duration: null,
+        uploadDate: null,
+        viewCount: null,
+        thumbnailUrl: null
+      },
+      {
+        fileId: 'file-2',
+        size: 0,
+        authorName: 'B',
+        authorUser: 'b',
+        publishDate: '2024-01-01',
+        description: 'D',
+        key: 'file-2.mp4',
+        contentType: 'video/mp4',
+        title: 'Queued Video',
+        status: 'Queued',
+        url: null,
+        duration: null,
+        uploadDate: null,
+        viewCount: null,
+        thumbnailUrl: null
+      }
+    ]
+
+    it('should filter to Downloaded files by default', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue(mockFiles)
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
+
+      expect(result.contents).toHaveLength(1)
+      expect(result.contents[0].status).toBe('Downloaded')
+      expect(result.keyCount).toBe(1)
+    })
+
+    it('should return all files when status=all', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue(mockFiles)
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'all'}})
+
+      expect(result.contents).toHaveLength(2)
+      expect(result.keyCount).toBe(2)
+    })
+
+    it('should use default status when query.status is undefined', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue(mockFiles)
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {}})
+
+      expect(result.contents).toHaveLength(1)
+      expect(result.contents[0].status).toBe('Downloaded')
+    })
+  })
+
+  describe('sorting', () => {
+    it('should sort files by publishDate descending (newest first)', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue([
+        {
+          fileId: 'old',
+          size: 1000,
+          authorName: 'A',
+          authorUser: 'a',
+          publishDate: '2024-01-01',
+          description: 'D',
+          key: 'old.mp4',
+          contentType: 'video/mp4',
+          title: 'Old Video',
+          status: 'Downloaded',
+          url: null,
+          duration: null,
+          uploadDate: null,
+          viewCount: null,
+          thumbnailUrl: null
+        },
+        {
+          fileId: 'new',
+          size: 2000,
+          authorName: 'B',
+          authorUser: 'b',
+          publishDate: '2024-06-15',
+          description: 'D',
+          key: 'new.mp4',
+          contentType: 'video/mp4',
+          title: 'New Video',
+          status: 'Downloaded',
+          url: null,
+          duration: null,
+          uploadDate: null,
+          viewCount: null,
+          thumbnailUrl: null
+        }
+      ])
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
+
+      expect(result.contents[0].fileId).toBe('new')
+      expect(result.contents[1].fileId).toBe('old')
+    })
+  })
+
+  describe('metrics', () => {
+    it('should emit FilesReturned metric for authenticated users', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue([])
+
+      await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
+
+      expect(metrics.addMetric).toHaveBeenCalledWith('FilesReturned', 'Count', 0)
+    })
+  })
+
+  describe('empty results', () => {
+    it('should return empty array when user has no files', async () => {
+      vi.mocked(getFilesForUser).mockResolvedValue([])
+
+      const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
+
+      expect(result.contents).toHaveLength(0)
+      expect(result.keyCount).toBe(0)
+    })
+  })
+})

--- a/test/lambdas/api/user/index.delete.test.ts
+++ b/test/lambdas/api/user/index.delete.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for UserDelete Lambda (DELETE /user)
+ *
+ * Tests cascade deletion ordering, partial failures, and GitHub issue creation on error.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})), defineLambda: vi.fn()}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnauthorizedError extends Error {
+    statusCode = 401
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnauthorizedError'
+    }
+  }
+  class UnexpectedError extends Error {
+    statusCode = 500
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnexpectedError'
+    }
+  }
+  return {UnauthorizedError, UnexpectedError}
+})
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logError: vi.fn()}))
+
+vi.mock('@mantleframework/validation',
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({})), number: vi.fn(() => ({}))}
+  }))
+
+vi.mock('#entities/queries', () => ({deleteUser: vi.fn(), deleteUserDevicesByUserId: vi.fn(), deleteUserFilesByUserId: vi.fn(), getDevicesBatch: vi.fn()}))
+
+vi.mock('#errors/custom-errors', () => ({providerFailureErrorMessage: 'AWS request failed'}))
+
+vi.mock('#integrations/github/issueService', () => ({createFailedUserDeletionIssue: vi.fn()}))
+
+vi.mock('#services/device/deviceService', () => ({deleteDevice: vi.fn(), getUserDevices: vi.fn()}))
+
+const {handler} = await import('#lambdas/api/user/index.delete.js')
+import {deleteUser, deleteUserDevicesByUserId, deleteUserFilesByUserId, getDevicesBatch} from '#entities/queries'
+import {createFailedUserDeletionIssue} from '#integrations/github/issueService'
+import {deleteDevice, getUserDevices} from '#services/device/deviceService'
+import {buildValidatedResponse} from '@mantleframework/core'
+
+describe('UserDelete Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw UnauthorizedError when userId is missing', async () => {
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: undefined})).rejects.toThrow('Authentication required')
+  })
+
+  it('should throw UnauthorizedError when userId is empty string', async () => {
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: ''})).rejects.toThrow('Authentication required')
+  })
+
+  it('should delete user with no devices successfully', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([])
+    vi.mocked(deleteUserFilesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUserDevicesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUser).mockResolvedValue(undefined as never)
+
+    await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    expect(buildValidatedResponse).toHaveBeenCalledWith({awsRequestId: 'req-1'}, 204)
+    expect(getDevicesBatch).not.toHaveBeenCalled()
+  })
+
+  it('should throw UnexpectedError when getDevicesBatch returns empty for known devices', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([{userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()}])
+    vi.mocked(getDevicesBatch).mockResolvedValue([])
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow('AWS request failed')
+  })
+
+  it('should return 207 when relation deletions fail', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([])
+    vi.mocked(deleteUserFilesByUserId).mockRejectedValue(new Error('DB error'))
+    vi.mocked(deleteUserDevicesByUserId).mockResolvedValue(undefined as never)
+
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    expect(result.statusCode).toBe(207)
+    expect(result.message).toContain('Partial deletion')
+    expect(result.failedOperations).toBe(1)
+  })
+
+  it('should return 207 when device deletions fail', async () => {
+    const mockDevice = {deviceId: 'dev-1', name: 'iPhone', token: 'tok', systemVersion: '17', systemName: 'iOS', endpointArn: 'arn:aws:sns:endpoint'}
+    vi.mocked(getUserDevices).mockResolvedValue([{userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()}])
+    vi.mocked(getDevicesBatch).mockResolvedValue([mockDevice])
+    vi.mocked(deleteUserFilesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUserDevicesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteDevice).mockRejectedValue(new Error('SNS error'))
+
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    expect(result.statusCode).toBe(207)
+    expect(result.message).toContain('devices could not be removed')
+  })
+
+  it('should create GitHub issue and throw when deleteUser fails', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([])
+    vi.mocked(deleteUserFilesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUserDevicesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUser).mockRejectedValue(new Error('DB constraint error'))
+    vi.mocked(createFailedUserDeletionIssue).mockResolvedValue(undefined as never)
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow('Operation failed unexpectedly; but logged for resolution')
+
+    expect(createFailedUserDeletionIssue).toHaveBeenCalledWith('user-1', [], expect.any(Error), 'req-1')
+  })
+
+  it('should handle non-Error thrown from deleteUser', async () => {
+    vi.mocked(getUserDevices).mockResolvedValue([])
+    vi.mocked(deleteUserFilesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUserDevicesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUser).mockRejectedValue('string error')
+    vi.mocked(createFailedUserDeletionIssue).mockResolvedValue(undefined as never)
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow('Operation failed unexpectedly')
+
+    expect(createFailedUserDeletionIssue).toHaveBeenCalledWith('user-1', [], expect.objectContaining({message: 'string error'}), 'req-1')
+  })
+
+  it('should delete user and devices in correct cascade order', async () => {
+    const mockDevice = {deviceId: 'dev-1', name: 'iPhone', token: 'tok', systemVersion: '17', systemName: 'iOS', endpointArn: 'arn:aws:sns:endpoint'}
+    vi.mocked(getUserDevices).mockResolvedValue([{userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()}])
+    vi.mocked(getDevicesBatch).mockResolvedValue([mockDevice])
+    vi.mocked(deleteUserFilesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUserDevicesByUserId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteDevice).mockResolvedValue(undefined as never)
+    vi.mocked(deleteUser).mockResolvedValue(undefined as never)
+
+    await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    // Relations deleted first, then devices, then user last
+    expect(deleteUserFilesByUserId).toHaveBeenCalled()
+    expect(deleteUserDevicesByUserId).toHaveBeenCalled()
+    expect(deleteDevice).toHaveBeenCalledWith(mockDevice)
+    expect(deleteUser).toHaveBeenCalled()
+    expect(buildValidatedResponse).toHaveBeenCalledWith({awsRequestId: 'req-1'}, 204)
+  })
+})

--- a/test/lambdas/api/user/login.post.test.ts
+++ b/test/lambdas/api/user/login.post.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for LoginUser Lambda (POST /user/login)
+ *
+ * Tests sign-in flow, session retrieval, and error paths.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/auth', () => ({getAuth: vi.fn()}))
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, _code, data) => data), defineLambda: vi.fn()}))
+
+vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'mock-value')}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnexpectedError extends Error {
+    statusCode = 500
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnexpectedError'
+    }
+  }
+  return {UnexpectedError}
+})
+
+vi.mock('@mantleframework/observability', () => ({logInfo: vi.fn()}))
+
+vi.mock('@mantleframework/validation',
+  () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler), z: {object: vi.fn(() => ({})), string: vi.fn(() => ({}))}}))
+
+vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
+
+vi.mock('#db/schema', () => ({accounts: {}, sessions: {}, users: {}, verification: {}}))
+
+vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
+
+const {handler} = await import('#lambdas/api/user/login.post.js')
+import {getAuth} from '@mantleframework/auth'
+
+function createMockAuth(overrides: {signInSocialResult?: object; getSessionResult?: object | null} = {}) {
+  const now = new Date()
+  const signInSocialResult = overrides.signInSocialResult ??
+    {
+      redirect: false,
+      token: 'test-token',
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+    }
+  const getSessionResult = overrides.getSessionResult !== undefined
+    ? overrides.getSessionResult
+    : {
+      session: {id: 'session-1', token: 'test-token', userId: 'user-1', expiresAt: new Date(Date.now() + 86400000), createdAt: now, updatedAt: now},
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+    }
+  return {api: {signInSocial: vi.fn().mockResolvedValue(signInSocialResult), getSession: vi.fn().mockResolvedValue(getSessionResult)}}
+}
+
+describe('LoginUser Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw UnexpectedError when getSession returns null', async () => {
+    const mockAuth = createMockAuth({getSessionResult: null})
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await expect(
+      handler({
+        event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+        context: {awsRequestId: 'req-1'},
+        body: {idToken: 'test-id-token'}
+      })
+    ).rejects.toThrow('signInSocial succeeded but getSession returned null')
+  })
+
+  it('should throw when session object is missing', async () => {
+    const mockAuth = createMockAuth({getSessionResult: {session: null, user: {id: 'user-1'}}})
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await expect(
+      handler({
+        event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+        context: {awsRequestId: 'req-1'},
+        body: {idToken: 'test-id-token'}
+      })
+    ).rejects.toThrow('signInSocial succeeded but getSession returned null')
+  })
+
+  it('should return token, expiresAt, sessionId, and userId on success', async () => {
+    const expiresAt = new Date(Date.now() + 86400000)
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'my-token',
+        user: {id: 'user-42', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+      },
+      getSessionResult: {
+        session: {id: 'session-99', token: 'my-token', userId: 'user-42', expiresAt, createdAt: new Date(), updatedAt: new Date()},
+        user: {id: 'user-42', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    const result = await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(result).toEqual({token: 'my-token', expiresAt: expiresAt.toISOString(), sessionId: 'session-99', userId: 'user-42'})
+  })
+
+  it('should pass ipAddress and userAgent to signInSocial', async () => {
+    const mockAuth = createMockAuth()
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '10.0.0.1'}}, headers: {'User-Agent': 'MediaDownloader/1.0'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(mockAuth.api.signInSocial).toHaveBeenCalledWith(
+      expect.objectContaining({headers: {'user-agent': 'MediaDownloader/1.0', 'x-forwarded-for': '10.0.0.1'}})
+    )
+  })
+
+  it('should handle missing sourceIp gracefully', async () => {
+    const mockAuth = createMockAuth()
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await handler({
+      event: {requestContext: {identity: {}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(mockAuth.api.signInSocial).toHaveBeenCalledWith(expect.objectContaining({headers: expect.objectContaining({'x-forwarded-for': ''})}))
+  })
+
+  it('should propagate signInSocial errors', async () => {
+    const mockAuth = createMockAuth()
+    mockAuth.api.signInSocial.mockRejectedValue(new Error('Invalid ID token'))
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await expect(
+      handler({
+        event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+        context: {awsRequestId: 'req-1'},
+        body: {idToken: 'invalid-token'}
+      })
+    ).rejects.toThrow('Invalid ID token')
+  })
+})

--- a/test/lambdas/api/user/logout.post.test.ts
+++ b/test/lambdas/api/user/logout.post.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for LogoutUser Lambda (POST /user/logout)
+ *
+ * Tests token extraction, session expiry, and auth error paths.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/auth', () => ({expireSession: vi.fn(), extractBearerToken: vi.fn()}))
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code) => ({statusCode: code})), defineLambda: vi.fn()}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnauthorizedError extends Error {
+    statusCode = 401
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnauthorizedError'
+    }
+  }
+  return {UnauthorizedError}
+})
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logInfo: vi.fn()}))
+
+vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler)}))
+
+vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
+
+vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
+
+const {handler} = await import('#lambdas/api/user/logout.post.js')
+import {expireSession, extractBearerToken} from '@mantleframework/auth'
+import {getAuthInstance} from '#domain/auth/authInstance'
+import {getDrizzleClient} from '#db/client'
+import {buildValidatedResponse} from '@mantleframework/core'
+
+describe('LogoutUser Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw UnauthorizedError when userId is missing', async () => {
+    await expect(handler({event: {headers: {Authorization: 'Bearer token'}}, context: {awsRequestId: 'req-1'}, userId: undefined})).rejects.toThrow(
+      'Authentication required'
+    )
+  })
+
+  it('should throw UnauthorizedError when bearer token is missing', async () => {
+    vi.mocked(extractBearerToken).mockReturnValue(null as never)
+
+    await expect(handler({event: {headers: {}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow('Missing Authorization header')
+  })
+
+  it('should expire session and return 204', async () => {
+    vi.mocked(extractBearerToken).mockReturnValue('my-token')
+    vi.mocked(getAuthInstance).mockResolvedValue({} as never)
+    vi.mocked(getDrizzleClient).mockResolvedValue({} as never)
+    vi.mocked(expireSession).mockResolvedValue(undefined as never)
+
+    const result = await handler({event: {headers: {Authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    expect(expireSession).toHaveBeenCalledWith({}, 'my-token', {})
+    expect(buildValidatedResponse).toHaveBeenCalledWith({awsRequestId: 'req-1'}, 204)
+    expect(result.statusCode).toBe(204)
+  })
+
+  it('should propagate expireSession errors', async () => {
+    vi.mocked(extractBearerToken).mockReturnValue('my-token')
+    vi.mocked(getAuthInstance).mockResolvedValue({} as never)
+    vi.mocked(getDrizzleClient).mockResolvedValue({} as never)
+    vi.mocked(expireSession).mockRejectedValue(new Error('Session not found'))
+
+    await expect(handler({event: {headers: {Authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow(
+      'Session not found'
+    )
+  })
+})

--- a/test/lambdas/api/user/refresh.post.test.ts
+++ b/test/lambdas/api/user/refresh.post.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for RefreshToken Lambda (POST /user/refresh)
+ *
+ * Tests token extraction, session validation, and auth error paths.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/auth', () => ({extractBearerToken: vi.fn(), validateSession: vi.fn()}))
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, _code, data) => data), defineLambda: vi.fn()}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnauthorizedError extends Error {
+    statusCode = 401
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnauthorizedError'
+    }
+  }
+  return {UnauthorizedError}
+})
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logInfo: vi.fn()}))
+
+vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler)}))
+
+vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
+
+vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
+
+const {handler} = await import('#lambdas/api/user/refresh.post.js')
+import {extractBearerToken, validateSession} from '@mantleframework/auth'
+import {getAuthInstance} from '#domain/auth/authInstance'
+
+describe('RefreshToken Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw UnauthorizedError when userId is missing', async () => {
+    await expect(handler({event: {headers: {Authorization: 'Bearer token'}}, context: {awsRequestId: 'req-1'}, userId: undefined})).rejects.toThrow(
+      'Authentication required'
+    )
+  })
+
+  it('should throw UnauthorizedError when bearer token is missing', async () => {
+    vi.mocked(extractBearerToken).mockReturnValue(null as never)
+
+    await expect(handler({event: {headers: {}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow('Missing Authorization header')
+  })
+
+  it('should return refreshed session info on success', async () => {
+    const expiresAt = new Date(Date.now() + 86400000)
+    vi.mocked(extractBearerToken).mockReturnValue('my-token')
+    vi.mocked(getAuthInstance).mockResolvedValue({} as never)
+    vi.mocked(validateSession).mockResolvedValue({
+      session: {id: 'session-1', expiresAt, token: 'my-token', userId: 'user-1', createdAt: new Date(), updatedAt: new Date()},
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+    })
+
+    const result = await handler({event: {headers: {Authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    expect(result).toEqual({token: 'my-token', expiresAt: expiresAt.toISOString(), sessionId: 'session-1', userId: 'user-1'})
+  })
+
+  it('should check lowercase authorization header', async () => {
+    vi.mocked(extractBearerToken).mockReturnValue('my-token')
+    vi.mocked(getAuthInstance).mockResolvedValue({} as never)
+    vi.mocked(validateSession).mockResolvedValue({
+      session: {id: 's-1', expiresAt: new Date(), token: 'my-token', userId: 'user-1', createdAt: new Date(), updatedAt: new Date()},
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+    })
+
+    await handler({event: {headers: {authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})
+
+    expect(extractBearerToken).toHaveBeenCalledWith('Bearer my-token')
+  })
+
+  it('should propagate validateSession errors', async () => {
+    vi.mocked(extractBearerToken).mockReturnValue('my-token')
+    vi.mocked(getAuthInstance).mockResolvedValue({} as never)
+    vi.mocked(validateSession).mockRejectedValue(new Error('Session expired'))
+
+    await expect(handler({event: {headers: {Authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})).rejects.toThrow(
+      'Session expired'
+    )
+  })
+})

--- a/test/lambdas/api/user/register.post.test.ts
+++ b/test/lambdas/api/user/register.post.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for RegisterUser Lambda (POST /user/register)
+ *
+ * Tests sign-in flow, session validation, new user name update, and error paths.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/auth', () => ({getAuth: vi.fn()}))
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, _code, data) => data), defineLambda: vi.fn()}))
+
+vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'mock-value')}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnexpectedError extends Error {
+    statusCode = 500
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnexpectedError'
+    }
+  }
+  return {UnexpectedError}
+})
+
+vi.mock('@mantleframework/observability', () => ({logInfo: vi.fn(), metrics: {addMetric: vi.fn()}, MetricUnit: {Count: 'Count'}}))
+
+vi.mock('@mantleframework/validation',
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({optional: vi.fn(() => ({}))}))}
+  }))
+
+vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
+
+vi.mock('#db/schema', () => ({accounts: {}, sessions: {}, users: {}, verification: {}}))
+
+vi.mock('#entities/queries', () => ({updateUser: vi.fn()}))
+
+vi.mock('#types/api-schema', () => ({userRegistrationResponseSchema: {}}))
+
+const {handler} = await import('#lambdas/api/user/register.post.js')
+import {getAuth} from '@mantleframework/auth'
+import {updateUser} from '#entities/queries'
+import {metrics} from '@mantleframework/observability'
+
+function createMockAuth(overrides: {signInSocialResult?: object; getSessionResult?: object | null} = {}) {
+  const now = new Date()
+  const signInSocialResult = overrides.signInSocialResult ??
+    {
+      redirect: false,
+      token: 'test-token',
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+    }
+  const getSessionResult = overrides.getSessionResult !== undefined
+    ? overrides.getSessionResult
+    : {
+      session: {id: 'session-1', token: 'test-token', userId: 'user-1', expiresAt: new Date(Date.now() + 86400000), createdAt: now, updatedAt: now},
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+    }
+
+  return {api: {signInSocial: vi.fn().mockResolvedValue(signInSocialResult), getSession: vi.fn().mockResolvedValue(getSessionResult)}}
+}
+
+describe('RegisterUser Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw UnexpectedError when getSession returns null', async () => {
+    const mockAuth = createMockAuth({getSessionResult: null})
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await expect(
+      handler({
+        event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+        context: {awsRequestId: 'req-1'},
+        body: {idToken: 'test-id-token'}
+      })
+    ).rejects.toThrow('signInSocial succeeded but getSession returned null')
+  })
+
+  it('should throw when session is missing from result', async () => {
+    const mockAuth = createMockAuth({getSessionResult: {session: null, user: {id: 'user-1'}}})
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await expect(
+      handler({
+        event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+        context: {awsRequestId: 'req-1'},
+        body: {idToken: 'test-id-token'}
+      })
+    ).rejects.toThrow('signInSocial succeeded but getSession returned null')
+  })
+
+  it('should update user name for new users with firstName and lastName', async () => {
+    const now = new Date()
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'test-token',
+        user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+    vi.mocked(updateUser).mockResolvedValue(undefined as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token', firstName: 'John', lastName: 'Doe'}
+    })
+
+    expect(updateUser).toHaveBeenCalledWith('user-1', {name: 'John Doe', firstName: 'John', lastName: 'Doe'})
+  })
+
+  it('should not update user name when no name fields provided for new user', async () => {
+    const now = new Date()
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'test-token',
+        user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(updateUser).not.toHaveBeenCalled()
+  })
+
+  it('should not update user name for existing users', async () => {
+    const oldDate = new Date(Date.now() - 60000) // 60 seconds ago
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'test-token',
+        user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: oldDate, updatedAt: oldDate}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token', firstName: 'John', lastName: 'Doe'}
+    })
+
+    expect(updateUser).not.toHaveBeenCalled()
+  })
+
+  it('should emit NewUserRegistration metric for new users', async () => {
+    const now = new Date()
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'test-token',
+        user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(metrics.addMetric).toHaveBeenCalledWith('NewUserRegistration', 'Count', 1)
+  })
+
+  it('should return token, expiresAt, sessionId, and userId', async () => {
+    const expiresAt = new Date(Date.now() + 86400000)
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'my-token',
+        user: {id: 'user-42', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(Date.now() - 60000), updatedAt: new Date()}
+      },
+      getSessionResult: {
+        session: {id: 'session-99', token: 'my-token', userId: 'user-42', expiresAt, createdAt: new Date(), updatedAt: new Date()},
+        user: {id: 'user-42', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    const result = await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(result).toEqual({token: 'my-token', expiresAt: expiresAt.toISOString(), sessionId: 'session-99', userId: 'user-42'})
+  })
+
+  it('should handle firstName only (no lastName)', async () => {
+    const now = new Date()
+    const mockAuth = createMockAuth({
+      signInSocialResult: {
+        redirect: false,
+        token: 'test-token',
+        user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
+      }
+    })
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+    vi.mocked(updateUser).mockResolvedValue(undefined as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {'User-Agent': 'test'}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token', firstName: 'John'}
+    })
+
+    expect(updateUser).toHaveBeenCalledWith('user-1', {name: 'John', firstName: 'John', lastName: ''})
+  })
+
+  it('should use empty string for User-Agent when missing', async () => {
+    const mockAuth = createMockAuth()
+    vi.mocked(getAuth).mockResolvedValue(mockAuth as never)
+
+    await handler({
+      event: {requestContext: {identity: {sourceIp: '1.2.3.4'}}, headers: {}},
+      context: {awsRequestId: 'req-1'},
+      body: {idToken: 'test-id-token'}
+    })
+
+    expect(mockAuth.api.signInSocial).toHaveBeenCalledWith(expect.objectContaining({headers: expect.objectContaining({'user-agent': ''})}))
+  })
+})

--- a/test/lambdas/api/user/subscribe.post.test.ts
+++ b/test/lambdas/api/user/subscribe.post.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for UserSubscribe Lambda (POST /user/subscribe)
+ *
+ * Tests subscription creation, auth validation, and platform config check.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data}))}))
+
+vi.mock('@mantleframework/errors', () => {
+  class UnauthorizedError extends Error {
+    statusCode = 401
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnauthorizedError'
+    }
+  }
+  return {UnauthorizedError}
+})
+
+vi.mock('@mantleframework/validation',
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({optional: vi.fn(() => ({}))}))}
+  }))
+
+vi.mock('#services/device/deviceService', () => ({subscribeEndpointToTopic: vi.fn()}))
+
+vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
+
+const {handler} = await import('#lambdas/api/user/subscribe.post.js')
+import {subscribeEndpointToTopic} from '#services/device/deviceService'
+import {verifyPlatformConfiguration} from '#utils/platform-config'
+
+describe('UserSubscribe Lambda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw UnauthorizedError when userId is missing', async () => {
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: undefined, body: {endpointArn: 'arn:endpoint', topicArn: 'arn:topic'}})).rejects.toThrow(
+      'Authentication required'
+    )
+  })
+
+  it('should call verifyPlatformConfiguration before subscribing', async () => {
+    vi.mocked(subscribeEndpointToTopic).mockResolvedValue({SubscriptionArn: 'arn:sub', $metadata: {}})
+
+    await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', body: {endpointArn: 'arn:endpoint', topicArn: 'arn:topic'}})
+
+    expect(verifyPlatformConfiguration).toHaveBeenCalled()
+  })
+
+  it('should return 201 with subscription ARN', async () => {
+    vi.mocked(subscribeEndpointToTopic).mockResolvedValue({SubscriptionArn: 'arn:aws:sns:sub/123', $metadata: {}})
+
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', body: {endpointArn: 'arn:endpoint', topicArn: 'arn:topic'}})
+
+    expect(result.statusCode).toBe(201)
+    expect(result.subscriptionArn).toBe('arn:aws:sns:sub/123')
+  })
+
+  it('should propagate subscription errors', async () => {
+    vi.mocked(subscribeEndpointToTopic).mockRejectedValue(new Error('SNS error'))
+
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', body: {endpointArn: 'arn:endpoint', topicArn: 'arn:topic'}})).rejects.toThrow(
+      'SNS error'
+    )
+  })
+})

--- a/test/services/notification/endpointCleanup.test.ts
+++ b/test/services/notification/endpointCleanup.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for APNS Endpoint Cleanup Service
+ *
+ * Tests cleanup of disabled APNS endpoints including single device cleanup,
+ * lookup-based cleanup, and batch operations.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMockDevice} from '#test/helpers/entity-fixtures'
+
+vi.mock('#entities/queries', () => ({deleteDevice: vi.fn(), deleteUserDevicesByDeviceId: vi.fn(), getDevice: vi.fn()}))
+
+vi.mock('@mantleframework/aws', () => ({deleteEndpoint: vi.fn()}))
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logInfo: vi.fn(), logWarn: vi.fn(), logError: vi.fn()}))
+
+vi.mock('@mantleframework/core',
+  () => ({
+    ok: vi.fn((value: unknown) => ({success: true, value})),
+    err: vi.fn((error: unknown) => ({success: false, error})),
+    isOk: vi.fn((result: {success: boolean}) => result.success)
+  }))
+
+const {cleanupDisabledEndpoint, cleanupDisabledEndpointByDeviceId, cleanupDisabledEndpoints} = await import('#services/notification/endpointCleanup.js')
+import {deleteDevice as deleteDeviceRecord, deleteUserDevicesByDeviceId, getDevice} from '#entities/queries'
+import {deleteEndpoint} from '@mantleframework/aws'
+import {logError, logInfo} from '@mantleframework/observability'
+
+describe('Endpoint Cleanup Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('cleanupDisabledEndpoint', () => {
+    const deviceId = 'device-123'
+    const endpointArn = 'arn:aws:sns:us-west-2:123456789012:endpoint/APNS_SANDBOX/app/device-123'
+
+    it('should cleanup all resources in order and return ok result', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockResolvedValue({$metadata: {}})
+      vi.mocked(deleteDeviceRecord).mockResolvedValue(undefined)
+
+      const result = await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(result).toEqual({success: true, value: {deviceId, endpointArn}})
+
+      // Verify order: junction records first, then SNS endpoint, then device
+      const deleteUserDevicesCall = vi.mocked(deleteUserDevicesByDeviceId).mock.invocationCallOrder[0]
+      const deleteEndpointCall = vi.mocked(deleteEndpoint).mock.invocationCallOrder[0]
+      const deleteDeviceCall = vi.mocked(deleteDeviceRecord).mock.invocationCallOrder[0]
+      expect(deleteUserDevicesCall).toBeLessThan(deleteEndpointCall!)
+      expect(deleteEndpointCall).toBeLessThan(deleteDeviceCall!)
+    })
+
+    it('should log info messages on start and completion', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockResolvedValue({$metadata: {}})
+      vi.mocked(deleteDeviceRecord).mockResolvedValue(undefined)
+
+      await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(logInfo).toHaveBeenCalledWith('Cleaning up disabled endpoint', {deviceId, endpointArn})
+      expect(logInfo).toHaveBeenCalledWith('Successfully cleaned up disabled endpoint', {deviceId})
+    })
+
+    it('should return err result when deleteUserDevicesByDeviceId fails', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockRejectedValue(new Error('DB connection lost'))
+
+      const result = await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(result).toEqual({success: false, error: {deviceId, endpointArn, error: 'DB connection lost'}})
+      expect(deleteEndpoint).not.toHaveBeenCalled()
+      expect(deleteDeviceRecord).not.toHaveBeenCalled()
+    })
+
+    it('should return err result when deleteEndpoint fails', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockRejectedValue(new Error('SNS error'))
+
+      const result = await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(result).toEqual({success: false, error: {deviceId, endpointArn, error: 'SNS error'}})
+      expect(deleteDeviceRecord).not.toHaveBeenCalled()
+    })
+
+    it('should return err result when deleteDeviceRecord fails', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockResolvedValue({$metadata: {}})
+      vi.mocked(deleteDeviceRecord).mockRejectedValue(new Error('Device not found'))
+
+      const result = await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(result).toEqual({success: false, error: {deviceId, endpointArn, error: 'Device not found'}})
+    })
+
+    it('should log error when cleanup fails', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockRejectedValue(new Error('Timeout'))
+
+      await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(logError).toHaveBeenCalledWith('Failed to cleanup disabled endpoint', {deviceId, endpointArn, error: 'Timeout'})
+    })
+
+    it('should handle non-Error thrown values', async () => {
+      vi.mocked(deleteUserDevicesByDeviceId).mockRejectedValue('string error')
+
+      const result = await cleanupDisabledEndpoint(deviceId, endpointArn)
+
+      expect(result).toEqual({success: false, error: {deviceId, endpointArn, error: 'string error'}})
+    })
+  })
+
+  describe('cleanupDisabledEndpointByDeviceId', () => {
+    it('should look up device and clean up endpoint', async () => {
+      const device = createMockDevice({deviceId: 'device-456'})
+      vi.mocked(getDevice).mockResolvedValue(device)
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockResolvedValue({$metadata: {}})
+      vi.mocked(deleteDeviceRecord).mockResolvedValue(undefined)
+
+      const result = await cleanupDisabledEndpointByDeviceId('device-456')
+
+      expect(result).toEqual({success: true, value: {deviceId: 'device-456', endpointArn: device.endpointArn}})
+      expect(getDevice).toHaveBeenCalledWith('device-456')
+    })
+
+    it('should return undefined when device is not found', async () => {
+      vi.mocked(getDevice).mockResolvedValue(null)
+
+      const result = await cleanupDisabledEndpointByDeviceId('nonexistent')
+
+      expect(result).toBeUndefined()
+      expect(logInfo).toHaveBeenCalledWith('Device not found for cleanup', {deviceId: 'nonexistent'})
+      expect(deleteUserDevicesByDeviceId).not.toHaveBeenCalled()
+    })
+
+    it('should return undefined when device has no endpoint ARN', async () => {
+      const device = createMockDevice({deviceId: 'device-no-arn', endpointArn: ''})
+      vi.mocked(getDevice).mockResolvedValue(device)
+
+      const result = await cleanupDisabledEndpointByDeviceId('device-no-arn')
+
+      expect(result).toBeUndefined()
+      expect(logInfo).toHaveBeenCalledWith('Device has no endpoint ARN', {deviceId: 'device-no-arn'})
+      expect(deleteUserDevicesByDeviceId).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cleanupDisabledEndpoints', () => {
+    it('should return empty array for empty input', async () => {
+      const results = await cleanupDisabledEndpoints([])
+
+      expect(results).toEqual([])
+      expect(getDevice).not.toHaveBeenCalled()
+    })
+
+    it('should process multiple devices in parallel', async () => {
+      const device1 = createMockDevice({deviceId: 'dev-1'})
+      const device2 = createMockDevice({deviceId: 'dev-2'})
+
+      vi.mocked(getDevice).mockResolvedValueOnce(device1).mockResolvedValueOnce(device2)
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockResolvedValue({$metadata: {}})
+      vi.mocked(deleteDeviceRecord).mockResolvedValue(undefined)
+
+      const results = await cleanupDisabledEndpoints(['dev-1', 'dev-2'])
+
+      expect(results).toHaveLength(2)
+      expect(getDevice).toHaveBeenCalledTimes(2)
+    })
+
+    it('should skip devices not found (no result added)', async () => {
+      vi.mocked(getDevice).mockResolvedValue(null)
+
+      const results = await cleanupDisabledEndpoints(['missing-1', 'missing-2'])
+
+      // Not found devices return undefined from cleanupDisabledEndpointByDeviceId,
+      // which are filtered out in the results
+      expect(results).toHaveLength(0)
+    })
+
+    it('should include err results for rejected promises', async () => {
+      vi.mocked(getDevice).mockRejectedValue(new Error('DB down'))
+
+      const results = await cleanupDisabledEndpoints(['dev-fail'])
+
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({success: false, error: {deviceId: 'dev-fail', endpointArn: '', error: 'DB down'}})
+    })
+
+    it('should log batch summary', async () => {
+      vi.mocked(getDevice).mockResolvedValue(null)
+
+      await cleanupDisabledEndpoints(['dev-1'])
+
+      expect(logInfo).toHaveBeenCalledWith('Starting batch endpoint cleanup', {deviceCount: 1})
+      expect(logInfo).toHaveBeenCalledWith('Batch endpoint cleanup complete', expect.objectContaining({total: 1}))
+    })
+
+    it('should handle mix of successes and failures', async () => {
+      const device1 = createMockDevice({deviceId: 'dev-ok'})
+      vi.mocked(getDevice).mockResolvedValueOnce(device1).mockRejectedValueOnce(new Error('fail'))
+      vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined)
+      vi.mocked(deleteEndpoint).mockResolvedValue({$metadata: {}})
+      vi.mocked(deleteDeviceRecord).mockResolvedValue(undefined)
+
+      const results = await cleanupDisabledEndpoints(['dev-ok', 'dev-fail'])
+
+      expect(results).toHaveLength(2)
+      expect(logInfo).toHaveBeenCalledWith('Batch endpoint cleanup complete', expect.objectContaining({total: 2, cleaned: 1, failed: 1}))
+    })
+  })
+})

--- a/test/services/notification/transformers.test.ts
+++ b/test/services/notification/transformers.test.ts
@@ -6,9 +6,15 @@ import {FileStatus} from '#types/enums'
 // Mock SQS stringAttribute
 vi.mock('@mantleframework/aws', () => ({stringAttribute: vi.fn((value: string) => ({DataType: 'String', StringValue: value}))}))
 
-const {truncateDescription, createMetadataNotification, createDownloadReadyNotification, transformToAPNSNotification} = await import(
-  '#services/notification/transformers.js'
-)
+const {
+  truncateDescription,
+  createMetadataNotification,
+  createDownloadStartedNotification,
+  createDownloadReadyNotification,
+  createFailureNotification,
+  transformToAPNSNotification,
+  transformToAPNSAlertNotification
+} = await import('#services/notification/transformers.js')
 
 describe('Notification Transformers', () => {
   describe('truncateDescription', () => {
@@ -156,6 +162,145 @@ describe('Notification Transformers', () => {
 
       const message = JSON.parse(result.Message!)
       expect(message.default).toEqual('Default message')
+    })
+  })
+
+  describe('createDownloadStartedNotification', () => {
+    const mockVideoInfo: YtDlpVideoInfo = {
+      id: 'start-vid',
+      title: 'Starting Download',
+      uploader: 'Test Channel',
+      description: 'Test',
+      upload_date: '20240101',
+      thumbnail: 'https://example.com/thumb.jpg',
+      duration: 120,
+      formats: []
+    }
+
+    test('should create download started notification with correct structure', () => {
+      const result = createDownloadStartedNotification('start-vid', mockVideoInfo, 'user-1')
+      const body = JSON.parse(result.messageBody)
+
+      expect(body.notificationType).toEqual('DownloadStartedNotification')
+      expect(body.file.fileId).toEqual('start-vid')
+      expect(body.file.title).toEqual('Starting Download')
+      expect(body.file.thumbnailUrl).toEqual('https://example.com/thumb.jpg')
+    })
+
+    test('should handle missing title gracefully', () => {
+      const videoInfo: YtDlpVideoInfo = {id: 'vid-2', title: '', formats: [], duration: 0, thumbnail: ''}
+      const result = createDownloadStartedNotification('vid-2', videoInfo, 'user-1')
+      const body = JSON.parse(result.messageBody)
+
+      expect(body.file.title).toEqual('')
+    })
+
+    test('should set correct message attributes', () => {
+      const result = createDownloadStartedNotification('start-vid', mockVideoInfo, 'user-99')
+
+      expect(result.messageAttributes.userId).toEqual({DataType: 'String', StringValue: 'user-99'})
+      expect(result.messageAttributes.notificationType).toEqual({DataType: 'String', StringValue: 'DownloadStartedNotification'})
+    })
+  })
+
+  describe('createFailureNotification', () => {
+    test('should create failure notification with all fields', () => {
+      const result = createFailureNotification('fail-1', 'permanent', 'Video unavailable', true, 'user-1', 'My Video')
+      const body = JSON.parse(result.messageBody)
+
+      expect(body.notificationType).toEqual('FailureNotification')
+      expect(body.file.fileId).toEqual('fail-1')
+      expect(body.file.title).toEqual('My Video')
+      expect(body.file.errorCategory).toEqual('permanent')
+      expect(body.file.errorMessage).toEqual('Video unavailable')
+      expect(body.file.retryExhausted).toBe(true)
+    })
+
+    test('should handle missing title', () => {
+      const result = createFailureNotification('fail-2', 'cookie_expired', 'Auth failed', false, 'user-1')
+      const body = JSON.parse(result.messageBody)
+
+      expect(body.file.title).toBeUndefined()
+      expect(body.file.retryExhausted).toBe(false)
+    })
+
+    test('should set correct message attributes', () => {
+      const result = createFailureNotification('fail-3', 'rate_limited', 'Too many requests', false, 'user-42')
+
+      expect(result.messageAttributes.userId).toEqual({DataType: 'String', StringValue: 'user-42'})
+      expect(result.messageAttributes.notificationType).toEqual({DataType: 'String', StringValue: 'FailureNotification'})
+    })
+  })
+
+  describe('transformToAPNSAlertNotification', () => {
+    test('should transform failure to APNS alert format', () => {
+      const sqsMessageBody = JSON.stringify({
+        file: {fileId: 'vid-1', title: 'Test Video', errorCategory: 'permanent', errorMessage: 'Video removed', retryExhausted: true},
+        notificationType: 'FailureNotification'
+      })
+      const targetArn = 'arn:aws:sns:us-west-2:123456789:endpoint/APNS_SANDBOX/app/token'
+
+      const result = transformToAPNSAlertNotification(sqsMessageBody, targetArn)
+
+      expect(result.TargetArn).toEqual(targetArn)
+      expect(result.MessageStructure).toEqual('json')
+
+      const message = JSON.parse(result.Message)
+      const apnsPayload = JSON.parse(message.APNS_SANDBOX)
+      expect(apnsPayload.aps.alert.title).toEqual('Download Failed')
+      expect(apnsPayload.aps.alert.subtitle).toEqual('Test Video')
+      expect(apnsPayload.aps.alert.body).toContain('Failed after multiple attempts')
+      expect(apnsPayload.aps.sound).toEqual('default')
+    })
+
+    test('should use fileId as subtitle when title is missing', () => {
+      const sqsMessageBody = JSON.stringify({
+        file: {fileId: 'vid-2', errorCategory: 'cookie_expired', errorMessage: 'Auth failed', retryExhausted: false},
+        notificationType: 'FailureNotification'
+      })
+
+      const result = transformToAPNSAlertNotification(sqsMessageBody, 'arn:test')
+
+      const message = JSON.parse(result.Message)
+      const apnsPayload = JSON.parse(message.APNS_SANDBOX)
+      expect(apnsPayload.aps.alert.subtitle).toEqual('vid-2')
+    })
+
+    test('should show different message when retry not exhausted', () => {
+      const sqsMessageBody = JSON.stringify({
+        file: {fileId: 'vid-3', title: 'Some Video', errorCategory: 'rate_limited', errorMessage: 'Too many requests', retryExhausted: false},
+        notificationType: 'FailureNotification'
+      })
+
+      const result = transformToAPNSAlertNotification(sqsMessageBody, 'arn:test')
+
+      const message = JSON.parse(result.Message)
+      const apnsPayload = JSON.parse(message.APNS_SANDBOX)
+      expect(apnsPayload.aps.alert.body).toContain('Unable to download')
+      expect(apnsPayload.aps.alert.body).not.toContain('Failed after multiple attempts')
+    })
+
+    test('should set priority 10 and alert push type', () => {
+      const sqsMessageBody = JSON.stringify({file: {fileId: 'vid-4', errorMessage: 'Error', retryExhausted: false}, notificationType: 'FailureNotification'})
+
+      const result = transformToAPNSAlertNotification(sqsMessageBody, 'arn:test')
+
+      expect(result.MessageAttributes).toEqual({
+        'AWS.SNS.MOBILE.APNS.PRIORITY': {DataType: 'String', StringValue: '10'},
+        'AWS.SNS.MOBILE.APNS.PUSH_TYPE': {DataType: 'String', StringValue: 'alert'}
+      })
+    })
+
+    test('should include file payload in APNS message', () => {
+      const file = {fileId: 'vid-5', title: 'A Video', errorCategory: 'permanent', errorMessage: 'Gone', retryExhausted: true}
+      const sqsMessageBody = JSON.stringify({file, notificationType: 'FailureNotification'})
+
+      const result = transformToAPNSAlertNotification(sqsMessageBody, 'arn:test')
+
+      const message = JSON.parse(result.Message)
+      const apnsPayload = JSON.parse(message.APNS_SANDBOX)
+      expect(apnsPayload.file).toEqual(file)
+      expect(apnsPayload.notificationType).toEqual('FailureNotification')
     })
   })
 })

--- a/test/services/youtube/youtube.test.ts
+++ b/test/services/youtube/youtube.test.ts
@@ -84,7 +84,7 @@ process.env.YTDLP_BINARY_PATH = '/opt/bin/yt-dlp_linux'
 process.env.AWS_REGION = 'us-west-2'
 
 // Import after mocking
-const {downloadVideoToS3, getVideoID, isCookieExpirationError} = await import('#services/youtube/youtube.js')
+const {downloadVideoToS3, getVideoID, isCookieExpirationError, classifyCookieError, isSabrError} = await import('#services/youtube/youtube.js')
 
 describe('#Vendor:YouTube', () => {
   beforeEach(() => {
@@ -222,6 +222,93 @@ describe('#Vendor:YouTube', () => {
 
     test('should throw error for invalid URL', () => {
       expect(() => getVideoID('https://example.com/video')).toThrow('Invalid YouTube URL format')
+    })
+
+    test('should extract video ID from URL with extra query params', () => {
+      expect(getVideoID('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120')).toBe('dQw4w9WgXcQ')
+    })
+
+    test('should throw for empty string', () => {
+      expect(() => getVideoID('')).toThrow('Invalid YouTube URL format')
+    })
+
+    test('should throw for non-URL string', () => {
+      expect(() => getVideoID('not-a-url')).toThrow('Invalid YouTube URL format')
+    })
+
+    test('should throw for YouTube URL without video ID', () => {
+      expect(() => getVideoID('https://www.youtube.com/channel/UCtest')).toThrow('Invalid YouTube URL format')
+    })
+  })
+
+  describe('classifyCookieError', () => {
+    test('should classify bot detection errors', () => {
+      expect(classifyCookieError("Sign in to confirm you're not a bot")).toBe('bot_detection')
+      expect(classifyCookieError('This helps protect our community')).toBe('bot_detection')
+      expect(classifyCookieError('bot detection triggered')).toBe('bot_detection')
+      expect(classifyCookieError('confirm your human identity')).toBe('bot_detection')
+      expect(classifyCookieError('confirm you are human please')).toBe('bot_detection')
+    })
+
+    test('should classify cookie expired errors', () => {
+      expect(classifyCookieError('HTTP Error 403: Forbidden')).toBe('cookie_expired')
+      expect(classifyCookieError('cookies have expired')).toBe('cookie_expired')
+      expect(classifyCookieError('session expired, please log in again')).toBe('cookie_expired')
+      expect(classifyCookieError('login required to continue')).toBe('cookie_expired')
+    })
+
+    test('should classify rate limited errors', () => {
+      expect(classifyCookieError('HTTP Error 429')).toBe('rate_limited')
+      expect(classifyCookieError('Too many requests')).toBe('rate_limited')
+      expect(classifyCookieError('rate limit exceeded')).toBe('rate_limited')
+      expect(classifyCookieError('temporarily blocked')).toBe('rate_limited')
+    })
+
+    test('should return null for non-cookie errors', () => {
+      expect(classifyCookieError('Video not available')).toBeNull()
+      expect(classifyCookieError('Network timeout')).toBeNull()
+      expect(classifyCookieError('')).toBeNull()
+    })
+
+    test('should be case-insensitive', () => {
+      expect(classifyCookieError('HTTP ERROR 403')).toBe('cookie_expired')
+      expect(classifyCookieError('TOO MANY REQUESTS')).toBe('rate_limited')
+      expect(classifyCookieError('BOT DETECTION')).toBe('bot_detection')
+    })
+  })
+
+  describe('isSabrError', () => {
+    test('should detect SABR streaming errors', () => {
+      expect(isSabrError('SABR streaming is enforced')).toBe(true)
+      expect(isSabrError('Error: missing a url for format')).toBe(true)
+      expect(isSabrError('Some formats have been skipped')).toBe(true)
+      expect(isSabrError('YouTube is forcing SABR mode')).toBe(true)
+    })
+
+    test('should return false for non-SABR errors', () => {
+      expect(isSabrError('Video unavailable')).toBe(false)
+      expect(isSabrError('HTTP Error 403')).toBe(false)
+      expect(isSabrError('')).toBe(false)
+    })
+
+    test('should be case-insensitive', () => {
+      expect(isSabrError('sabr streaming')).toBe(true)
+      expect(isSabrError('MISSING A URL')).toBe(true)
+    })
+  })
+
+  describe('isCookieExpirationError (extended)', () => {
+    test('should return true for all cookie error categories', () => {
+      // bot_detection
+      expect(isCookieExpirationError("Sign in to confirm you're not a bot")).toBe(true)
+      // cookie_expired
+      expect(isCookieExpirationError('HTTP Error 403')).toBe(true)
+      // rate_limited
+      expect(isCookieExpirationError('HTTP Error 429')).toBe(true)
+    })
+
+    test('should return false for empty string', () => {
+      expect(isCookieExpirationError('')).toBe(false)
     })
   })
 })

--- a/test/utils/platform-config.test.ts
+++ b/test/utils/platform-config.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for Platform Configuration Verification
+ *
+ * Tests APNS platform configuration validation with env var present and missing.
+ */
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@mantleframework/env', () => ({getOptionalEnv: vi.fn()}))
+
+vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn()}))
+
+vi.mock('@mantleframework/errors', () => ({
+  ServiceUnavailableError: class ServiceUnavailableError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = 'ServiceUnavailableError'
+    }
+  }
+}))
+
+const {verifyPlatformConfiguration} = await import('#utils/platform-config.js')
+import {getOptionalEnv} from '@mantleframework/env'
+import {logDebug} from '@mantleframework/observability'
+
+describe('verifyPlatformConfiguration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should succeed when PLATFORM_APPLICATION_ARN is set', () => {
+    const arn = 'arn:aws:sns:us-west-2:123456789012:app/APNS_SANDBOX/MediaDownloader'
+    vi.mocked(getOptionalEnv).mockReturnValue(arn)
+
+    expect(() => verifyPlatformConfiguration()).not.toThrow()
+
+    expect(getOptionalEnv).toHaveBeenCalledWith('PLATFORM_APPLICATION_ARN', '')
+    expect(logDebug).toHaveBeenCalledWith('process.env.PLATFORM_APPLICATION_ARN <=', {platformApplicationArn: arn})
+  })
+
+  it('should throw ServiceUnavailableError when PLATFORM_APPLICATION_ARN is empty', () => {
+    vi.mocked(getOptionalEnv).mockReturnValue('')
+
+    expect(() => verifyPlatformConfiguration()).toThrow('requires configuration')
+  })
+
+  it('should throw ServiceUnavailableError when env var returns default empty string', () => {
+    vi.mocked(getOptionalEnv).mockReturnValue('')
+
+    expect(() => verifyPlatformConfiguration()).toThrow(expect.objectContaining({name: 'ServiceUnavailableError'}))
+  })
+
+  it('should log the ARN value for debugging', () => {
+    const arn = 'arn:aws:sns:us-east-1:111111111111:app/APNS/Prod'
+    vi.mocked(getOptionalEnv).mockReturnValue(arn)
+
+    verifyPlatformConfiguration()
+
+    expect(logDebug).toHaveBeenCalledWith('process.env.PLATFORM_APPLICATION_ARN <=', {platformApplicationArn: arn})
+  })
+})


### PR DESCRIPTION
## Summary

- **Phase 1**: New tests for endpointCleanup, platform-config + expanded youtube, transformers, github integration tests
- **Phase 2**: Entity query unit tests for all 7 query modules (userQueries, deviceQueries, fileQueries, sessionQueries, relationshipQueries, cascadeOperations, preparedQueries) + Drizzle mock helpers
- **Phase 3**: API Lambda handler unit tests for all 11 handlers (files, user, device, feedly)

Added 26 new/modified test files with 449 total passing tests (up from ~200).

## Motivation

Weekly mutation tests score was 20.01% against a 45% break threshold. These tests target the highest-impact uncovered mutants: null coalescing, conditional branching, error paths, and pure helper functions.

## Test plan

- [x] `pnpm run test` — 449 passed, 11 skipped, 0 failed
- [ ] Merge and trigger `gh workflow run mutation-tests.yml` to verify score improvement
- [ ] If score still below 45%, Phase 4 (event-driven Lambda tests) will follow