### PR TITLE
fix(test): resolve broken test types and bump hono

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pack:light": "repomix --include \"src/**/*.ts,docs/**/*.md,AGENTS.md\" --ignore \"**/*.test.ts,**/*.spec.ts\"",
     "plan:staging": "mantle deploy --stage staging --dry-run",
     "plan:production": "mantle deploy --stage production --dry-run",
-    "precheck": "tsc --noEmit && pnpm run lint && pnpm run format:check",
+    "precheck": "tsc --noEmit && pnpm run check:test:types && pnpm run lint && pnpm run format:check",
     "typecheck": "tsc --noEmit",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7419,7 +7419,7 @@ snapshots:
 
   '@mcp-ui/client@6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+      '@modelcontextprotocol/ext-apps': 1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7437,7 +7437,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/ext-apps@1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       zod: 3.25.76
@@ -7459,7 +7459,7 @@ snapshots:
   '@modelcontextprotocol/inspector-client@0.21.2(@types/react@18.3.28)':
     dependencies:
       '@mcp-ui/client': 6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modelcontextprotocol/ext-apps': 1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+      '@modelcontextprotocol/ext-apps': 1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       '@radix-ui/react-checkbox': 1.3.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.15(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/test/entities/queries/cascadeOperations.test.ts
+++ b/test/entities/queries/cascadeOperations.test.ts
@@ -5,30 +5,26 @@
  * (!existing -> early return, remaining.length > 0 -> partial return).
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
 import {createMockUserFile} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
-vi.mock('#db/schema', () => ({
-  userFiles: {userId: 'userId', fileId: 'fileId'},
-  userDevices: {userId: 'userId', deviceId: 'deviceId'},
-  sessions: {userId: 'userId'},
-  accounts: {userId: 'userId'},
-  users: {id: 'id'},
-  files: {fileId: 'fileId'},
-  fileDownloads: {fileId: 'fileId'}
-}))
+vi.mock('#db/schema',
+  () => ({
+    userFiles: {userId: 'userId', fileId: 'fileId'},
+    userDevices: {userId: 'userId', deviceId: 'deviceId'},
+    sessions: {userId: 'userId'},
+    accounts: {userId: 'userId'},
+    users: {id: 'id'},
+    files: {fileId: 'fileId'},
+    fileDownloads: {fileId: 'fileId'}
+  }))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  and: vi.fn((...args: unknown[]) => args),
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition')
-}))
+vi.mock('@mantleframework/database/orm', () => ({and: vi.fn((...args: unknown[]) => args), eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition')}))
 
-const {deleteUserCascade, deleteUserRelationships, deleteUserAuthRecords, deleteFileCascade} = await import(
-  '#entities/queries/cascadeOperations'
-)
+const {deleteUserCascade, deleteUserRelationships, deleteUserAuthRecords, deleteFileCascade} = await import('#entities/queries/cascadeOperations')
 
 describe('Cascade Operations', () => {
   beforeEach(() => {
@@ -90,7 +86,7 @@ describe('Cascade Operations', () => {
         selectCallCount++
         const result = selectCallCount === 1
           ? [existingLink] // First: existing link found
-          : [otherLink]    // Third: remaining links
+          : [otherLink] // Third: remaining links
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -119,7 +115,7 @@ describe('Cascade Operations', () => {
         selectCallCount++
         const result = selectCallCount === 1
           ? [existingLink] // First: existing link found
-          : []             // Third: no remaining links (orphaned)
+          : [] // Third: no remaining links (orphaned)
         return {
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({

--- a/test/entities/queries/deviceQueries.test.ts
+++ b/test/entities/queries/deviceQueries.test.ts
@@ -6,26 +6,20 @@
  * and non-null assertions on returning().
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
 import {createMockDevice} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
 vi.mock('#db/schema', () => ({devices: {deviceId: 'deviceId'}}))
-vi.mock('#db/zodSchemas', () => ({
-  deviceInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  deviceUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
-}))
+vi.mock('#db/zodSchemas',
+  () => ({deviceInsertSchema: {parse: vi.fn((v: unknown) => v)}, deviceUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}}))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
-  inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
-}))
+vi.mock('@mantleframework/database/orm',
+  () => ({eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'), inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')}))
 
-const {getDevice, getDevicesBatch, createDevice, upsertDevice, updateDevice, deleteDevice, getAllDevices} = await import(
-  '#entities/queries/deviceQueries'
-)
+const {getDevice, getDevicesBatch, createDevice, upsertDevice, updateDevice, deleteDevice, getAllDevices} = await import('#entities/queries/deviceQueries')
 
 describe('Device Queries', () => {
   beforeEach(() => {

--- a/test/entities/queries/fileQueries.test.ts
+++ b/test/entities/queries/fileQueries.test.ts
@@ -6,32 +6,38 @@
  * and non-null assertions on returning().
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
 import {createMockFile, createMockFileDownload} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
-vi.mock('#db/schema', () => ({
-  files: {fileId: 'fileId', key: 'key', status: 'status'},
-  fileDownloads: {fileId: 'fileId'}
-}))
-vi.mock('#db/zodSchemas', () => ({
-  fileInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  fileUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))},
-  fileDownloadInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  fileDownloadUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
-}))
+vi.mock('#db/schema', () => ({files: {fileId: 'fileId', key: 'key', status: 'status'}, fileDownloads: {fileId: 'fileId'}}))
+vi.mock('#db/zodSchemas',
+  () => ({
+    fileInsertSchema: {parse: vi.fn((v: unknown) => v)},
+    fileUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))},
+    fileDownloadInsertSchema: {parse: vi.fn((v: unknown) => v)},
+    fileDownloadUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
+  }))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
-  inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
-}))
+vi.mock('@mantleframework/database/orm',
+  () => ({eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'), inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')}))
 
 const {
-  getFile, getFileStatus, getFilesBatch, getFilesByKey,
-  createFile, upsertFile, updateFile, deleteFile,
-  getFileDownload, createFileDownload, upsertFileDownload, updateFileDownload, deleteFileDownload
+  getFile,
+  getFileStatus,
+  getFilesBatch,
+  getFilesByKey,
+  createFile,
+  upsertFile,
+  updateFile,
+  deleteFile,
+  getFileDownload,
+  createFileDownload,
+  upsertFileDownload,
+  updateFileDownload,
+  deleteFileDownload
 } = await import('#entities/queries/fileQueries')
 
 describe('File Queries', () => {
@@ -113,9 +119,16 @@ describe('File Queries', () => {
       mockDb._setInsertResult([mockFile])
 
       const result = await createFile({
-        fileId: 'file-1', authorName: 'Author', authorUser: 'user',
-        publishDate: '2021-01-01', description: 'desc', key: 'file.mp4',
-        url: null, contentType: 'video/mp4', title: 'Test', status: 'Queued'
+        fileId: 'file-1',
+        authorName: 'Author',
+        authorUser: 'user',
+        publishDate: '2021-01-01',
+        description: 'desc',
+        key: 'file.mp4',
+        url: null,
+        contentType: 'video/mp4',
+        title: 'Test',
+        status: 'Queued'
       })
 
       expect(result).toEqual(mockFile)
@@ -128,9 +141,16 @@ describe('File Queries', () => {
       mockDb._setInsertResult([mockFile])
 
       const result = await upsertFile({
-        fileId: 'file-1', authorName: 'Author', authorUser: 'user',
-        publishDate: '2021-01-01', description: 'desc', key: 'file.mp4',
-        url: null, contentType: 'video/mp4', title: 'Test', status: 'Queued'
+        fileId: 'file-1',
+        authorName: 'Author',
+        authorUser: 'user',
+        publishDate: '2021-01-01',
+        description: 'desc',
+        key: 'file.mp4',
+        url: null,
+        contentType: 'video/mp4',
+        title: 'Test',
+        status: 'Queued'
       })
 
       expect(result).toEqual(mockFile)
@@ -182,9 +202,7 @@ describe('File Queries', () => {
       const mockDownload = createMockFileDownload()
       mockDb._setInsertResult([mockDownload])
 
-      const result = await createFileDownload({
-        fileId: 'file-1', status: 'Pending', retryCount: 0, maxRetries: 5
-      })
+      const result = await createFileDownload({fileId: 'file-1', status: 'Pending', retryCount: 0, maxRetries: 5})
 
       expect(result).toEqual(mockDownload)
     })
@@ -195,9 +213,7 @@ describe('File Queries', () => {
       const mockDownload = createMockFileDownload()
       mockDb._setInsertResult([mockDownload])
 
-      const result = await upsertFileDownload({
-        fileId: 'file-1', status: 'Pending', retryCount: 0, maxRetries: 5
-      })
+      const result = await upsertFileDownload({fileId: 'file-1', status: 'Pending', retryCount: 0, maxRetries: 5})
 
       expect(result).toEqual(mockDownload)
     })

--- a/test/entities/queries/preparedQueries.test.ts
+++ b/test/entities/queries/preparedQueries.test.ts
@@ -5,26 +5,18 @@
  * and map transform (results.map(r => r.file)).
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
 import {createMockFile, createMockSession} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
-vi.mock('#db/schema', () => ({
-  files: {fileId: 'fileId', key: 'key'},
-  sessions: {id: 'id', token: 'token'},
-  userFiles: {userId: 'userId', fileId: 'fileId'}
-}))
+vi.mock('#db/schema', () => ({files: {fileId: 'fileId', key: 'key'}, sessions: {id: 'id', token: 'token'}, userFiles: {userId: 'userId', fileId: 'fileId'}}))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
-  sql: {placeholder: vi.fn((name: string) => ({placeholder: name}))}
-}))
+vi.mock('@mantleframework/database/orm',
+  () => ({eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'), sql: {placeholder: vi.fn((name: string) => ({placeholder: name}))}}))
 
-const {getFileByKeyPrepared, getUserFilesPrepared, getSessionByTokenPrepared} = await import(
-  '#entities/queries/preparedQueries'
-)
+const {getFileByKeyPrepared, getUserFilesPrepared, getSessionByTokenPrepared} = await import('#entities/queries/preparedQueries')
 
 describe('Prepared Queries', () => {
   beforeEach(() => {
@@ -38,13 +30,7 @@ describe('Prepared Queries', () => {
       // Our mock needs to handle the prepare+execute chain
       const executeMock = vi.fn().mockResolvedValue([mockFile])
       const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
-      mockDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            prepare: prepareMock
-          })
-        })
-      }))
+      mockDb.select.mockImplementation(() => ({from: vi.fn().mockReturnValue({where: vi.fn().mockReturnValue({prepare: prepareMock})})}))
 
       const result = await getFileByKeyPrepared('test.mp4')
 
@@ -54,13 +40,7 @@ describe('Prepared Queries', () => {
     it('should return null when file not found (null coalescing)', async () => {
       const executeMock = vi.fn().mockResolvedValue([])
       const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
-      mockDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            prepare: prepareMock
-          })
-        })
-      }))
+      mockDb.select.mockImplementation(() => ({from: vi.fn().mockReturnValue({where: vi.fn().mockReturnValue({prepare: prepareMock})})}))
 
       const result = await getFileByKeyPrepared('nonexistent.mp4')
 
@@ -75,13 +55,7 @@ describe('Prepared Queries', () => {
       const executeMock = vi.fn().mockResolvedValue([{file: file1}, {file: file2}])
       const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
       mockDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              prepare: prepareMock
-            })
-          })
-        })
+        from: vi.fn().mockReturnValue({innerJoin: vi.fn().mockReturnValue({where: vi.fn().mockReturnValue({prepare: prepareMock})})})
       }))
 
       const result = await getUserFilesPrepared('user-1')
@@ -93,13 +67,7 @@ describe('Prepared Queries', () => {
       const executeMock = vi.fn().mockResolvedValue([])
       const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
       mockDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              prepare: prepareMock
-            })
-          })
-        })
+        from: vi.fn().mockReturnValue({innerJoin: vi.fn().mockReturnValue({where: vi.fn().mockReturnValue({prepare: prepareMock})})})
       }))
 
       const result = await getUserFilesPrepared('user-1')
@@ -114,13 +82,7 @@ describe('Prepared Queries', () => {
       const executeMock = vi.fn().mockResolvedValue([mockSession])
       const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
       mockDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              prepare: prepareMock
-            })
-          })
-        })
+        from: vi.fn().mockReturnValue({where: vi.fn().mockReturnValue({limit: vi.fn().mockReturnValue({prepare: prepareMock})})})
       }))
 
       const result = await getSessionByTokenPrepared('valid-token')
@@ -132,13 +94,7 @@ describe('Prepared Queries', () => {
       const executeMock = vi.fn().mockResolvedValue([])
       const prepareMock = vi.fn().mockReturnValue({execute: executeMock})
       mockDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              prepare: prepareMock
-            })
-          })
-        })
+        from: vi.fn().mockReturnValue({where: vi.fn().mockReturnValue({limit: vi.fn().mockReturnValue({prepare: prepareMock})})})
       }))
 
       const result = await getSessionByTokenPrepared('invalid-token')

--- a/test/entities/queries/relationshipQueries.test.ts
+++ b/test/entities/queries/relationshipQueries.test.ts
@@ -6,43 +6,58 @@
  * and upsert branching (result.length === 0 -> fetch existing).
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
-import {createMockUserFile, createMockUserDevice, createMockFile, createMockDevice} from '#test/helpers/entity-fixtures'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
+import {createMockDevice, createMockFile, createMockUserDevice, createMockUserFile} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
-vi.mock('#db/schema', () => ({
-  userFiles: {userId: 'userId', fileId: 'fileId'},
-  userDevices: {userId: 'userId', deviceId: 'deviceId'},
-  files: {fileId: 'fileId'},
-  devices: {deviceId: 'deviceId'},
-  users: {id: 'id'}
-}))
-vi.mock('#db/zodSchemas', () => ({
-  userFileInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  userDeviceInsertSchema: {parse: vi.fn((v: unknown) => v)}
-}))
-vi.mock('#db/fkEnforcement', () => ({
-  assertUserExists: vi.fn().mockResolvedValue(undefined),
-  assertFileExists: vi.fn().mockResolvedValue(undefined),
-  assertDeviceExists: vi.fn().mockResolvedValue(undefined)
-}))
+vi.mock('#db/schema',
+  () => ({
+    userFiles: {userId: 'userId', fileId: 'fileId'},
+    userDevices: {userId: 'userId', deviceId: 'deviceId'},
+    files: {fileId: 'fileId'},
+    devices: {deviceId: 'deviceId'},
+    users: {id: 'id'}
+  }))
+vi.mock('#db/zodSchemas', () => ({userFileInsertSchema: {parse: vi.fn((v: unknown) => v)}, userDeviceInsertSchema: {parse: vi.fn((v: unknown) => v)}}))
+vi.mock('#db/fkEnforcement',
+  () => ({
+    assertUserExists: vi.fn().mockResolvedValue(undefined),
+    assertFileExists: vi.fn().mockResolvedValue(undefined),
+    assertDeviceExists: vi.fn().mockResolvedValue(undefined)
+  }))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  and: vi.fn((...args: unknown[]) => args),
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
-  or: vi.fn((...args: unknown[]) => args),
-  inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
-}))
+vi.mock('@mantleframework/database/orm',
+  () => ({
+    and: vi.fn((...args: unknown[]) => args),
+    eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
+    or: vi.fn((...args: unknown[]) => args),
+    inArray: vi.fn((_col: unknown, _vals: unknown) => 'inArray-condition')
+  }))
 
 const {
-  getUserFile, getUserFilesByUserId, getUserFileIdsByUserId, getUserFilesByFileId,
-  getFilesForUser, createUserFile, upsertUserFile, deleteUserFile,
-  deleteUserFilesByUserId, deleteUserFilesBatch,
-  getUserDevice, getUserDevicesByUserId, getUserDeviceIdsByUserId, getUserDevicesByDeviceId,
-  getDevicesForUser, getDeviceIdsForUsers, createUserDevice, upsertUserDevice,
-  deleteUserDevice, deleteUserDevicesByUserId, deleteUserDevicesByDeviceId
+  getUserFile,
+  getUserFilesByUserId,
+  getUserFileIdsByUserId,
+  getUserFilesByFileId,
+  getFilesForUser,
+  createUserFile,
+  upsertUserFile,
+  deleteUserFile,
+  deleteUserFilesByUserId,
+  deleteUserFilesBatch,
+  getUserDevice,
+  getUserDevicesByUserId,
+  getUserDeviceIdsByUserId,
+  getUserDevicesByDeviceId,
+  getDevicesForUser,
+  getDeviceIdsForUsers,
+  createUserDevice,
+  upsertUserDevice,
+  deleteUserDevice,
+  deleteUserDevicesByUserId,
+  deleteUserDevicesByDeviceId
 } = await import('#entities/queries/relationshipQueries')
 
 describe('Relationship Queries', () => {

--- a/test/entities/queries/sessionQueries.test.ts
+++ b/test/entities/queries/sessionQueries.test.ts
@@ -5,34 +5,47 @@
  * and non-null assertions on returning().
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
-import {createMockSession, createMockAccount, createMockVerification} from '#test/helpers/entity-fixtures'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
+import {createMockAccount, createMockSession, createMockVerification} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
-vi.mock('#db/schema', () => ({
-  sessions: {id: 'id', token: 'token', userId: 'userId', expiresAt: 'expiresAt'},
-  accounts: {id: 'id', userId: 'userId'},
-  verification: {id: 'id', identifier: 'identifier', expiresAt: 'expiresAt'}
-}))
-vi.mock('#db/zodSchemas', () => ({
-  sessionInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  sessionUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))},
-  accountInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  verificationInsertSchema: {parse: vi.fn((v: unknown) => v)}
-}))
+vi.mock('#db/schema',
+  () => ({
+    sessions: {id: 'id', token: 'token', userId: 'userId', expiresAt: 'expiresAt'},
+    accounts: {id: 'id', userId: 'userId'},
+    verification: {id: 'id', identifier: 'identifier', expiresAt: 'expiresAt'}
+  }))
+vi.mock('#db/zodSchemas',
+  () => ({
+    sessionInsertSchema: {parse: vi.fn((v: unknown) => v)},
+    sessionUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))},
+    accountInsertSchema: {parse: vi.fn((v: unknown) => v)},
+    verificationInsertSchema: {parse: vi.fn((v: unknown) => v)}
+  }))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'),
-  lt: vi.fn((_col: unknown, _val: unknown) => 'lt-condition')
-}))
+vi.mock('@mantleframework/database/orm',
+  () => ({eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition'), lt: vi.fn((_col: unknown, _val: unknown) => 'lt-condition')}))
 
 const {
-  getSession, getSessionByToken, getSessionsByUserId,
-  createSession, updateSession, deleteSession, deleteSessionsByUserId, deleteExpiredSessions,
-  getAccount, getAccountsByUserId, createAccount, deleteAccount, deleteAccountsByUserId,
-  getVerificationByIdentifier, createVerification, deleteVerification, deleteExpiredVerifications
+  getSession,
+  getSessionByToken,
+  getSessionsByUserId,
+  createSession,
+  updateSession,
+  deleteSession,
+  deleteSessionsByUserId,
+  deleteExpiredSessions,
+  getAccount,
+  getAccountsByUserId,
+  createAccount,
+  deleteAccount,
+  deleteAccountsByUserId,
+  getVerificationByIdentifier,
+  createVerification,
+  deleteVerification,
+  deleteExpiredVerifications
 } = await import('#entities/queries/sessionQueries')
 
 describe('Session Queries', () => {
@@ -104,9 +117,7 @@ describe('Session Queries', () => {
       const mockSession = createMockSession()
       mockDb._setInsertResult([mockSession])
 
-      const result = await createSession({
-        userId: 'user-1', token: 'token-1', expiresAt: new Date()
-      })
+      const result = await createSession({userId: 'user-1', token: 'token-1', expiresAt: new Date()})
 
       expect(result).toEqual(mockSession)
     })
@@ -181,9 +192,7 @@ describe('Session Queries', () => {
       const mockAccount = createMockAccount()
       mockDb._setInsertResult([mockAccount])
 
-      const result = await createAccount({
-        userId: 'user-1', accountId: 'apple-1', providerId: 'apple'
-      })
+      const result = await createAccount({userId: 'user-1', accountId: 'apple-1', providerId: 'apple'})
 
       expect(result).toEqual(mockAccount)
     })
@@ -229,9 +238,7 @@ describe('Session Queries', () => {
       const mockVerification = createMockVerification()
       mockDb._setInsertResult([mockVerification])
 
-      const result = await createVerification({
-        identifier: 'test@example.com', value: 'token-abc', expiresAt: new Date()
-      })
+      const result = await createVerification({identifier: 'test@example.com', value: 'token-abc', expiresAt: new Date()})
 
       expect(result).toEqual(mockVerification)
     })

--- a/test/entities/queries/userQueries.test.ts
+++ b/test/entities/queries/userQueries.test.ts
@@ -5,21 +5,17 @@
  * non-null assertions on returning(), and Zod validation passthrough.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {createMockDrizzleDb, createDefineQueryMock} from '#test/helpers/defineQuery-mock'
+import {createDefineQueryMock, createMockDrizzleDb} from '#test/helpers/defineQuery-mock'
 import {createMockUser} from '#test/helpers/entity-fixtures'
 
 const mockDb = createMockDrizzleDb()
 
 vi.mock('#db/defineQuery', () => createDefineQueryMock(mockDb))
 vi.mock('#db/schema', () => ({users: {id: 'id', email: 'email'}}))
-vi.mock('#db/zodSchemas', () => ({
-  userInsertSchema: {parse: vi.fn((v: unknown) => v)},
-  userUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}
-}))
+vi.mock('#db/zodSchemas',
+  () => ({userInsertSchema: {parse: vi.fn((v: unknown) => v)}, userUpdateSchema: {partial: vi.fn(() => ({parse: vi.fn((v: unknown) => v)}))}}))
 vi.mock('@mantleframework/database', () => ({DatabaseOperation: {Select: 'Select', Insert: 'Insert', Update: 'Update', Delete: 'Delete'}}))
-vi.mock('@mantleframework/database/orm', () => ({
-  eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition')
-}))
+vi.mock('@mantleframework/database/orm', () => ({eq: vi.fn((_col: unknown, _val: unknown) => 'eq-condition')}))
 
 const {getUser, getUsersByEmail, createUser, updateUser, deleteUser} = await import('#entities/queries/userQueries')
 

--- a/test/helpers/defineQuery-mock.ts
+++ b/test/helpers/defineQuery-mock.ts
@@ -73,16 +73,12 @@ export function createMockDrizzleDb(): MockDrizzleDb {
       limit: vi.fn().mockImplementation(() => terminal),
       then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) => Promise.resolve(selectResult).then(resolve, reject)
     }
-    return {
-      from: vi.fn().mockImplementation(() => fromResult)
-    }
+    return {from: vi.fn().mockImplementation(() => fromResult)}
   }
 
   // Insert chain: insert() -> values() -> returning() / onConflictDoUpdate().returning() / onConflictDoNothing().returning()
   const insertChain = () => {
-    const returningFn = vi.fn().mockImplementation(() =>
-      Promise.resolve(insertResult)
-    )
+    const returningFn = vi.fn().mockImplementation(() => Promise.resolve(insertResult))
     const conflictResult = {returning: returningFn}
     return {
       values: vi.fn().mockImplementation(() => ({
@@ -95,22 +91,12 @@ export function createMockDrizzleDb(): MockDrizzleDb {
 
   // Update chain: update() -> set() -> where() -> returning()
   const updateChain = () => {
-    const returningFn = vi.fn().mockImplementation(() =>
-      Promise.resolve(updateResult)
-    )
-    return {
-      set: vi.fn().mockImplementation(() => ({
-        where: vi.fn().mockImplementation(() => ({
-          returning: returningFn
-        }))
-      }))
-    }
+    const returningFn = vi.fn().mockImplementation(() => Promise.resolve(updateResult))
+    return {set: vi.fn().mockImplementation(() => ({where: vi.fn().mockImplementation(() => ({returning: returningFn}))}))}
   }
 
   // Delete chain: delete() -> where()
-  const deleteChain = () => ({
-    where: vi.fn().mockImplementation(() => Promise.resolve(deleteResult))
-  })
+  const deleteChain = () => ({where: vi.fn().mockImplementation(() => Promise.resolve(deleteResult))})
 
   const db: MockDrizzleDb = {
     select: vi.fn().mockImplementation(() => selectChain()),
@@ -121,10 +107,18 @@ export function createMockDrizzleDb(): MockDrizzleDb {
     _insertResult: insertResult,
     _updateResult: updateResult,
     _deleteResult: deleteResult,
-    _setSelectResult: (result: unknown[]) => { selectResult = result },
-    _setInsertResult: (result: unknown[]) => { insertResult = result },
-    _setUpdateResult: (result: unknown[]) => { updateResult = result },
-    _setDeleteResult: (result: unknown[]) => { deleteResult = result }
+    _setSelectResult: (result: unknown[]) => {
+      selectResult = result
+    },
+    _setInsertResult: (result: unknown[]) => {
+      insertResult = result
+    },
+    _setUpdateResult: (result: unknown[]) => {
+      updateResult = result
+    },
+    _setDeleteResult: (result: unknown[]) => {
+      deleteResult = result
+    }
   }
 
   return db

--- a/test/helpers/handler-test-types.ts
+++ b/test/helpers/handler-test-types.ts
@@ -4,13 +4,16 @@
  *
  * When define*Handler factories are mocked as pass-through, the exported handler
  * is the inner function at runtime but TypeScript sees the outer Lambda signature.
- * These types model the runtime shape for type-safe test assertions.
  *
- * @example
- * ```ts
- * const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedHandlerModule
- * ```
+ * Two approaches available:
+ * 1. MockedHandlerModule — permissive (existing tests, allows partial params + custom response props)
+ * 2. MockedModule<T> — fully typed via InnerHandlerOf (new tests with complete params)
  */
+import type {InnerHandlerOf} from '@mantleframework/core'
+
+// ============================================================================
+// Approach 1: Permissive types (for tests that pass partial params)
+// ============================================================================
 
 /**
  * Permissive result type for mocked handler returns.
@@ -48,4 +51,25 @@ interface AuthorizerResult {
 export type MockedAuthorizerModule = {
   handler: MockedHandler<AuthorizerResult>
   generateAllow: (principalId: string, resource: string, usageIdentifierKey?: string, authContext?: Record<string, string>) => AuthorizerResult
+}
+
+// ============================================================================
+// Approach 2: Fully typed via framework BrandedLambda (for new tests)
+// ============================================================================
+
+/**
+ * Extracts inner handler types from a module's exports using the framework's BrandedLambda phantom type.
+ * Requires tests to pass COMPLETE handler params (all required fields of AuthorizedApiParams, etc.).
+ *
+ * @example
+ * ```ts
+ * import type {MockedModule} from '#test/helpers/handler-test-types'
+ * import type * as Mod from '#lambdas/api/user/subscribe.post.js'
+ *
+ * const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedModule<typeof Mod>
+ * // handler is fully typed: (params: AuthorizedApiParams<SubscriptionRequest>) => Promise<APIGatewayProxyResult>
+ * ```
+ */
+export type MockedModule<TModule extends Record<string, unknown>> = {
+  [K in keyof TModule]: TModule[K] extends {readonly __innerHandler?: unknown} ? InnerHandlerOf<TModule[K]> : TModule[K]
 }

--- a/test/helpers/handler-test-types.ts
+++ b/test/helpers/handler-test-types.ts
@@ -1,0 +1,51 @@
+/**
+ * Type utilities for Lambda handler tests where define*Handler is mocked
+ * to pass through the inner function directly.
+ *
+ * When define*Handler factories are mocked as pass-through, the exported handler
+ * is the inner function at runtime but TypeScript sees the outer Lambda signature.
+ * These types model the runtime shape for type-safe test assertions.
+ *
+ * @example
+ * ```ts
+ * const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedHandlerModule
+ * ```
+ */
+
+/**
+ * Permissive result type for mocked handler returns.
+ * Uses `any` values to allow deep property access in test assertions (e.g., result.contents[0].fileId).
+ * This is intentional — test assertions verify runtime behavior, not compile-time types.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type HandlerResult = Record<string, any>
+
+/**
+ * A mocked handler function: callable with any args, returns a promise of TResult.
+ * Default return type allows deep property access in assertions without casts.
+ */
+export type MockedHandler<TResult = HandlerResult> = (...args: unknown[]) => Promise<TResult>
+
+/** Module shape for most mocked handler imports (single handler export) */
+export type MockedHandlerModule<TResult = HandlerResult> = {handler: MockedHandler<TResult>}
+
+/** Policy statement shape for Allow/Deny policies in authorizer tests */
+interface PolicyStatement {
+  Effect: string
+  Action: string
+  Resource: string
+}
+
+/** Return type of generateAllow in authorizer tests */
+interface AuthorizerResult {
+  principalId: string
+  policyDocument: {Version: string; Statement: PolicyStatement[]}
+  usageIdentifierKey?: string
+  context: Record<string, string>
+}
+
+/** Module shape for the ApiGatewayAuthorizer test (handler + generateAllow) */
+export type MockedAuthorizerModule = {
+  handler: MockedHandler<AuthorizerResult>
+  generateAllow: (principalId: string, resource: string, usageIdentifierKey?: string, authContext?: Record<string, string>) => AuthorizerResult
+}

--- a/test/helpers/handler-test-types.ts
+++ b/test/helpers/handler-test-types.ts
@@ -1,65 +1,47 @@
 /**
- * Type utilities for Lambda handler tests where define*Handler is mocked
- * to pass through the inner function directly.
+ * Type utilities and factory helpers for Lambda handler tests.
  *
- * When define*Handler factories are mocked as pass-through, the exported handler
- * is the inner function at runtime but TypeScript sees the outer Lambda signature.
+ * Framework handler factories return BrandedLambda<TInner, TLambda>, carrying the inner handler
+ * type via a phantom property. MockedModule<T> extracts it so tests get typed inner params
+ * while replacing the return type with Record<string, unknown> (since buildValidatedResponse is mocked).
  *
- * Two approaches available:
- * 1. MockedHandlerModule — permissive (existing tests, allows partial params + custom response props)
- * 2. MockedModule<T> — fully typed via InnerHandlerOf (new tests with complete params)
+ * Factory helpers (makeAuthorizedParams, etc.) provide defaults for required fields so tests
+ * only specify the fields they care about.
  */
-import type {InnerHandlerOf} from '@mantleframework/core'
+import type {
+  ApiHandlerParams,
+  AuthorizedApiParams,
+  AuthorizedOptionalApiParams,
+  SessionApiParams,
+  ValidatedApiParams,
+  WrapperMetadata
+} from '@mantleframework/core'
+import type {APIGatewayProxyEvent, Context} from 'aws-lambda'
 
 // ============================================================================
-// Approach 1: Permissive types (for tests that pass partial params)
+// MockedModule type — branded inner extraction with permissive return
 // ============================================================================
+
+/** Recursively makes all properties optional — needed because tests pass partial nested objects (e.g., context: {awsRequestId}) */
+type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T
+
+/** Make each element of a tuple optional */
+type OptionalArgs<T extends unknown[]> = { [K in keyof T]?: DeepPartial<T[K]> }
 
 /**
- * Permissive result type for mocked handler returns.
- * Uses `any` values to allow deep property access in test assertions (e.g., result.contents[0].fileId).
- * This is intentional — test assertions verify runtime behavior, not compile-time types.
+ * Transform inner handler for test usage:
+ * - All params become optional (DeepPartial) — tests pass only fields they care about
+ * - Return becomes Record<string, unknown> — buildValidatedResponse is mocked
+ * - Handles zero-arg, single-arg, and multi-arg handlers
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type HandlerResult = Record<string, any>
+type MockInner<T> = T extends (...args: infer A) => unknown ? (...args: OptionalArgs<A>) => Promise<Record<string, unknown>> :
+  T
 
 /**
- * A mocked handler function: callable with any args, returns a promise of TResult.
- * Default return type allows deep property access in assertions without casts.
- */
-export type MockedHandler<TResult = HandlerResult> = (...args: unknown[]) => Promise<TResult>
-
-/** Module shape for most mocked handler imports (single handler export) */
-export type MockedHandlerModule<TResult = HandlerResult> = {handler: MockedHandler<TResult>}
-
-/** Policy statement shape for Allow/Deny policies in authorizer tests */
-interface PolicyStatement {
-  Effect: string
-  Action: string
-  Resource: string
-}
-
-/** Return type of generateAllow in authorizer tests */
-interface AuthorizerResult {
-  principalId: string
-  policyDocument: {Version: string; Statement: PolicyStatement[]}
-  usageIdentifierKey?: string
-  context: Record<string, string>
-}
-
-/** Module shape for the ApiGatewayAuthorizer test (handler + generateAllow) */
-export type MockedAuthorizerModule = {
-  handler: MockedHandler<AuthorizerResult>
-  generateAllow: (principalId: string, resource: string, usageIdentifierKey?: string, authContext?: Record<string, string>) => AuthorizerResult
-}
-
-// ============================================================================
-// Approach 2: Fully typed via framework BrandedLambda (for new tests)
-// ============================================================================
-
-/**
- * Extracts inner handler types from a module's exports using the framework's BrandedLambda phantom type.
- * Requires tests to pass COMPLETE handler params (all required fields of AuthorizedApiParams, etc.).
+ * Extracts inner handler types from a module using BrandedLambda.
+ * - Params become Partial (tests only pass fields they use, but typos are caught)
+ * - Return becomes Record<string, unknown> (mocked buildValidatedResponse returns custom shapes)
+ * - Non-handler exports pass through unchanged
  *
  * @example
  * ```ts
@@ -67,9 +49,94 @@ export type MockedAuthorizerModule = {
  * import type * as Mod from '#lambdas/api/user/subscribe.post.js'
  *
  * const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedModule<typeof Mod>
- * // handler is fully typed: (params: AuthorizedApiParams<SubscriptionRequest>) => Promise<APIGatewayProxyResult>
+ * // Typed! handler({userId: 'x', body: {endpointArn: '...'}}) — field names checked, body shape checked
  * ```
  */
 export type MockedModule<TModule extends Record<string, unknown>> = {
-  [K in keyof TModule]: TModule[K] extends {readonly __innerHandler?: unknown} ? InnerHandlerOf<TModule[K]> : TModule[K]
+  [K in keyof TModule]: TModule[K] extends {readonly __innerHandler?: infer I} ? MockInner<I> : TModule[K]
+}
+
+// ============================================================================
+// Factory helpers — provide defaults for required handler params
+// ============================================================================
+
+const defaultMetadata: WrapperMetadata = {traceId: 'test-trace', correlationId: 'test-correlation'}
+
+const defaultContext = {
+  awsRequestId: 'test-req-id',
+  callbackWaitsForEmptyEventLoop: true,
+  functionName: 'test',
+  functionVersion: '$LATEST',
+  invokedFunctionArn: 'arn:aws:lambda:us-west-2:123:function:test',
+  logGroupName: '/aws/lambda/test',
+  logStreamName: 'test',
+  memoryLimitInMB: '128',
+  getRemainingTimeInMillis: () => 30000,
+  done: () => {},
+  fail: () => {},
+  succeed: () => {}
+} satisfies Context
+
+/** Create AuthorizedApiParams (auth: 'authorizer') with defaults. Only specify fields your test cares about. */
+export function makeAuthorizedParams<TBody = undefined, TQuery = undefined, TPath = undefined>(
+  overrides: Partial<AuthorizedApiParams<TBody, TQuery, TPath>> & {userId: string}
+): AuthorizedApiParams<TBody, TQuery, TPath> {
+  return {
+    event: {} as APIGatewayProxyEvent,
+    context: defaultContext,
+    metadata: defaultMetadata,
+    authorizer: {},
+    userStatus: 'Authenticated',
+    body: undefined as AuthorizedApiParams<TBody, TQuery, TPath>['body'],
+    query: undefined as AuthorizedApiParams<TBody, TQuery, TPath>['query'],
+    path: undefined as AuthorizedApiParams<TBody, TQuery, TPath>['path'],
+    ...overrides
+  }
+}
+
+/** Create AuthorizedOptionalApiParams (auth: 'authorizer-optional') with defaults. */
+export function makeOptionalAuthParams<TBody = undefined, TQuery = undefined, TPath = undefined>(
+  overrides: Partial<AuthorizedOptionalApiParams<TBody, TQuery, TPath>> = {}
+): AuthorizedOptionalApiParams<TBody, TQuery, TPath> {
+  return {
+    event: {} as APIGatewayProxyEvent,
+    context: defaultContext,
+    metadata: defaultMetadata,
+    authorizer: {},
+    userId: undefined,
+    userStatus: 'Anonymous',
+    body: undefined as AuthorizedOptionalApiParams<TBody, TQuery, TPath>['body'],
+    query: undefined as AuthorizedOptionalApiParams<TBody, TQuery, TPath>['query'],
+    path: undefined as AuthorizedOptionalApiParams<TBody, TQuery, TPath>['path'],
+    ...overrides
+  }
+}
+
+/** Create ValidatedApiParams (auth: 'none' with body schema) with defaults. */
+export function makeValidatedParams<TBody>(overrides: Partial<ValidatedApiParams<TBody>> & {body: TBody}): ValidatedApiParams<TBody> {
+  return {event: {} as APIGatewayProxyEvent, context: defaultContext, metadata: defaultMetadata, ...overrides}
+}
+
+/** Create ApiHandlerParams (auth: 'none', no schema) with defaults. */
+export function makeApiParams(overrides: Partial<ApiHandlerParams> = {}): ApiHandlerParams {
+  return {event: {} as APIGatewayProxyEvent, context: defaultContext, metadata: defaultMetadata, ...overrides}
+}
+
+/** Create SessionApiParams (auth: 'session') with defaults. */
+export function makeSessionParams<TBody = undefined, TQuery = undefined, TPath = undefined>(
+  overrides: Partial<SessionApiParams<TBody, TQuery, TPath>> & {userId: string}
+): SessionApiParams<TBody, TQuery, TPath> {
+  return {
+    event: {} as APIGatewayProxyEvent,
+    context: defaultContext,
+    metadata: defaultMetadata,
+    session: {
+      user: {id: overrides.userId, email: 'test@test.com', emailVerified: true},
+      session: {id: 'sess-1', token: 'tok-1', expiresAt: new Date(Date.now() + 86400000)}
+    },
+    body: undefined as SessionApiParams<TBody, TQuery, TPath>['body'],
+    query: undefined as SessionApiParams<TBody, TQuery, TPath>['query'],
+    path: undefined as SessionApiParams<TBody, TQuery, TPath>['path'],
+    ...overrides
+  }
 }

--- a/test/lambdas/api/device/event.post.test.ts
+++ b/test/lambdas/api/device/event.post.test.ts
@@ -4,6 +4,7 @@
  * Tests event logging, metrics, and tracing span management.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code) => ({statusCode: code}))}))
 
@@ -19,7 +20,7 @@ vi.mock('@mantleframework/observability',
 
 vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
-const {handler} = (await import('#lambdas/api/device/event.post.js')) as any
+const {handler} = (await import('#lambdas/api/device/event.post.js')) as unknown as MockedHandlerModule
 import {addAnnotation, endSpan, logInfo, metrics, startSpan} from '@mantleframework/observability'
 
 describe('DeviceEvent Lambda', () => {

--- a/test/lambdas/api/device/event.post.test.ts
+++ b/test/lambdas/api/device/event.post.test.ts
@@ -17,9 +17,9 @@ vi.mock('@mantleframework/observability',
     startSpan: vi.fn(() => 'mock-span')
   }))
 
-vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler)}))
+vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
-const {handler} = await import('#lambdas/api/device/event.post.js')
+const {handler} = (await import('#lambdas/api/device/event.post.js')) as any
 import {addAnnotation, endSpan, logInfo, metrics, startSpan} from '@mantleframework/observability'
 
 describe('DeviceEvent Lambda', () => {

--- a/test/lambdas/api/device/event.post.test.ts
+++ b/test/lambdas/api/device/event.post.test.ts
@@ -4,7 +4,8 @@
  * Tests event logging, metrics, and tracing span management.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as EventMod from '#lambdas/api/device/event.post.js'
 
 vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code) => ({statusCode: code}))}))
 
@@ -20,7 +21,7 @@ vi.mock('@mantleframework/observability',
 
 vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
-const {handler} = (await import('#lambdas/api/device/event.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/device/event.post.js')) as unknown as MockedModule<typeof EventMod>
 import {addAnnotation, endSpan, logInfo, metrics, startSpan} from '@mantleframework/observability'
 
 describe('DeviceEvent Lambda', () => {

--- a/test/lambdas/api/device/register.post.test.ts
+++ b/test/lambdas/api/device/register.post.test.ts
@@ -4,7 +4,8 @@
  * Tests platform endpoint creation, user device registration, subscription management.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as RegisterDeviceMod from '#lambdas/api/device/register.post.js'
 
 vi.mock('@mantleframework/aws', () => ({createPlatformEndpoint: vi.fn(), listSubscriptionsByTopic: vi.fn()}))
 
@@ -52,7 +53,7 @@ vi.mock('#types/api-schema', () => ({deviceRegistrationResponseSchema: {}}))
 
 vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/device/register.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/device/register.post.js')) as unknown as MockedModule<typeof RegisterDeviceMod>
 import {createPlatformEndpoint, listSubscriptionsByTopic} from '@mantleframework/aws'
 import {upsertDevice, upsertUserDevice} from '#entities/queries'
 import {getUserDevices, subscribeEndpointToTopic, unsubscribeEndpointToTopic} from '#services/device/deviceService'

--- a/test/lambdas/api/device/register.post.test.ts
+++ b/test/lambdas/api/device/register.post.test.ts
@@ -37,7 +37,7 @@ vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn()}))
 
 vi.mock('@mantleframework/validation',
   () => ({
-    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
     z: {object: vi.fn(() => ({})), string: vi.fn(() => ({optional: vi.fn(() => ({}))}))}
   }))
 
@@ -51,7 +51,7 @@ vi.mock('#types/api-schema', () => ({deviceRegistrationResponseSchema: {}}))
 
 vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
 
-const {handler} = await import('#lambdas/api/device/register.post.js')
+const {handler} = (await import('#lambdas/api/device/register.post.js')) as any
 import {createPlatformEndpoint, listSubscriptionsByTopic} from '@mantleframework/aws'
 import {upsertDevice, upsertUserDevice} from '#entities/queries'
 import {getUserDevices, subscribeEndpointToTopic, unsubscribeEndpointToTopic} from '#services/device/deviceService'
@@ -62,7 +62,7 @@ describe('RegisterDevice Lambda', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(createPlatformEndpoint).mockResolvedValue({EndpointArn: 'arn:aws:sns:endpoint/dev-1'})
+    vi.mocked(createPlatformEndpoint).mockResolvedValue({EndpointArn: 'arn:aws:sns:endpoint/dev-1', $metadata: {}})
     vi.mocked(upsertDevice).mockResolvedValue(undefined as never)
     vi.mocked(upsertUserDevice).mockResolvedValue(undefined as never)
   })
@@ -105,7 +105,8 @@ describe('RegisterDevice Lambda', () => {
         Protocol: 'application',
         Owner: '123',
         TopicArn: 'arn:aws:sns:topic'
-      }]
+      }],
+      $metadata: {}
     })
     vi.mocked(unsubscribeEndpointToTopic).mockResolvedValue(undefined as never)
 
@@ -129,7 +130,7 @@ describe('RegisterDevice Lambda', () => {
       {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
       {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
     ])
-    vi.mocked(listSubscriptionsByTopic).mockResolvedValue({Subscriptions: undefined})
+    vi.mocked(listSubscriptionsByTopic).mockResolvedValue({Subscriptions: undefined, $metadata: {}})
 
     await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})).rejects.toThrow(
       'AWS request failed'
@@ -148,7 +149,8 @@ describe('RegisterDevice Lambda', () => {
         Protocol: 'application',
         Owner: '123',
         TopicArn: 'arn:aws:sns:topic'
-      }]
+      }],
+      $metadata: {}
     })
 
     await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', body: baseBody})).rejects.toThrow(

--- a/test/lambdas/api/device/register.post.test.ts
+++ b/test/lambdas/api/device/register.post.test.ts
@@ -4,6 +4,7 @@
  * Tests platform endpoint creation, user device registration, subscription management.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/aws', () => ({createPlatformEndpoint: vi.fn(), listSubscriptionsByTopic: vi.fn()}))
 
@@ -51,7 +52,7 @@ vi.mock('#types/api-schema', () => ({deviceRegistrationResponseSchema: {}}))
 
 vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/device/register.post.js')) as any
+const {handler} = (await import('#lambdas/api/device/register.post.js')) as unknown as MockedHandlerModule
 import {createPlatformEndpoint, listSubscriptionsByTopic} from '@mantleframework/aws'
 import {upsertDevice, upsertUserDevice} from '#entities/queries'
 import {getUserDevices, subscribeEndpointToTopic, unsubscribeEndpointToTopic} from '#services/device/deviceService'

--- a/test/lambdas/api/feedly/webhook.post.test.ts
+++ b/test/lambdas/api/feedly/webhook.post.test.ts
@@ -40,11 +40,18 @@ vi.mock('@mantleframework/resilience', () => {
     registerLambdaContext = vi.fn()
     constructor() {}
   }
-  return {createIdempotencyStore: vi.fn(() => ({})), IdempotencyConfig: MockIdempotencyConfig, makeIdempotent: vi.fn((fn: Function) => fn)}
+  return {
+    createIdempotencyStore: vi.fn(() => ({})),
+    IdempotencyConfig: MockIdempotencyConfig,
+    makeIdempotent: vi.fn((fn: (...a: unknown[]) => unknown) => fn)
+  }
 })
 
 vi.mock('@mantleframework/validation',
-  () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler), z: {object: vi.fn(() => ({})), string: vi.fn(() => ({}))}}))
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({}))}
+  }))
 
 vi.mock('#domain/user/userFileService', () => ({associateFileToUser: vi.fn()}))
 
@@ -63,7 +70,7 @@ vi.mock('#types/enums',
     ResponseStatus: {Dispatched: 'Dispatched', Accepted: 'Accepted', Initiated: 'Initiated'}
   }))
 
-const {handler} = await import('#lambdas/api/feedly/webhook.post.js')
+const {handler} = (await import('#lambdas/api/feedly/webhook.post.js')) as any
 import {getVideoID} from '#services/youtube/youtube'
 import {createFile, createFileDownload, getFile} from '#entities/queries'
 import {associateFileToUser} from '#domain/user/userFileService'
@@ -90,7 +97,7 @@ describe('WebhookFeedly Lambda', () => {
 
   it('should emit DownloadRequested event for new file', async () => {
     vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
-    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(getFile).mockResolvedValue(null as never)
     vi.mocked(createFile).mockResolvedValue(undefined as never)
     vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
     vi.mocked(emitEvent).mockResolvedValue(undefined as never)
@@ -173,7 +180,7 @@ describe('WebhookFeedly Lambda', () => {
 
   it('should track WebhookReceived and WebhookProcessed metrics', async () => {
     vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
-    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(getFile).mockResolvedValue(null as never)
     vi.mocked(createFile).mockResolvedValue(undefined as never)
     vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
     vi.mocked(emitEvent).mockResolvedValue(undefined as never)
@@ -191,7 +198,7 @@ describe('WebhookFeedly Lambda', () => {
 
   it('should handle associateFileToUser failure gracefully', async () => {
     vi.mocked(associateFileToUser).mockRejectedValue(new Error('DB error'))
-    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(getFile).mockResolvedValue(null as never)
     vi.mocked(createFile).mockResolvedValue(undefined as never)
     vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
     vi.mocked(emitEvent).mockResolvedValue(undefined as never)
@@ -209,7 +216,7 @@ describe('WebhookFeedly Lambda', () => {
 
   it('should extract videoID from article URL', async () => {
     vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
-    vi.mocked(getFile).mockResolvedValue(undefined)
+    vi.mocked(getFile).mockResolvedValue(null as never)
     vi.mocked(createFile).mockResolvedValue(undefined as never)
     vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
     vi.mocked(emitEvent).mockResolvedValue(undefined as never)

--- a/test/lambdas/api/feedly/webhook.post.test.ts
+++ b/test/lambdas/api/feedly/webhook.post.test.ts
@@ -4,6 +4,7 @@
  * Tests auth validation, video ID extraction, idempotency, and error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/aws', () => ({sendMessage: vi.fn()}))
 
@@ -70,7 +71,7 @@ vi.mock('#types/enums',
     ResponseStatus: {Dispatched: 'Dispatched', Accepted: 'Accepted', Initiated: 'Initiated'}
   }))
 
-const {handler} = (await import('#lambdas/api/feedly/webhook.post.js')) as any
+const {handler} = (await import('#lambdas/api/feedly/webhook.post.js')) as unknown as MockedHandlerModule
 import {getVideoID} from '#services/youtube/youtube'
 import {createFile, createFileDownload, getFile} from '#entities/queries'
 import {associateFileToUser} from '#domain/user/userFileService'

--- a/test/lambdas/api/feedly/webhook.post.test.ts
+++ b/test/lambdas/api/feedly/webhook.post.test.ts
@@ -4,7 +4,8 @@
  * Tests auth validation, video ID extraction, idempotency, and error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as WebhookMod from '#lambdas/api/feedly/webhook.post.js'
 
 vi.mock('@mantleframework/aws', () => ({sendMessage: vi.fn()}))
 
@@ -71,7 +72,7 @@ vi.mock('#types/enums',
     ResponseStatus: {Dispatched: 'Dispatched', Accepted: 'Accepted', Initiated: 'Initiated'}
   }))
 
-const {handler} = (await import('#lambdas/api/feedly/webhook.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/feedly/webhook.post.js')) as unknown as MockedModule<typeof WebhookMod>
 import {getVideoID} from '#services/youtube/youtube'
 import {createFile, createFileDownload, getFile} from '#entities/queries'
 import {associateFileToUser} from '#domain/user/userFileService'

--- a/test/lambdas/api/files/fileId/index.delete.test.ts
+++ b/test/lambdas/api/files/fileId/index.delete.test.ts
@@ -4,6 +4,7 @@
  * Tests cascade deletion, S3 cleanup, not-found errors, and S3 failure resilience.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core',
   () => ({
@@ -37,7 +38,7 @@ vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'test-bucket
 
 vi.mock('#entities/queries', () => ({deleteFileCascade: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/files/[fileId]/index.delete.js')) as any
+const {handler} = (await import('#lambdas/api/files/[fileId]/index.delete.js')) as unknown as MockedHandlerModule
 import {deleteFileCascade} from '#entities/queries'
 import {deleteObject} from '@mantleframework/aws'
 import {logError, logInfo} from '@mantleframework/observability'

--- a/test/lambdas/api/files/fileId/index.delete.test.ts
+++ b/test/lambdas/api/files/fileId/index.delete.test.ts
@@ -4,7 +4,8 @@
  * Tests cascade deletion, S3 cleanup, not-found errors, and S3 failure resilience.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as FileDeleteMod from '#lambdas/api/files/[fileId]/index.delete.js'
 
 vi.mock('@mantleframework/core',
   () => ({
@@ -38,7 +39,7 @@ vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'test-bucket
 
 vi.mock('#entities/queries', () => ({deleteFileCascade: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/files/[fileId]/index.delete.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/files/[fileId]/index.delete.js')) as unknown as MockedModule<typeof FileDeleteMod>
 import {deleteFileCascade} from '#entities/queries'
 import {deleteObject} from '@mantleframework/aws'
 import {logError, logInfo} from '@mantleframework/observability'

--- a/test/lambdas/api/files/fileId/index.delete.test.ts
+++ b/test/lambdas/api/files/fileId/index.delete.test.ts
@@ -5,15 +5,14 @@
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-vi.mock('@mantleframework/core', () => ({
-  buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})),
-  defineLambda: vi.fn(),
-  S3BucketName: vi.fn((name: string) => name)
-}))
+vi.mock('@mantleframework/core',
+  () => ({
+    buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})),
+    defineLambda: vi.fn(),
+    S3BucketName: vi.fn((name: string) => name)
+  }))
 
-vi.mock('@mantleframework/aws', () => ({
-  deleteObject: vi.fn()
-}))
+vi.mock('@mantleframework/aws', () => ({deleteObject: vi.fn()}))
 
 vi.mock('@mantleframework/errors', () => {
   class NotFoundError extends Error {
@@ -26,25 +25,19 @@ vi.mock('@mantleframework/errors', () => {
   return {NotFoundError}
 })
 
-vi.mock('@mantleframework/observability', () => ({
-  logError: vi.fn(),
-  logInfo: vi.fn()
-}))
+vi.mock('@mantleframework/observability', () => ({logError: vi.fn(), logInfo: vi.fn()}))
 
-vi.mock('@mantleframework/validation', () => ({
-  defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
-  z: {object: vi.fn(() => ({})), string: vi.fn(() => ({})), boolean: vi.fn(() => ({}))}
-}))
+vi.mock('@mantleframework/validation',
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({})), boolean: vi.fn(() => ({}))}
+  }))
 
-vi.mock('@mantleframework/env', () => ({
-  getRequiredEnv: vi.fn(() => 'test-bucket')
-}))
+vi.mock('@mantleframework/env', () => ({getRequiredEnv: vi.fn(() => 'test-bucket')}))
 
-vi.mock('#entities/queries', () => ({
-  deleteFileCascade: vi.fn()
-}))
+vi.mock('#entities/queries', () => ({deleteFileCascade: vi.fn()}))
 
-const {handler} = await import('#lambdas/api/files/[fileId]/index.delete.js')
+const {handler} = (await import('#lambdas/api/files/[fileId]/index.delete.js')) as any
 import {deleteFileCascade} from '#entities/queries'
 import {deleteObject} from '@mantleframework/aws'
 import {logError, logInfo} from '@mantleframework/observability'
@@ -57,21 +50,13 @@ describe('FileDelete Lambda', () => {
   it('should throw NotFoundError when file does not exist for user', async () => {
     vi.mocked(deleteFileCascade).mockResolvedValue({existed: false, fileRemoved: false})
 
-    await expect(handler({
-      context: {awsRequestId: 'req-1'},
-      userId: 'user-1',
-      path: {fileId: 'abc123'}
-    })).rejects.toThrow('File not found for this user')
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', path: {fileId: 'abc123'}})).rejects.toThrow('File not found for this user')
   })
 
   it('should delete file link without S3 cleanup when other users linked', async () => {
     vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: false})
 
-    const result = await handler({
-      context: {awsRequestId: 'req-1'},
-      userId: 'user-1',
-      path: {fileId: 'abc123'}
-    })
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', path: {fileId: 'abc123'}})
 
     expect(deleteObject).not.toHaveBeenCalled()
     expect(result.deleted).toBe(true)
@@ -82,11 +67,7 @@ describe('FileDelete Lambda', () => {
     vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: true})
     vi.mocked(deleteObject).mockResolvedValue(undefined as never)
 
-    const result = await handler({
-      context: {awsRequestId: 'req-1'},
-      userId: 'user-1',
-      path: {fileId: 'abc123'}
-    })
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', path: {fileId: 'abc123'}})
 
     expect(deleteObject).toHaveBeenCalledWith({Bucket: 'test-bucket', Key: 'abc123.mp4'})
     expect(logInfo).toHaveBeenCalledWith('Deleted orphaned S3 object', {fileId: 'abc123', key: 'abc123.mp4'})
@@ -98,16 +79,9 @@ describe('FileDelete Lambda', () => {
     vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: true})
     vi.mocked(deleteObject).mockRejectedValue(new Error('S3 access denied'))
 
-    const result = await handler({
-      context: {awsRequestId: 'req-1'},
-      userId: 'user-1',
-      path: {fileId: 'abc123'}
-    })
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', path: {fileId: 'abc123'}})
 
-    expect(logError).toHaveBeenCalledWith(
-      'Failed to delete S3 object (orphaned)',
-      expect.objectContaining({fileId: 'abc123', error: 'S3 access denied'})
-    )
+    expect(logError).toHaveBeenCalledWith('Failed to delete S3 object (orphaned)', expect.objectContaining({fileId: 'abc123', error: 'S3 access denied'}))
     expect(result.deleted).toBe(true)
     expect(result.fileRemoved).toBe(true)
   })
@@ -116,26 +90,15 @@ describe('FileDelete Lambda', () => {
     vi.mocked(deleteFileCascade).mockResolvedValue({existed: true, fileRemoved: true})
     vi.mocked(deleteObject).mockRejectedValue('string error')
 
-    const result = await handler({
-      context: {awsRequestId: 'req-1'},
-      userId: 'user-1',
-      path: {fileId: 'abc123'}
-    })
+    const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', path: {fileId: 'abc123'}})
 
-    expect(logError).toHaveBeenCalledWith(
-      'Failed to delete S3 object (orphaned)',
-      expect.objectContaining({error: 'string error'})
-    )
+    expect(logError).toHaveBeenCalledWith('Failed to delete S3 object (orphaned)', expect.objectContaining({error: 'string error'}))
     expect(result.deleted).toBe(true)
   })
 
   it('should propagate database errors from deleteFileCascade', async () => {
     vi.mocked(deleteFileCascade).mockRejectedValue(new Error('DB connection failed'))
 
-    await expect(handler({
-      context: {awsRequestId: 'req-1'},
-      userId: 'user-1',
-      path: {fileId: 'abc123'}
-    })).rejects.toThrow('DB connection failed')
+    await expect(handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', path: {fileId: 'abc123'}})).rejects.toThrow('DB connection failed')
   })
 })

--- a/test/lambdas/api/files/index.get.test.ts
+++ b/test/lambdas/api/files/index.get.test.ts
@@ -4,7 +4,8 @@
  * Tests the toFile helper, anonymous demo mode, status filtering, and sorting.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as ListFilesMod from '#lambdas/api/files/index.get.js'
 
 vi.mock('@mantleframework/core',
   () => ({
@@ -45,7 +46,7 @@ vi.mock('#types/api-schema', () => ({fileListResponseSchema: {}}))
 
 vi.mock('#types/enums', () => ({FileStatus: {Queued: 'Queued', Downloading: 'Downloading', Downloaded: 'Downloaded', Failed: 'Failed'}}))
 
-const {handler} = (await import('#lambdas/api/files/index.get.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/files/index.get.js')) as unknown as MockedModule<typeof ListFilesMod>
 import {getFilesForUser} from '#entities/queries'
 import {getDefaultFile} from '#config/constants'
 import {buildValidatedResponse} from '@mantleframework/core'
@@ -78,11 +79,11 @@ describe('ListFiles Lambda', () => {
 
       const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
 
-      expect(result.contents[0].url).toBeUndefined()
-      expect(result.contents[0].duration).toBeUndefined()
-      expect(result.contents[0].uploadDate).toBeUndefined()
-      expect(result.contents[0].viewCount).toBeUndefined()
-      expect(result.contents[0].thumbnailUrl).toBeUndefined()
+      expect((result.contents as Record<string, unknown>[])[0]!.url).toBeUndefined()
+      expect((result.contents as Record<string, unknown>[])[0]!.duration).toBeUndefined()
+      expect((result.contents as Record<string, unknown>[])[0]!.uploadDate).toBeUndefined()
+      expect((result.contents as Record<string, unknown>[])[0]!.viewCount).toBeUndefined()
+      expect((result.contents as Record<string, unknown>[])[0]!.thumbnailUrl).toBeUndefined()
     })
 
     it('should preserve non-null optional fields', async () => {
@@ -106,11 +107,11 @@ describe('ListFiles Lambda', () => {
 
       const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
 
-      expect(result.contents[0].url).toBe('https://cdn.example.com/abc123.mp4')
-      expect(result.contents[0].duration).toBe(300)
-      expect(result.contents[0].uploadDate).toBe('20240101')
-      expect(result.contents[0].viewCount).toBe(5000)
-      expect(result.contents[0].thumbnailUrl).toBe('https://i.ytimg.com/vi/abc123/maxresdefault.jpg')
+      expect((result.contents as Record<string, unknown>[])[0]!.url).toBe('https://cdn.example.com/abc123.mp4')
+      expect((result.contents as Record<string, unknown>[])[0]!.duration).toBe(300)
+      expect((result.contents as Record<string, unknown>[])[0]!.uploadDate).toBe('20240101')
+      expect((result.contents as Record<string, unknown>[])[0]!.viewCount).toBe(5000)
+      expect((result.contents as Record<string, unknown>[])[0]!.thumbnailUrl).toBe('https://i.ytimg.com/vi/abc123/maxresdefault.jpg')
     })
 
     it('should cast status to File status type', async () => {
@@ -134,7 +135,7 @@ describe('ListFiles Lambda', () => {
 
       const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'all'}})
 
-      expect(result.contents[0].status).toBe('Queued')
+      expect((result.contents as Record<string, unknown>[])[0]!.status).toBe('Queued')
     })
   })
 
@@ -192,7 +193,7 @@ describe('ListFiles Lambda', () => {
       const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
 
       expect(result.contents).toHaveLength(1)
-      expect(result.contents[0].status).toBe('Downloaded')
+      expect((result.contents as Record<string, unknown>[])[0]!.status).toBe('Downloaded')
       expect(result.keyCount).toBe(1)
     })
 
@@ -211,7 +212,7 @@ describe('ListFiles Lambda', () => {
       const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {}})
 
       expect(result.contents).toHaveLength(1)
-      expect(result.contents[0].status).toBe('Downloaded')
+      expect((result.contents as Record<string, unknown>[])[0]!.status).toBe('Downloaded')
     })
   })
 
@@ -256,8 +257,8 @@ describe('ListFiles Lambda', () => {
 
       const result = await handler({context: {awsRequestId: 'req-1'}, userId: 'user-1', userStatus: 'Authenticated', query: {status: 'downloaded'}})
 
-      expect(result.contents[0].fileId).toBe('new')
-      expect(result.contents[1].fileId).toBe('old')
+      expect((result.contents as Record<string, unknown>[])[0]!.fileId).toBe('new')
+      expect((result.contents as Record<string, unknown>[])[1]!.fileId).toBe('old')
     })
   })
 

--- a/test/lambdas/api/files/index.get.test.ts
+++ b/test/lambdas/api/files/index.get.test.ts
@@ -17,7 +17,7 @@ vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), metrics: {a
 
 vi.mock('@mantleframework/validation',
   () => ({
-    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
     z: {object: vi.fn(() => ({optional: vi.fn(() => ({default: vi.fn()}))})), string: vi.fn(() => ({optional: vi.fn(() => ({default: vi.fn()}))}))}
   }))
 
@@ -44,7 +44,7 @@ vi.mock('#types/api-schema', () => ({fileListResponseSchema: {}}))
 
 vi.mock('#types/enums', () => ({FileStatus: {Queued: 'Queued', Downloading: 'Downloading', Downloaded: 'Downloaded', Failed: 'Failed'}}))
 
-const {handler} = await import('#lambdas/api/files/index.get.js')
+const {handler} = (await import('#lambdas/api/files/index.get.js')) as any
 import {getFilesForUser} from '#entities/queries'
 import {getDefaultFile} from '#config/constants'
 import {buildValidatedResponse} from '@mantleframework/core'

--- a/test/lambdas/api/files/index.get.test.ts
+++ b/test/lambdas/api/files/index.get.test.ts
@@ -4,6 +4,7 @@
  * Tests the toFile helper, anonymous demo mode, status filtering, and sorting.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core',
   () => ({
@@ -44,7 +45,7 @@ vi.mock('#types/api-schema', () => ({fileListResponseSchema: {}}))
 
 vi.mock('#types/enums', () => ({FileStatus: {Queued: 'Queued', Downloading: 'Downloading', Downloaded: 'Downloaded', Failed: 'Failed'}}))
 
-const {handler} = (await import('#lambdas/api/files/index.get.js')) as any
+const {handler} = (await import('#lambdas/api/files/index.get.js')) as unknown as MockedHandlerModule
 import {getFilesForUser} from '#entities/queries'
 import {getDefaultFile} from '#config/constants'
 import {buildValidatedResponse} from '@mantleframework/core'

--- a/test/lambdas/api/user/index.delete.test.ts
+++ b/test/lambdas/api/user/index.delete.test.ts
@@ -4,7 +4,8 @@
  * Tests cascade deletion ordering, partial failures, and GitHub issue creation on error.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as UserDeleteMod from '#lambdas/api/user/index.delete.js'
 
 vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})), defineLambda: vi.fn()}))
 
@@ -42,7 +43,7 @@ vi.mock('#integrations/github/issueService', () => ({createFailedUserDeletionIss
 
 vi.mock('#services/device/deviceService', () => ({deleteDevice: vi.fn(), getUserDevices: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/user/index.delete.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/user/index.delete.js')) as unknown as MockedModule<typeof UserDeleteMod>
 import {deleteUser, deleteUserDevicesByUserId, deleteUserFilesByUserId, getDevicesBatch} from '#entities/queries'
 import {createFailedUserDeletionIssue} from '#integrations/github/issueService'
 import {deleteDevice, getUserDevices} from '#services/device/deviceService'

--- a/test/lambdas/api/user/index.delete.test.ts
+++ b/test/lambdas/api/user/index.delete.test.ts
@@ -29,7 +29,7 @@ vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logError: v
 
 vi.mock('@mantleframework/validation',
   () => ({
-    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
     z: {object: vi.fn(() => ({})), string: vi.fn(() => ({})), number: vi.fn(() => ({}))}
   }))
 
@@ -41,7 +41,7 @@ vi.mock('#integrations/github/issueService', () => ({createFailedUserDeletionIss
 
 vi.mock('#services/device/deviceService', () => ({deleteDevice: vi.fn(), getUserDevices: vi.fn()}))
 
-const {handler} = await import('#lambdas/api/user/index.delete.js')
+const {handler} = (await import('#lambdas/api/user/index.delete.js')) as any
 import {deleteUser, deleteUserDevicesByUserId, deleteUserFilesByUserId, getDevicesBatch} from '#entities/queries'
 import {createFailedUserDeletionIssue} from '#integrations/github/issueService'
 import {deleteDevice, getUserDevices} from '#services/device/deviceService'

--- a/test/lambdas/api/user/index.delete.test.ts
+++ b/test/lambdas/api/user/index.delete.test.ts
@@ -4,6 +4,7 @@
  * Tests cascade deletion ordering, partial failures, and GitHub issue creation on error.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data})), defineLambda: vi.fn()}))
 
@@ -41,7 +42,7 @@ vi.mock('#integrations/github/issueService', () => ({createFailedUserDeletionIss
 
 vi.mock('#services/device/deviceService', () => ({deleteDevice: vi.fn(), getUserDevices: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/user/index.delete.js')) as any
+const {handler} = (await import('#lambdas/api/user/index.delete.js')) as unknown as MockedHandlerModule
 import {deleteUser, deleteUserDevicesByUserId, deleteUserFilesByUserId, getDevicesBatch} from '#entities/queries'
 import {createFailedUserDeletionIssue} from '#integrations/github/issueService'
 import {deleteDevice, getUserDevices} from '#services/device/deviceService'

--- a/test/lambdas/api/user/login.post.test.ts
+++ b/test/lambdas/api/user/login.post.test.ts
@@ -4,6 +4,7 @@
  * Tests sign-in flow, session retrieval, and error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/auth', () => ({getAuth: vi.fn()}))
 
@@ -36,7 +37,7 @@ vi.mock('#db/schema', () => ({accounts: {}, sessions: {}, users: {}, verificatio
 
 vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
 
-const {handler} = (await import('#lambdas/api/user/login.post.js')) as any
+const {handler} = (await import('#lambdas/api/user/login.post.js')) as unknown as MockedHandlerModule
 import {getAuth} from '@mantleframework/auth'
 
 function createMockAuth(overrides: {signInSocialResult?: object; getSessionResult?: object | null} = {}) {

--- a/test/lambdas/api/user/login.post.test.ts
+++ b/test/lambdas/api/user/login.post.test.ts
@@ -4,7 +4,8 @@
  * Tests sign-in flow, session retrieval, and error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as LoginMod from '#lambdas/api/user/login.post.js'
 
 vi.mock('@mantleframework/auth', () => ({getAuth: vi.fn()}))
 
@@ -37,7 +38,7 @@ vi.mock('#db/schema', () => ({accounts: {}, sessions: {}, users: {}, verificatio
 
 vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
 
-const {handler} = (await import('#lambdas/api/user/login.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/user/login.post.js')) as unknown as MockedModule<typeof LoginMod>
 import {getAuth} from '@mantleframework/auth'
 
 function createMockAuth(overrides: {signInSocialResult?: object; getSessionResult?: object | null} = {}) {

--- a/test/lambdas/api/user/login.post.test.ts
+++ b/test/lambdas/api/user/login.post.test.ts
@@ -25,7 +25,10 @@ vi.mock('@mantleframework/errors', () => {
 vi.mock('@mantleframework/observability', () => ({logInfo: vi.fn()}))
 
 vi.mock('@mantleframework/validation',
-  () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler), z: {object: vi.fn(() => ({})), string: vi.fn(() => ({}))}}))
+  () => ({
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
+    z: {object: vi.fn(() => ({})), string: vi.fn(() => ({}))}
+  }))
 
 vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
 
@@ -33,7 +36,7 @@ vi.mock('#db/schema', () => ({accounts: {}, sessions: {}, users: {}, verificatio
 
 vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
 
-const {handler} = await import('#lambdas/api/user/login.post.js')
+const {handler} = (await import('#lambdas/api/user/login.post.js')) as any
 import {getAuth} from '@mantleframework/auth'
 
 function createMockAuth(overrides: {signInSocialResult?: object; getSessionResult?: object | null} = {}) {

--- a/test/lambdas/api/user/logout.post.test.ts
+++ b/test/lambdas/api/user/logout.post.test.ts
@@ -22,13 +22,13 @@ vi.mock('@mantleframework/errors', () => {
 
 vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logInfo: vi.fn()}))
 
-vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler)}))
+vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
 vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
 
 vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
 
-const {handler} = await import('#lambdas/api/user/logout.post.js')
+const {handler} = (await import('#lambdas/api/user/logout.post.js')) as any
 import {expireSession, extractBearerToken} from '@mantleframework/auth'
 import {getAuthInstance} from '#domain/auth/authInstance'
 import {getDrizzleClient} from '#db/client'

--- a/test/lambdas/api/user/logout.post.test.ts
+++ b/test/lambdas/api/user/logout.post.test.ts
@@ -4,7 +4,8 @@
  * Tests token extraction, session expiry, and auth error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as LogoutMod from '#lambdas/api/user/logout.post.js'
 
 vi.mock('@mantleframework/auth', () => ({expireSession: vi.fn(), extractBearerToken: vi.fn()}))
 
@@ -29,7 +30,7 @@ vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
 
 vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/user/logout.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/user/logout.post.js')) as unknown as MockedModule<typeof LogoutMod>
 import {expireSession, extractBearerToken} from '@mantleframework/auth'
 import {getAuthInstance} from '#domain/auth/authInstance'
 import {getDrizzleClient} from '#db/client'

--- a/test/lambdas/api/user/logout.post.test.ts
+++ b/test/lambdas/api/user/logout.post.test.ts
@@ -4,6 +4,7 @@
  * Tests token extraction, session expiry, and auth error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/auth', () => ({expireSession: vi.fn(), extractBearerToken: vi.fn()}))
 
@@ -28,7 +29,7 @@ vi.mock('#db/client', () => ({getDrizzleClient: vi.fn()}))
 
 vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/user/logout.post.js')) as any
+const {handler} = (await import('#lambdas/api/user/logout.post.js')) as unknown as MockedHandlerModule
 import {expireSession, extractBearerToken} from '@mantleframework/auth'
 import {getAuthInstance} from '#domain/auth/authInstance'
 import {getDrizzleClient} from '#db/client'

--- a/test/lambdas/api/user/refresh.post.test.ts
+++ b/test/lambdas/api/user/refresh.post.test.ts
@@ -22,13 +22,13 @@ vi.mock('@mantleframework/errors', () => {
 
 vi.mock('@mantleframework/observability', () => ({logDebug: vi.fn(), logInfo: vi.fn()}))
 
-vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler)}))
+vi.mock('@mantleframework/validation', () => ({defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
 vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
 
 vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
 
-const {handler} = await import('#lambdas/api/user/refresh.post.js')
+const {handler} = (await import('#lambdas/api/user/refresh.post.js')) as any
 import {extractBearerToken, validateSession} from '@mantleframework/auth'
 import {getAuthInstance} from '#domain/auth/authInstance'
 
@@ -54,8 +54,8 @@ describe('RefreshToken Lambda', () => {
     vi.mocked(extractBearerToken).mockReturnValue('my-token')
     vi.mocked(getAuthInstance).mockResolvedValue({} as never)
     vi.mocked(validateSession).mockResolvedValue({
-      session: {id: 'session-1', expiresAt, token: 'my-token', userId: 'user-1', createdAt: new Date(), updatedAt: new Date()},
-      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+      session: {id: 'session-1', expiresAt, token: 'my-token'},
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test'}
     })
 
     const result = await handler({event: {headers: {Authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})
@@ -67,8 +67,8 @@ describe('RefreshToken Lambda', () => {
     vi.mocked(extractBearerToken).mockReturnValue('my-token')
     vi.mocked(getAuthInstance).mockResolvedValue({} as never)
     vi.mocked(validateSession).mockResolvedValue({
-      session: {id: 's-1', expiresAt: new Date(), token: 'my-token', userId: 'user-1', createdAt: new Date(), updatedAt: new Date()},
-      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: new Date(), updatedAt: new Date()}
+      session: {id: 's-1', expiresAt: new Date(), token: 'my-token'},
+      user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test'}
     })
 
     await handler({event: {headers: {authorization: 'Bearer my-token'}}, context: {awsRequestId: 'req-1'}, userId: 'user-1'})

--- a/test/lambdas/api/user/refresh.post.test.ts
+++ b/test/lambdas/api/user/refresh.post.test.ts
@@ -4,7 +4,8 @@
  * Tests token extraction, session validation, and auth error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as RefreshMod from '#lambdas/api/user/refresh.post.js'
 
 vi.mock('@mantleframework/auth', () => ({extractBearerToken: vi.fn(), validateSession: vi.fn()}))
 
@@ -29,7 +30,7 @@ vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
 
 vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
 
-const {handler} = (await import('#lambdas/api/user/refresh.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/user/refresh.post.js')) as unknown as MockedModule<typeof RefreshMod>
 import {extractBearerToken, validateSession} from '@mantleframework/auth'
 import {getAuthInstance} from '#domain/auth/authInstance'
 

--- a/test/lambdas/api/user/refresh.post.test.ts
+++ b/test/lambdas/api/user/refresh.post.test.ts
@@ -4,6 +4,7 @@
  * Tests token extraction, session validation, and auth error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/auth', () => ({extractBearerToken: vi.fn(), validateSession: vi.fn()}))
 
@@ -28,7 +29,7 @@ vi.mock('#domain/auth/authInstance', () => ({getAuthInstance: vi.fn()}))
 
 vi.mock('#types/api-schema', () => ({userLoginResponseSchema: {}}))
 
-const {handler} = (await import('#lambdas/api/user/refresh.post.js')) as any
+const {handler} = (await import('#lambdas/api/user/refresh.post.js')) as unknown as MockedHandlerModule
 import {extractBearerToken, validateSession} from '@mantleframework/auth'
 import {getAuthInstance} from '#domain/auth/authInstance'
 

--- a/test/lambdas/api/user/register.post.test.ts
+++ b/test/lambdas/api/user/register.post.test.ts
@@ -26,7 +26,7 @@ vi.mock('@mantleframework/observability', () => ({logInfo: vi.fn(), metrics: {ad
 
 vi.mock('@mantleframework/validation',
   () => ({
-    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
     z: {object: vi.fn(() => ({})), string: vi.fn(() => ({optional: vi.fn(() => ({}))}))}
   }))
 
@@ -38,7 +38,7 @@ vi.mock('#entities/queries', () => ({updateUser: vi.fn()}))
 
 vi.mock('#types/api-schema', () => ({userRegistrationResponseSchema: {}}))
 
-const {handler} = await import('#lambdas/api/user/register.post.js')
+const {handler} = (await import('#lambdas/api/user/register.post.js')) as any
 import {getAuth} from '@mantleframework/auth'
 import {updateUser} from '#entities/queries'
 import {metrics} from '@mantleframework/observability'

--- a/test/lambdas/api/user/register.post.test.ts
+++ b/test/lambdas/api/user/register.post.test.ts
@@ -4,6 +4,7 @@
  * Tests sign-in flow, session validation, new user name update, and error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/auth', () => ({getAuth: vi.fn()}))
 
@@ -38,7 +39,7 @@ vi.mock('#entities/queries', () => ({updateUser: vi.fn()}))
 
 vi.mock('#types/api-schema', () => ({userRegistrationResponseSchema: {}}))
 
-const {handler} = (await import('#lambdas/api/user/register.post.js')) as any
+const {handler} = (await import('#lambdas/api/user/register.post.js')) as unknown as MockedHandlerModule
 import {getAuth} from '@mantleframework/auth'
 import {updateUser} from '#entities/queries'
 import {metrics} from '@mantleframework/observability'

--- a/test/lambdas/api/user/register.post.test.ts
+++ b/test/lambdas/api/user/register.post.test.ts
@@ -4,7 +4,8 @@
  * Tests sign-in flow, session validation, new user name update, and error paths.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as RegisterMod from '#lambdas/api/user/register.post.js'
 
 vi.mock('@mantleframework/auth', () => ({getAuth: vi.fn()}))
 
@@ -39,7 +40,7 @@ vi.mock('#entities/queries', () => ({updateUser: vi.fn()}))
 
 vi.mock('#types/api-schema', () => ({userRegistrationResponseSchema: {}}))
 
-const {handler} = (await import('#lambdas/api/user/register.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/user/register.post.js')) as unknown as MockedModule<typeof RegisterMod>
 import {getAuth} from '@mantleframework/auth'
 import {updateUser} from '#entities/queries'
 import {metrics} from '@mantleframework/observability'

--- a/test/lambdas/api/user/subscribe.post.test.ts
+++ b/test/lambdas/api/user/subscribe.post.test.ts
@@ -20,7 +20,7 @@ vi.mock('@mantleframework/errors', () => {
 
 vi.mock('@mantleframework/validation',
   () => ({
-    defineApiHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
+    defineApiHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
     z: {object: vi.fn(() => ({})), string: vi.fn(() => ({optional: vi.fn(() => ({}))}))}
   }))
 
@@ -28,7 +28,7 @@ vi.mock('#services/device/deviceService', () => ({subscribeEndpointToTopic: vi.f
 
 vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
 
-const {handler} = await import('#lambdas/api/user/subscribe.post.js')
+const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as any
 import {subscribeEndpointToTopic} from '#services/device/deviceService'
 import {verifyPlatformConfiguration} from '#utils/platform-config'
 

--- a/test/lambdas/api/user/subscribe.post.test.ts
+++ b/test/lambdas/api/user/subscribe.post.test.ts
@@ -4,6 +4,7 @@
  * Tests subscription creation, auth validation, and platform config check.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data}))}))
 
@@ -28,7 +29,7 @@ vi.mock('#services/device/deviceService', () => ({subscribeEndpointToTopic: vi.f
 
 vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as any
+const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedHandlerModule
 import {subscribeEndpointToTopic} from '#services/device/deviceService'
 import {verifyPlatformConfiguration} from '#utils/platform-config'
 

--- a/test/lambdas/api/user/subscribe.post.test.ts
+++ b/test/lambdas/api/user/subscribe.post.test.ts
@@ -4,7 +4,8 @@
  * Tests subscription creation, auth validation, and platform config check.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as SubscribeMod from '#lambdas/api/user/subscribe.post.js'
 
 vi.mock('@mantleframework/core', () => ({buildValidatedResponse: vi.fn((_ctx, code, data) => ({statusCode: code, ...data}))}))
 
@@ -29,7 +30,7 @@ vi.mock('#services/device/deviceService', () => ({subscribeEndpointToTopic: vi.f
 
 vi.mock('#utils/platform-config', () => ({verifyPlatformConfiguration: vi.fn()}))
 
-const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/api/user/subscribe.post.js')) as unknown as MockedModule<typeof SubscribeMod>
 import {subscribeEndpointToTopic} from '#services/device/deviceService'
 import {verifyPlatformConfiguration} from '#utils/platform-config'
 

--- a/test/lambdas/s3/S3ObjectCreated/index.test.ts
+++ b/test/lambdas/s3/S3ObjectCreated/index.test.ts
@@ -5,9 +5,7 @@
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-vi.mock('@mantleframework/core', () => ({
-  defineS3Handler: vi.fn(() => (innerHandler: Function) => innerHandler)
-}))
+vi.mock('@mantleframework/core', () => ({defineS3Handler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
 vi.mock('@mantleframework/aws', () => ({sendMessage: vi.fn()}))
 
@@ -24,31 +22,33 @@ vi.mock('@mantleframework/errors', () => {
   return {NotFoundError}
 })
 
-vi.mock('@mantleframework/observability', () => ({
-  addAnnotation: vi.fn(),
-  addMetadata: vi.fn(),
-  endSpan: vi.fn(),
-  logDebug: vi.fn(),
-  logError: vi.fn(),
-  logInfo: vi.fn(),
-  metrics: {addMetric: vi.fn()},
-  MetricUnit: {Count: 'Count'},
-  startSpan: vi.fn(() => ({}))
-}))
-
-vi.mock('#entities/queries', () => ({
-  getFilesByKey: vi.fn(),
-  getUserFilesByFileId: vi.fn()
-}))
-
-vi.mock('#services/notification/transformers', () => ({
-  createDownloadReadyNotification: vi.fn(() => ({
-    messageBody: JSON.stringify({file: {fileId: 'file-1'}, notificationType: 'DownloadReadyNotification'}),
-    messageAttributes: {userId: {DataType: 'String', StringValue: 'user-1'}, notificationType: {DataType: 'String', StringValue: 'DownloadReadyNotification'}}
+vi.mock('@mantleframework/observability',
+  () => ({
+    addAnnotation: vi.fn(),
+    addMetadata: vi.fn(),
+    endSpan: vi.fn(),
+    logDebug: vi.fn(),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => ({}))
   }))
-}))
 
-const {handler} = await import('#lambdas/s3/S3ObjectCreated/index.js')
+vi.mock('#entities/queries', () => ({getFilesByKey: vi.fn(), getUserFilesByFileId: vi.fn()}))
+
+vi.mock('#services/notification/transformers',
+  () => ({
+    createDownloadReadyNotification: vi.fn(() => ({
+      messageBody: JSON.stringify({file: {fileId: 'file-1'}, notificationType: 'DownloadReadyNotification'}),
+      messageAttributes: {
+        userId: {DataType: 'String', StringValue: 'user-1'},
+        notificationType: {DataType: 'String', StringValue: 'DownloadReadyNotification'}
+      }
+    }))
+  }))
+
+const {handler} = (await import('#lambdas/s3/S3ObjectCreated/index.js')) as any
 import {sendMessage} from '@mantleframework/aws'
 import {getFilesByKey, getUserFilesByFileId} from '#entities/queries'
 import {createDownloadReadyNotification} from '#services/notification/transformers'
@@ -68,14 +68,18 @@ describe('S3ObjectCreated Lambda', () => {
     url: 'https://example.cloudfront.net/dQw4w9WgXcQ.mp4',
     contentType: 'video/mp4',
     title: 'Test Video',
-    status: 'Downloaded'
+    status: 'Downloaded',
+    duration: null,
+    uploadDate: null,
+    viewCount: null,
+    thumbnailUrl: null
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(getFilesByKey).mockResolvedValue([mockFile])
     vi.mocked(getUserFilesByFileId).mockResolvedValue([{userId: 'user-1', fileId: 'dQw4w9WgXcQ', createdAt: new Date()}])
-    vi.mocked(sendMessage).mockResolvedValue({MessageId: 'msg-1'})
+    vi.mocked(sendMessage).mockResolvedValue({MessageId: 'msg-1', $metadata: {}})
   })
 
   it('should find file by key and dispatch notification', async () => {
@@ -125,9 +129,7 @@ describe('S3ObjectCreated Lambda', () => {
       {userId: 'user-1', fileId: 'dQw4w9WgXcQ', createdAt: new Date()},
       {userId: 'user-2', fileId: 'dQw4w9WgXcQ', createdAt: new Date()}
     ])
-    vi.mocked(sendMessage)
-      .mockResolvedValueOnce({MessageId: 'msg-1'})
-      .mockRejectedValueOnce(new Error('SQS failure'))
+    vi.mocked(sendMessage).mockResolvedValueOnce({MessageId: 'msg-1', $metadata: {}}).mockRejectedValueOnce(new Error('SQS failure'))
 
     await handler(makeRecord())
 

--- a/test/lambdas/s3/S3ObjectCreated/index.test.ts
+++ b/test/lambdas/s3/S3ObjectCreated/index.test.ts
@@ -4,6 +4,7 @@
  * Tests S3 object creation event processing and push notification dispatch.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core', () => ({defineS3Handler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
@@ -48,7 +49,7 @@ vi.mock('#services/notification/transformers',
     }))
   }))
 
-const {handler} = (await import('#lambdas/s3/S3ObjectCreated/index.js')) as any
+const {handler} = (await import('#lambdas/s3/S3ObjectCreated/index.js')) as unknown as MockedHandlerModule
 import {sendMessage} from '@mantleframework/aws'
 import {getFilesByKey, getUserFilesByFileId} from '#entities/queries'
 import {createDownloadReadyNotification} from '#services/notification/transformers'

--- a/test/lambdas/s3/S3ObjectCreated/index.test.ts
+++ b/test/lambdas/s3/S3ObjectCreated/index.test.ts
@@ -4,7 +4,8 @@
  * Tests S3 object creation event processing and push notification dispatch.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as S3Mod from '#lambdas/s3/S3ObjectCreated/index.js'
 
 vi.mock('@mantleframework/core', () => ({defineS3Handler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
@@ -49,7 +50,7 @@ vi.mock('#services/notification/transformers',
     }))
   }))
 
-const {handler} = (await import('#lambdas/s3/S3ObjectCreated/index.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/s3/S3ObjectCreated/index.js')) as unknown as MockedModule<typeof S3Mod>
 import {sendMessage} from '@mantleframework/aws'
 import {getFilesByKey, getUserFilesByFileId} from '#entities/queries'
 import {createDownloadReadyNotification} from '#services/notification/transformers'

--- a/test/lambdas/scheduled/CleanupExpiredRecords/index.test.ts
+++ b/test/lambdas/scheduled/CleanupExpiredRecords/index.test.ts
@@ -6,34 +6,31 @@
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-vi.mock('@mantleframework/core', () => ({
-  defineScheduledHandler: vi.fn(() => (innerHandler: Function) => innerHandler)
-}))
+vi.mock('@mantleframework/core', () => ({defineScheduledHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
-vi.mock('@mantleframework/observability', () => ({
-  addMetadata: vi.fn(),
-  endSpan: vi.fn(),
-  logDebug: vi.fn(),
-  logError: vi.fn(),
-  logInfo: vi.fn(),
-  metrics: {addMetric: vi.fn()},
-  MetricUnit: {Count: 'Count'},
-  startSpan: vi.fn(() => ({}))
-}))
+vi.mock('@mantleframework/observability',
+  () => ({
+    addMetadata: vi.fn(),
+    endSpan: vi.fn(),
+    logDebug: vi.fn(),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => ({}))
+  }))
 
-vi.mock('@mantleframework/database/orm', () => ({
-  and: vi.fn((...args: unknown[]) => ({type: 'and', conditions: args})),
-  eq: vi.fn((col: unknown, val: unknown) => ({type: 'eq', col, val})),
-  lt: vi.fn((col: unknown, val: unknown) => ({type: 'lt', col, val})),
-  or: vi.fn((...args: unknown[]) => ({type: 'or', conditions: args}))
-}))
+vi.mock('@mantleframework/database/orm',
+  () => ({
+    and: vi.fn((...args: unknown[]) => ({type: 'and', conditions: args})),
+    eq: vi.fn((col: unknown, val: unknown) => ({type: 'eq', col, val})),
+    lt: vi.fn((col: unknown, val: unknown) => ({type: 'lt', col, val})),
+    or: vi.fn((...args: unknown[]) => ({type: 'or', conditions: args}))
+  }))
 
 // Create chainable mock for Drizzle client
 function createChainableMock(returnValue: unknown[] = []) {
-  const chain = {
-    returning: vi.fn(() => Promise.resolve(returnValue)),
-    where: vi.fn(() => chain)
-  }
+  const chain = {returning: vi.fn(() => Promise.resolve(returnValue)), where: vi.fn(() => chain)}
   const deleteMethod = vi.fn(() => chain)
   return {db: {delete: deleteMethod}, chain, deleteMethod}
 }
@@ -42,20 +39,18 @@ const drizzleMock = createChainableMock()
 
 vi.mock('#db/client', () => ({getDrizzleClient: vi.fn(() => Promise.resolve(drizzleMock.db))}))
 
-vi.mock('#db/schema', () => ({
-  fileDownloads: {fileId: 'fileId', status: 'status', updatedAt: 'updatedAt'},
-  sessions: {id: 'id', expiresAt: 'expiresAt'},
-  verification: {id: 'id', expiresAt: 'expiresAt'}
-}))
+vi.mock('#db/schema',
+  () => ({
+    fileDownloads: {fileId: 'fileId', status: 'status', updatedAt: 'updatedAt'},
+    sessions: {id: 'id', expiresAt: 'expiresAt'},
+    verification: {id: 'id', expiresAt: 'expiresAt'}
+  }))
 
 vi.mock('#types/enums', () => ({DownloadStatus: {Completed: 'Completed', Failed: 'Failed'}}))
 
-vi.mock('#utils/time', () => ({
-  secondsAgo: vi.fn(() => new Date('2024-01-01T00:00:00Z')),
-  TIME: {DAY_SEC: 86400}
-}))
+vi.mock('#utils/time', () => ({secondsAgo: vi.fn(() => new Date('2024-01-01T00:00:00Z')), TIME: {DAY_SEC: 86400}}))
 
-const {handler} = await import('#lambdas/scheduled/CleanupExpiredRecords/index.js')
+const {handler} = (await import('#lambdas/scheduled/CleanupExpiredRecords/index.js')) as any
 import {getDrizzleClient} from '#db/client'
 import {metrics} from '@mantleframework/observability'
 
@@ -77,8 +72,12 @@ describe('CleanupExpiredRecords Lambda', () => {
     let callCount = 0
     vi.mocked(getDrizzleClient).mockImplementation(() => {
       callCount++
-      if (callCount === 1) return Promise.resolve(fileDownloadsMock.db as never)
-      if (callCount === 2) return Promise.resolve(sessionsMock.db as never)
+      if (callCount === 1) {
+        return Promise.resolve(fileDownloadsMock.db as never)
+      }
+      if (callCount === 2) {
+        return Promise.resolve(sessionsMock.db as never)
+      }
       return Promise.resolve(verificationMock.db as never)
     })
 
@@ -111,7 +110,9 @@ describe('CleanupExpiredRecords Lambda', () => {
     let callCount = 0
     vi.mocked(getDrizzleClient).mockImplementation(() => {
       callCount++
-      if (callCount === 1) return Promise.resolve(failingMock.db as never)
+      if (callCount === 1) {
+        return Promise.resolve(failingMock.db as never)
+      }
       return Promise.resolve(successMock.db as never)
     })
 
@@ -133,8 +134,12 @@ describe('CleanupExpiredRecords Lambda', () => {
     let callCount = 0
     vi.mocked(getDrizzleClient).mockImplementation(() => {
       callCount++
-      if (callCount === 1) return Promise.resolve(successMock.db as never)
-      if (callCount === 2) return Promise.resolve(failingMock.db as never)
+      if (callCount === 1) {
+        return Promise.resolve(successMock.db as never)
+      }
+      if (callCount === 2) {
+        return Promise.resolve(failingMock.db as never)
+      }
       return Promise.resolve(verifyMock.db as never)
     })
 
@@ -156,8 +161,12 @@ describe('CleanupExpiredRecords Lambda', () => {
     let callCount = 0
     vi.mocked(getDrizzleClient).mockImplementation(() => {
       callCount++
-      if (callCount === 1) return Promise.resolve(successMock.db as never)
-      if (callCount === 2) return Promise.resolve(sessionMock.db as never)
+      if (callCount === 1) {
+        return Promise.resolve(successMock.db as never)
+      }
+      if (callCount === 2) {
+        return Promise.resolve(sessionMock.db as never)
+      }
       return Promise.resolve(failingMock.db as never)
     })
 

--- a/test/lambdas/scheduled/CleanupExpiredRecords/index.test.ts
+++ b/test/lambdas/scheduled/CleanupExpiredRecords/index.test.ts
@@ -5,6 +5,8 @@
  * CRITICAL: This Lambda uses getDrizzleClient() directly, not defineQuery.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {CleanupResult} from '#types/lambda'
 
 vi.mock('@mantleframework/core', () => ({defineScheduledHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
@@ -50,7 +52,7 @@ vi.mock('#types/enums', () => ({DownloadStatus: {Completed: 'Completed', Failed:
 
 vi.mock('#utils/time', () => ({secondsAgo: vi.fn(() => new Date('2024-01-01T00:00:00Z')), TIME: {DAY_SEC: 86400}}))
 
-const {handler} = (await import('#lambdas/scheduled/CleanupExpiredRecords/index.js')) as any
+const {handler} = (await import('#lambdas/scheduled/CleanupExpiredRecords/index.js')) as unknown as MockedHandlerModule<CleanupResult>
 import {getDrizzleClient} from '#db/client'
 import {metrics} from '@mantleframework/observability'
 

--- a/test/lambdas/scheduled/CleanupExpiredRecords/index.test.ts
+++ b/test/lambdas/scheduled/CleanupExpiredRecords/index.test.ts
@@ -5,8 +5,8 @@
  * CRITICAL: This Lambda uses getDrizzleClient() directly, not defineQuery.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
-import type {CleanupResult} from '#types/lambda'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as CleanupMod from '#lambdas/scheduled/CleanupExpiredRecords/index.js'
 
 vi.mock('@mantleframework/core', () => ({defineScheduledHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
@@ -52,7 +52,7 @@ vi.mock('#types/enums', () => ({DownloadStatus: {Completed: 'Completed', Failed:
 
 vi.mock('#utils/time', () => ({secondsAgo: vi.fn(() => new Date('2024-01-01T00:00:00Z')), TIME: {DAY_SEC: 86400}}))
 
-const {handler} = (await import('#lambdas/scheduled/CleanupExpiredRecords/index.js')) as unknown as MockedHandlerModule<CleanupResult>
+const {handler} = (await import('#lambdas/scheduled/CleanupExpiredRecords/index.js')) as unknown as MockedModule<typeof CleanupMod>
 import {getDrizzleClient} from '#db/client'
 import {metrics} from '@mantleframework/observability'
 
@@ -124,7 +124,7 @@ describe('CleanupExpiredRecords Lambda', () => {
     expect(result.sessionsDeleted).toBe(1)
     expect(result.verificationTokensDeleted).toBe(1)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]).toContain('FileDownloads cleanup failed')
+    expect((result.errors as string[])[0]).toContain('FileDownloads cleanup failed')
   })
 
   it('should continue cleanup when sessions fails', async () => {
@@ -151,7 +151,7 @@ describe('CleanupExpiredRecords Lambda', () => {
     expect(result.sessionsDeleted).toBe(0)
     expect(result.verificationTokensDeleted).toBe(1)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]).toContain('Sessions cleanup failed')
+    expect((result.errors as string[])[0]).toContain('Sessions cleanup failed')
   })
 
   it('should continue cleanup when verification fails', async () => {
@@ -178,7 +178,7 @@ describe('CleanupExpiredRecords Lambda', () => {
     expect(result.sessionsDeleted).toBe(1)
     expect(result.verificationTokensDeleted).toBe(0)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]).toContain('Verification cleanup failed')
+    expect((result.errors as string[])[0]).toContain('Verification cleanup failed')
   })
 
   it('should record errors for all failures but not throw', async () => {

--- a/test/lambdas/scheduled/PruneDevices/index.test.ts
+++ b/test/lambdas/scheduled/PruneDevices/index.test.ts
@@ -5,19 +5,12 @@
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-vi.mock('@mantleframework/core', () => ({
-  defineLambda: vi.fn(),
-  defineScheduledHandler: vi.fn(() => (innerHandler: Function) => innerHandler)
-}))
+vi.mock('@mantleframework/core',
+  () => ({defineLambda: vi.fn(), defineScheduledHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
 
 vi.mock('@mantleframework/env', () => ({
   getRequiredEnv: vi.fn((key: string) => {
-    const envs: Record<string, string> = {
-      APNS_TEAM: 'TEAM123',
-      APNS_KEY_ID: 'KEY123',
-      APNS_SIGNING_KEY: 'signing-key',
-      APNS_DEFAULT_TOPIC: 'com.app.test'
-    }
+    const envs: Record<string, string> = {APNS_TEAM: 'TEAM123', APNS_KEY_ID: 'KEY123', APNS_SIGNING_KEY: 'signing-key', APNS_DEFAULT_TOPIC: 'com.app.test'}
     return envs[key] ?? 'mock-value'
   }),
   getOptionalEnv: vi.fn((_key: string, defaultVal: string) => defaultVal)
@@ -34,21 +27,19 @@ vi.mock('@mantleframework/errors', () => {
   return {UnexpectedError}
 })
 
-vi.mock('@mantleframework/observability', () => ({
-  addMetadata: vi.fn(),
-  endSpan: vi.fn(),
-  logDebug: vi.fn(),
-  logError: vi.fn(),
-  logInfo: vi.fn(),
-  metrics: {addMetric: vi.fn()},
-  MetricUnit: {Count: 'Count'},
-  startSpan: vi.fn(() => ({}))
-}))
+vi.mock('@mantleframework/observability',
+  () => ({
+    addMetadata: vi.fn(),
+    endSpan: vi.fn(),
+    logDebug: vi.fn(),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => ({}))
+  }))
 
-vi.mock('#entities/queries', () => ({
-  deleteUserDevicesByDeviceId: vi.fn(),
-  getAllDevices: vi.fn()
-}))
+vi.mock('#entities/queries', () => ({deleteUserDevicesByDeviceId: vi.fn(), getAllDevices: vi.fn()}))
 
 vi.mock('#errors/custom-errors', () => ({
   Apns2Error: class Apns2Error extends Error {
@@ -74,21 +65,23 @@ vi.mock('apns2', () => {
   class MockApnsClient {
     send = mockApnsSend
   }
-  return {
-    ApnsClient: MockApnsClient,
-    Notification: vi.fn(),
-    Priority: {throttled: 5},
-    PushType: {background: 'background'}
-  }
+  return {ApnsClient: MockApnsClient, Notification: vi.fn(), Priority: {throttled: 5}, PushType: {background: 'background'}}
 })
 
-const {handler} = await import('#lambdas/scheduled/PruneDevices/index.js')
+const {handler} = (await import('#lambdas/scheduled/PruneDevices/index.js')) as any
 import {deleteUserDevicesByDeviceId, getAllDevices} from '#entities/queries'
 import {deleteDevice} from '#services/device/deviceService'
 import {metrics} from '@mantleframework/observability'
 
 describe('PruneDevices Lambda', () => {
-  const mockDevice = {deviceId: 'dev-1', name: 'iPhone', token: 'apns-token', systemVersion: '17.0', systemName: 'iOS', endpointArn: 'arn:aws:sns:endpoint/dev-1'}
+  const mockDevice = {
+    deviceId: 'dev-1',
+    name: 'iPhone',
+    token: 'apns-token',
+    systemVersion: '17.0',
+    systemName: 'iOS',
+    endpointArn: 'arn:aws:sns:endpoint/dev-1'
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -157,7 +150,9 @@ describe('PruneDevices Lambda', () => {
     let callCount = 0
     mockApnsSend.mockImplementation(() => {
       callCount++
-      if (callCount === 1) return Promise.resolve({})
+      if (callCount === 1) {
+        return Promise.resolve({})
+      }
       return Promise.reject({reason: 'Unregistered', statusCode: 410})
     })
     vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined as never)

--- a/test/lambdas/scheduled/PruneDevices/index.test.ts
+++ b/test/lambdas/scheduled/PruneDevices/index.test.ts
@@ -4,6 +4,8 @@
  * Tests device pruning logic based on APNS health checks.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {PruneDevicesResult} from '#types/lambda'
 
 vi.mock('@mantleframework/core',
   () => ({defineLambda: vi.fn(), defineScheduledHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
@@ -68,7 +70,7 @@ vi.mock('apns2', () => {
   return {ApnsClient: MockApnsClient, Notification: vi.fn(), Priority: {throttled: 5}, PushType: {background: 'background'}}
 })
 
-const {handler} = (await import('#lambdas/scheduled/PruneDevices/index.js')) as any
+const {handler} = (await import('#lambdas/scheduled/PruneDevices/index.js')) as unknown as MockedHandlerModule<PruneDevicesResult>
 import {deleteUserDevicesByDeviceId, getAllDevices} from '#entities/queries'
 import {deleteDevice} from '#services/device/deviceService'
 import {metrics} from '@mantleframework/observability'

--- a/test/lambdas/scheduled/PruneDevices/index.test.ts
+++ b/test/lambdas/scheduled/PruneDevices/index.test.ts
@@ -4,8 +4,8 @@
  * Tests device pruning logic based on APNS health checks.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
-import type {PruneDevicesResult} from '#types/lambda'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as PruneMod from '#lambdas/scheduled/PruneDevices/index.js'
 
 vi.mock('@mantleframework/core',
   () => ({defineLambda: vi.fn(), defineScheduledHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler)}))
@@ -70,7 +70,7 @@ vi.mock('apns2', () => {
   return {ApnsClient: MockApnsClient, Notification: vi.fn(), Priority: {throttled: 5}, PushType: {background: 'background'}}
 })
 
-const {handler} = (await import('#lambdas/scheduled/PruneDevices/index.js')) as unknown as MockedHandlerModule<PruneDevicesResult>
+const {handler} = (await import('#lambdas/scheduled/PruneDevices/index.js')) as unknown as MockedModule<typeof PruneMod>
 import {deleteUserDevicesByDeviceId, getAllDevices} from '#entities/queries'
 import {deleteDevice} from '#services/device/deviceService'
 import {metrics} from '@mantleframework/observability'
@@ -136,7 +136,7 @@ describe('PruneDevices Lambda', () => {
     expect(result.devicesChecked).toBe(1)
     expect(result.devicesPruned).toBe(0)
     expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]).toContain('Failed to properly remove device dev-1')
+    expect((result.errors as string[])[0]).toContain('Failed to properly remove device dev-1')
   })
 
   it('should throw UnexpectedError for non-APNS errors', async () => {

--- a/test/lambdas/sqs/SendPushNotification/index.test.ts
+++ b/test/lambdas/sqs/SendPushNotification/index.test.ts
@@ -5,27 +5,29 @@
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-vi.mock('@mantleframework/core', () => ({
-  defineSqsHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
-  err: vi.fn((error) => ({ok: false, error})),
-  isErr: vi.fn((result) => !result.ok),
-  isOk: vi.fn((result) => result.ok),
-  ok: vi.fn((value) => ({ok: true, value}))
-}))
+vi.mock('@mantleframework/core',
+  () => ({
+    defineSqsHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
+    err: vi.fn((error) => ({ok: false, error})),
+    isErr: vi.fn((result) => !result.ok),
+    isOk: vi.fn((result) => result.ok),
+    ok: vi.fn((value) => ({ok: true, value}))
+  }))
 
 vi.mock('@mantleframework/aws', () => ({publish: vi.fn()}))
 
-vi.mock('@mantleframework/observability', () => ({
-  addAnnotation: vi.fn(),
-  addMetadata: vi.fn(),
-  endSpan: vi.fn(),
-  logDebug: vi.fn(),
-  logError: vi.fn(),
-  logInfo: vi.fn(),
-  metrics: {addMetric: vi.fn()},
-  MetricUnit: {Count: 'Count'},
-  startSpan: vi.fn(() => ({}))
-}))
+vi.mock('@mantleframework/observability',
+  () => ({
+    addAnnotation: vi.fn(),
+    addMetadata: vi.fn(),
+    endSpan: vi.fn(),
+    logDebug: vi.fn(),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => ({}))
+  }))
 
 vi.mock('@mantleframework/validation', () => ({validateSchema: vi.fn()}))
 
@@ -40,23 +42,21 @@ vi.mock('@mantleframework/errors', () => {
   return {UnexpectedError}
 })
 
-vi.mock('#entities/queries', () => ({
-  getDevice: vi.fn(),
-  getUserDevicesByUserId: vi.fn()
-}))
+vi.mock('#entities/queries', () => ({getDevice: vi.fn(), getUserDevicesByUserId: vi.fn()}))
 
 vi.mock('#errors/custom-errors', () => ({providerFailureErrorMessage: 'AWS request failed'}))
 
-vi.mock('#services/notification/transformers', () => ({
-  transformToAPNSAlertNotification: vi.fn(() => ({Message: 'alert', TargetArn: 'arn:test'})),
-  transformToAPNSNotification: vi.fn(() => ({Message: 'background', TargetArn: 'arn:test'}))
-}))
+vi.mock('#services/notification/transformers',
+  () => ({
+    transformToAPNSAlertNotification: vi.fn(() => ({Message: 'alert', TargetArn: 'arn:test'})),
+    transformToAPNSNotification: vi.fn(() => ({Message: 'background', TargetArn: 'arn:test'}))
+  }))
 
 vi.mock('#services/notification/endpointCleanup', () => ({cleanupDisabledEndpoints: vi.fn(() => Promise.resolve([]))}))
 
 vi.mock('#types/schemas', () => ({pushNotificationAttributesSchema: {}}))
 
-const {handler} = await import('#lambdas/sqs/SendPushNotification/index.js')
+const {handler} = (await import('#lambdas/sqs/SendPushNotification/index.js')) as any
 import {publish} from '@mantleframework/aws'
 import {validateSchema} from '@mantleframework/validation'
 import {getDevice, getUserDevicesByUserId} from '#entities/queries'
@@ -68,18 +68,22 @@ describe('SendPushNotification Lambda', () => {
   const makeRecord = (notificationType = 'DownloadReadyNotification', userId = 'user-1') => ({
     messageId: 'msg-1',
     body: JSON.stringify({file: {fileId: 'file-1'}, notificationType}),
-    messageAttributes: {
-      notificationType: {stringValue: notificationType},
-      userId: {stringValue: userId}
-    }
+    messageAttributes: {notificationType: {stringValue: notificationType}, userId: {stringValue: userId}}
   })
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(validateSchema).mockReturnValue({success: true, data: {notificationType: 'DownloadReadyNotification', userId: 'user-1'}})
     vi.mocked(getUserDevicesByUserId).mockResolvedValue([{userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()}])
-    vi.mocked(getDevice).mockResolvedValue({deviceId: 'dev-1', name: 'iPhone', token: 'tok', systemVersion: '17', systemName: 'iOS', endpointArn: 'arn:aws:sns:endpoint/dev-1'})
-    vi.mocked(publish).mockResolvedValue({MessageId: 'msg-pub-1'})
+    vi.mocked(getDevice).mockResolvedValue({
+      deviceId: 'dev-1',
+      name: 'iPhone',
+      token: 'tok',
+      systemVersion: '17',
+      systemName: 'iOS',
+      endpointArn: 'arn:aws:sns:endpoint/dev-1'
+    })
+    vi.mocked(publish).mockResolvedValue({MessageId: 'msg-pub-1', $metadata: {}})
   })
 
   it('should send background notification to a single device', async () => {
@@ -111,7 +115,7 @@ describe('SendPushNotification Lambda', () => {
   })
 
   it('should discard message with invalid attributes', async () => {
-    vi.mocked(validateSchema).mockReturnValue({success: false, errors: ['invalid']})
+    vi.mocked(validateSchema).mockReturnValue({success: false, errors: {field: ['invalid']}})
 
     await handler(makeRecord())
 
@@ -124,12 +128,22 @@ describe('SendPushNotification Lambda', () => {
       {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
       {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
     ])
-    vi.mocked(getDevice)
-      .mockResolvedValueOnce({deviceId: 'dev-1', name: 'iPhone', token: 'tok1', systemVersion: '17', systemName: 'iOS', endpointArn: 'arn:aws:sns:endpoint/dev-1'})
-      .mockResolvedValueOnce({deviceId: 'dev-2', name: 'iPad', token: 'tok2', systemVersion: '17', systemName: 'iPadOS', endpointArn: 'arn:aws:sns:endpoint/dev-2'})
-    vi.mocked(publish)
-      .mockResolvedValueOnce({MessageId: 'msg-1'})
-      .mockRejectedValueOnce(new Error('SNS failure'))
+    vi.mocked(getDevice).mockResolvedValueOnce({
+      deviceId: 'dev-1',
+      name: 'iPhone',
+      token: 'tok1',
+      systemVersion: '17',
+      systemName: 'iOS',
+      endpointArn: 'arn:aws:sns:endpoint/dev-1'
+    }).mockResolvedValueOnce({
+      deviceId: 'dev-2',
+      name: 'iPad',
+      token: 'tok2',
+      systemVersion: '17',
+      systemName: 'iPadOS',
+      endpointArn: 'arn:aws:sns:endpoint/dev-2'
+    })
+    vi.mocked(publish).mockResolvedValueOnce({MessageId: 'msg-1', $metadata: {}}).mockRejectedValueOnce(new Error('SNS failure'))
 
     await handler(makeRecord())
 
@@ -165,12 +179,15 @@ describe('SendPushNotification Lambda', () => {
       {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
       {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
     ])
-    vi.mocked(getDevice)
-      .mockResolvedValueOnce({deviceId: 'dev-1', name: 'iPhone', token: 'tok1', systemVersion: '17', systemName: 'iOS', endpointArn: 'arn:endpoint/dev-1'})
-      .mockResolvedValueOnce({deviceId: 'dev-2', name: 'iPad', token: 'tok2', systemVersion: '17', systemName: 'iPadOS', endpointArn: 'arn:endpoint/dev-2'})
-    vi.mocked(publish)
-      .mockResolvedValueOnce({MessageId: 'msg-1'})
-      .mockRejectedValueOnce(new Error('fail'))
+    vi.mocked(getDevice).mockResolvedValueOnce({
+      deviceId: 'dev-1',
+      name: 'iPhone',
+      token: 'tok1',
+      systemVersion: '17',
+      systemName: 'iOS',
+      endpointArn: 'arn:endpoint/dev-1'
+    }).mockResolvedValueOnce({deviceId: 'dev-2', name: 'iPad', token: 'tok2', systemVersion: '17', systemName: 'iPadOS', endpointArn: 'arn:endpoint/dev-2'})
+    vi.mocked(publish).mockResolvedValueOnce({MessageId: 'msg-1', $metadata: {}}).mockRejectedValueOnce(new Error('fail'))
 
     await expect(handler(makeRecord())).resolves.toBeUndefined()
   })
@@ -202,13 +219,16 @@ describe('SendPushNotification Lambda', () => {
       {userId: 'user-1', deviceId: 'dev-1', createdAt: new Date()},
       {userId: 'user-1', deviceId: 'dev-2', createdAt: new Date()}
     ])
-    vi.mocked(getDevice)
-      .mockResolvedValueOnce({deviceId: 'dev-1', name: 'iPhone', token: 'tok1', systemVersion: '17', systemName: 'iOS', endpointArn: 'arn:endpoint/dev-1'})
-      .mockResolvedValueOnce({deviceId: 'dev-2', name: 'iPad', token: 'tok2', systemVersion: '17', systemName: 'iPadOS', endpointArn: 'arn:endpoint/dev-2'})
+    vi.mocked(getDevice).mockResolvedValueOnce({
+      deviceId: 'dev-1',
+      name: 'iPhone',
+      token: 'tok1',
+      systemVersion: '17',
+      systemName: 'iOS',
+      endpointArn: 'arn:endpoint/dev-1'
+    }).mockResolvedValueOnce({deviceId: 'dev-2', name: 'iPad', token: 'tok2', systemVersion: '17', systemName: 'iPadOS', endpointArn: 'arn:endpoint/dev-2'})
     // First device succeeds, second has disabled endpoint
-    vi.mocked(publish)
-      .mockResolvedValueOnce({MessageId: 'msg-1'})
-      .mockRejectedValueOnce(new Error('EndpointDisabled'))
+    vi.mocked(publish).mockResolvedValueOnce({MessageId: 'msg-1', $metadata: {}}).mockRejectedValueOnce(new Error('EndpointDisabled'))
     vi.mocked(cleanupDisabledEndpoints).mockRejectedValue(new Error('cleanup failed'))
 
     // Should not throw because at least one device succeeded

--- a/test/lambdas/sqs/SendPushNotification/index.test.ts
+++ b/test/lambdas/sqs/SendPushNotification/index.test.ts
@@ -4,6 +4,7 @@
  * Tests push notification delivery to user devices via SNS/APNS.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/core',
   () => ({
@@ -56,7 +57,7 @@ vi.mock('#services/notification/endpointCleanup', () => ({cleanupDisabledEndpoin
 
 vi.mock('#types/schemas', () => ({pushNotificationAttributesSchema: {}}))
 
-const {handler} = (await import('#lambdas/sqs/SendPushNotification/index.js')) as any
+const {handler} = (await import('#lambdas/sqs/SendPushNotification/index.js')) as unknown as MockedHandlerModule
 import {publish} from '@mantleframework/aws'
 import {validateSchema} from '@mantleframework/validation'
 import {getDevice, getUserDevicesByUserId} from '#entities/queries'

--- a/test/lambdas/sqs/SendPushNotification/index.test.ts
+++ b/test/lambdas/sqs/SendPushNotification/index.test.ts
@@ -4,7 +4,8 @@
  * Tests push notification delivery to user devices via SNS/APNS.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedHandlerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as PushMod from '#lambdas/sqs/SendPushNotification/index.js'
 
 vi.mock('@mantleframework/core',
   () => ({
@@ -57,7 +58,7 @@ vi.mock('#services/notification/endpointCleanup', () => ({cleanupDisabledEndpoin
 
 vi.mock('#types/schemas', () => ({pushNotificationAttributesSchema: {}}))
 
-const {handler} = (await import('#lambdas/sqs/SendPushNotification/index.js')) as unknown as MockedHandlerModule
+const {handler} = (await import('#lambdas/sqs/SendPushNotification/index.js')) as unknown as MockedModule<typeof PushMod>
 import {publish} from '@mantleframework/aws'
 import {validateSchema} from '@mantleframework/validation'
 import {getDevice, getUserDevicesByUserId} from '#entities/queries'

--- a/test/lambdas/standalone/ApiGatewayAuthorizer/index.test.ts
+++ b/test/lambdas/standalone/ApiGatewayAuthorizer/index.test.ts
@@ -4,7 +4,8 @@
  * Tests API key validation, session token extraction, and policy generation.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import type {MockedAuthorizerModule} from '#test/helpers/handler-test-types'
+import type {MockedModule} from '#test/helpers/handler-test-types'
+import type * as AuthorizerMod from '#lambdas/standalone/ApiGatewayAuthorizer/index.js'
 
 vi.mock('@mantleframework/aws', () => ({getApiKeys: vi.fn(), getUsage: vi.fn(), getUsagePlans: vi.fn()}))
 
@@ -54,7 +55,7 @@ vi.mock('#domain/auth/sessionService', () => ({validateSessionToken: vi.fn()}))
 
 vi.mock('#errors/custom-errors', () => ({providerFailureErrorMessage: 'AWS request failed'}))
 
-const {handler, generateAllow} = (await import('#lambdas/standalone/ApiGatewayAuthorizer/index.js')) as unknown as MockedAuthorizerModule
+const {handler, generateAllow} = (await import('#lambdas/standalone/ApiGatewayAuthorizer/index.js')) as unknown as MockedModule<typeof AuthorizerMod>
 import {getApiKeys, getUsage, getUsagePlans} from '@mantleframework/aws'
 import {validateSessionToken} from '#domain/auth/sessionService'
 import {getOptionalEnv} from '@mantleframework/env'
@@ -83,8 +84,8 @@ describe('ApiGatewayAuthorizer Lambda', () => {
       const result = generateAllow('user-1', methodArn)
 
       expect(result.principalId).toBe('user-1')
-      expect(result.policyDocument.Statement[0]!.Effect).toBe('Allow')
-      expect(result.policyDocument.Statement[0]!.Resource).toBe(methodArn)
+      expect((result.policyDocument as {Statement: {Effect: string; Resource: string}[]}).Statement[0]!.Effect).toBe('Allow')
+      expect((result.policyDocument as {Statement: {Effect: string; Resource: string}[]}).Statement[0]!.Resource).toBe(methodArn)
       expect(result.policyDocument.Version).toBe('2012-10-17')
     })
 

--- a/test/lambdas/standalone/ApiGatewayAuthorizer/index.test.ts
+++ b/test/lambdas/standalone/ApiGatewayAuthorizer/index.test.ts
@@ -4,6 +4,7 @@
  * Tests API key validation, session token extraction, and policy generation.
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import type {MockedAuthorizerModule} from '#test/helpers/handler-test-types'
 
 vi.mock('@mantleframework/aws', () => ({getApiKeys: vi.fn(), getUsage: vi.fn(), getUsagePlans: vi.fn()}))
 
@@ -53,7 +54,7 @@ vi.mock('#domain/auth/sessionService', () => ({validateSessionToken: vi.fn()}))
 
 vi.mock('#errors/custom-errors', () => ({providerFailureErrorMessage: 'AWS request failed'}))
 
-const {handler, generateAllow} = (await import('#lambdas/standalone/ApiGatewayAuthorizer/index.js')) as any
+const {handler, generateAllow} = (await import('#lambdas/standalone/ApiGatewayAuthorizer/index.js')) as unknown as MockedAuthorizerModule
 import {getApiKeys, getUsage, getUsagePlans} from '@mantleframework/aws'
 import {validateSessionToken} from '#domain/auth/sessionService'
 import {getOptionalEnv} from '@mantleframework/env'
@@ -82,8 +83,8 @@ describe('ApiGatewayAuthorizer Lambda', () => {
       const result = generateAllow('user-1', methodArn)
 
       expect(result.principalId).toBe('user-1')
-      expect(result.policyDocument.Statement[0].Effect).toBe('Allow')
-      expect(result.policyDocument.Statement[0].Resource).toBe(methodArn)
+      expect(result.policyDocument.Statement[0]!.Effect).toBe('Allow')
+      expect(result.policyDocument.Statement[0]!.Resource).toBe(methodArn)
       expect(result.policyDocument.Version).toBe('2012-10-17')
     })
 

--- a/test/lambdas/standalone/ApiGatewayAuthorizer/index.test.ts
+++ b/test/lambdas/standalone/ApiGatewayAuthorizer/index.test.ts
@@ -5,17 +5,14 @@
  */
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-vi.mock('@mantleframework/aws', () => ({
-  getApiKeys: vi.fn(),
-  getUsage: vi.fn(),
-  getUsagePlans: vi.fn()
-}))
+vi.mock('@mantleframework/aws', () => ({getApiKeys: vi.fn(), getUsage: vi.fn(), getUsagePlans: vi.fn()}))
 
-vi.mock('@mantleframework/core', () => ({
-  defineAuthorizerHandler: vi.fn(() => (innerHandler: Function) => innerHandler),
-  defineLambda: vi.fn(),
-  UserStatus: {Authenticated: 'Authenticated', Anonymous: 'Anonymous'}
-}))
+vi.mock('@mantleframework/core',
+  () => ({
+    defineAuthorizerHandler: vi.fn(() => (innerHandler: (...a: unknown[]) => unknown) => innerHandler),
+    defineLambda: vi.fn(),
+    UserStatus: {Authenticated: 'Authenticated', Anonymous: 'Anonymous'}
+  }))
 
 vi.mock('@mantleframework/env', () => ({
   getOptionalEnv: vi.fn((key: string, defaultVal: string) => {
@@ -23,9 +20,7 @@ vi.mock('@mantleframework/env', () => ({
     return envs[key] ?? defaultVal
   }),
   getRequiredEnv: vi.fn((key: string) => {
-    const envs: Record<string, string> = {
-      MULTI_AUTHENTICATION_PATH_PARTS: 'device/register,device/event,files'
-    }
+    const envs: Record<string, string> = {MULTI_AUTHENTICATION_PATH_PARTS: 'device/register,device/event,files'}
     return envs[key] ?? 'mock-value'
   })
 }))
@@ -41,23 +36,24 @@ vi.mock('@mantleframework/errors', () => {
   return {UnexpectedError}
 })
 
-vi.mock('@mantleframework/observability', () => ({
-  addAnnotation: vi.fn(),
-  addMetadata: vi.fn(),
-  endSpan: vi.fn(),
-  logDebug: vi.fn(),
-  logError: vi.fn(),
-  logInfo: vi.fn(),
-  metrics: {addMetric: vi.fn()},
-  MetricUnit: {Count: 'Count'},
-  startSpan: vi.fn(() => ({}))
-}))
+vi.mock('@mantleframework/observability',
+  () => ({
+    addAnnotation: vi.fn(),
+    addMetadata: vi.fn(),
+    endSpan: vi.fn(),
+    logDebug: vi.fn(),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    metrics: {addMetric: vi.fn()},
+    MetricUnit: {Count: 'Count'},
+    startSpan: vi.fn(() => ({}))
+  }))
 
 vi.mock('#domain/auth/sessionService', () => ({validateSessionToken: vi.fn()}))
 
 vi.mock('#errors/custom-errors', () => ({providerFailureErrorMessage: 'AWS request failed'}))
 
-const {handler, generateAllow} = await import('#lambdas/standalone/ApiGatewayAuthorizer/index.js')
+const {handler, generateAllow} = (await import('#lambdas/standalone/ApiGatewayAuthorizer/index.js')) as any
 import {getApiKeys, getUsage, getUsagePlans} from '@mantleframework/aws'
 import {validateSessionToken} from '#domain/auth/sessionService'
 import {getOptionalEnv} from '@mantleframework/env'
@@ -68,11 +64,7 @@ describe('ApiGatewayAuthorizer Lambda', () => {
   const validApiKey = 'valid-api-key-12345'
 
   const makeEvent = (overrides: Record<string, unknown> = {}) => ({
-    event: {
-      path: '/files',
-      requestContext: {identity: {sourceIp: '192.168.1.1'}},
-      ...overrides
-    },
+    event: {path: '/files', requestContext: {identity: {sourceIp: '192.168.1.1'}}, ...overrides},
     headers: {} as Record<string, string | undefined>,
     queryStringParameters: {ApiKey: validApiKey} as Record<string, string>,
     methodArn
@@ -80,9 +72,9 @@ describe('ApiGatewayAuthorizer Lambda', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(getApiKeys).mockResolvedValue({items: [{id: 'key-1', value: validApiKey, enabled: true}]})
-    vi.mocked(getUsagePlans).mockResolvedValue({items: [{id: 'plan-1'}]})
-    vi.mocked(getUsage).mockResolvedValue({items: {'key-1': [[100, 50]]}})
+    vi.mocked(getApiKeys).mockResolvedValue({items: [{id: 'key-1', value: validApiKey, enabled: true}], $metadata: {}})
+    vi.mocked(getUsagePlans).mockResolvedValue({items: [{id: 'plan-1'}], $metadata: {}})
+    vi.mocked(getUsage).mockResolvedValue({items: {'key-1': [[100, 50]]}, $metadata: {}})
   })
 
   describe('generateAllow', () => {
@@ -131,19 +123,19 @@ describe('ApiGatewayAuthorizer Lambda', () => {
     })
 
     it('should throw Unauthorized when API key does not match', async () => {
-      vi.mocked(getApiKeys).mockResolvedValue({items: [{id: 'key-1', value: 'different-key', enabled: true}]})
+      vi.mocked(getApiKeys).mockResolvedValue({items: [{id: 'key-1', value: 'different-key', enabled: true}], $metadata: {}})
 
       await expect(handler(makeEvent())).rejects.toThrow('Unauthorized')
     })
 
     it('should throw Unauthorized when API key is disabled', async () => {
-      vi.mocked(getApiKeys).mockResolvedValue({items: [{id: 'key-1', value: validApiKey, enabled: false}]})
+      vi.mocked(getApiKeys).mockResolvedValue({items: [{id: 'key-1', value: validApiKey, enabled: false}], $metadata: {}})
 
       await expect(handler(makeEvent())).rejects.toThrow('Unauthorized')
     })
 
     it('should throw UnexpectedError when getApiKeys returns no items', async () => {
-      vi.mocked(getApiKeys).mockResolvedValue({items: undefined})
+      vi.mocked(getApiKeys).mockResolvedValue({items: undefined, $metadata: {}})
 
       await expect(handler(makeEvent())).rejects.toThrow('AWS request failed')
     })
@@ -229,8 +221,12 @@ describe('ApiGatewayAuthorizer Lambda', () => {
 
     it('should not bypass auth in production', async () => {
       vi.mocked(getOptionalEnv).mockImplementation((key: string, defaultVal: string) => {
-        if (key === 'NODE_ENV') return 'production'
-        if (key === 'RESERVED_CLIENT_IP') return '104.1.88.244'
+        if (key === 'NODE_ENV') {
+          return 'production'
+        }
+        if (key === 'RESERVED_CLIENT_IP') {
+          return '104.1.88.244'
+        }
         return defaultVal
       })
       const event = makeEvent({path: '/protected-resource'})
@@ -268,14 +264,14 @@ describe('ApiGatewayAuthorizer Lambda', () => {
     })
 
     it('should throw UnexpectedError when getUsagePlans returns no items', async () => {
-      vi.mocked(getUsagePlans).mockResolvedValue({items: undefined})
+      vi.mocked(getUsagePlans).mockResolvedValue({items: undefined, $metadata: {}})
       const event = makeEvent({path: '/files'})
 
       await expect(handler(event)).rejects.toThrow('AWS request failed')
     })
 
     it('should throw UnexpectedError when getUsage returns no items', async () => {
-      vi.mocked(getUsage).mockResolvedValue({items: undefined})
+      vi.mocked(getUsage).mockResolvedValue({items: undefined, $metadata: {}})
       const event = makeEvent({path: '/files'})
 
       await expect(handler(event)).rejects.toThrow('AWS request failed')


### PR DESCRIPTION
## Summary
- Fix 199 TypeScript type errors across 16 Lambda handler test files that broke `check:test:types` on master
- Bump hono from 4.12.12 to 4.12.14 (security fix for JSX attribute name validation + AWS Lambda invalid header handling)
- Replace banned `Function` type with explicit callable signatures in mock declarations
- Apply dprint formatting to entity query tests

## Root Cause
Handler tests mock `define*Handler` factories to pass through the inner function directly. At runtime this works, but TypeScript infers the outer Lambda signature `(event, context)` from the source module, causing argument count mismatches, missing `$metadata` on AWS SDK outputs, and inaccessible response properties.

## Fix
- Cast mocked handler imports as `any` (16 files) — runtime types intentionally differ from static types in this test pattern
- Add `$metadata: {}` to AWS SDK mock return values
- Add missing File schema fields (`duration`, `uploadDate`, `viewCount`, `thumbnailUrl`)
- Fix `validateSchema` mock error type (`Record<string, string[]>` not `string[]`)
- Replace `Function` type with `(...a: unknown[]) => unknown` in mock declarations

## Test plan
- [x] `pnpm run check:test:types` — 0 errors (was 199)
- [x] `pnpm run precheck` — 0 errors, 34 warnings (all pre-existing)
- [x] `pnpm run test` — 509 passed, 11 skipped

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)