### PR TITLE
feat(notifications): server-side download progress at 25% milestones

### DIFF
--- a/src/lambdas/sqs/StartFileUpload/downloadOrchestrator.ts
+++ b/src/lambdas/sqs/StartFileUpload/downloadOrchestrator.ts
@@ -14,7 +14,11 @@ import type {ValidatedDownloadQueueMessage} from '#types/schemas'
 import {DownloadStatus, FileStatus} from '#types/enums'
 import {getRequiredEnv} from '@mantleframework/env'
 import {UnexpectedError} from '@mantleframework/errors'
-import {dispatchDownloadStartedNotifications, dispatchMetadataNotifications} from '#services/notification/dispatchService'
+import {
+  dispatchDownloadProgressNotifications,
+  dispatchDownloadStartedNotifications,
+  dispatchMetadataNotifications
+} from '#services/notification/dispatchService'
 import {handleDownloadFailure, tryCloseCookieExpirationIssue} from './failureHandler.js'
 import {updateDownloadState} from '#services/download/stateManager'
 import {checkS3FileExists, recoverFromS3} from './s3Recovery.js'
@@ -80,13 +84,25 @@ export async function processDownloadRequest(message: ValidatedDownloadQueueMess
 
   await dispatchMetadataNotifications(fileId, videoInfo)
   await updateFile(fileId, {status: FileStatus.Downloading})
-  await dispatchDownloadStartedNotifications(fileId, videoInfo)
+
+  // Dispatch DownloadStartedNotification; capture userIds for progress notifications
+  const notifyUserIds = await dispatchDownloadStartedNotifications(fileId, videoInfo)
 
   // Step 2: Download video to S3
   logDebug('downloadVideoToS3 <=', {url: fileUrl, bucket, key: fileName})
   let uploadResult
+  let lastDispatchedPercent = 0
   try {
-    uploadResult = await downloadVideoToS3Traced(fileUrl, bucket, fileName)
+    uploadResult = await downloadVideoToS3Traced(fileUrl, bucket, fileName, (percent) => {
+      if (percent <= lastDispatchedPercent) {
+        return
+      }
+      lastDispatchedPercent = percent
+      // mantle-ignore: C58 — fire-and-forget; Lambda has 900s timeout, progress notifications are advisory
+      dispatchDownloadProgressNotifications(fileId, percent, notifyUserIds).catch((err) => {
+        logDebug('DownloadProgressNotification dispatch failed (non-critical)', {fileId, percent, error: err instanceof Error ? err.message : String(err)})
+      })
+    })
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error))
     const result = await handleDownloadFailure(fileId, fileUrl, err, correlationId, videoInfoResult, existingRetryCount, existingMaxRetries)

--- a/src/services/download/youtubeTracing.ts
+++ b/src/services/download/youtubeTracing.ts
@@ -49,11 +49,12 @@ export async function fetchVideoInfoTraced(fileUrl: string, fileId: string): Pro
 export async function downloadVideoToS3Traced(
   fileUrl: string,
   bucket: S3BucketName,
-  fileName: string
+  fileName: string,
+  onProgress?: (percent: number) => void
 ): Promise<{fileSize: number; s3Url: string; duration: number}> {
   const span = startSpan('yt-dlp-download-to-s3')
   try {
-    const result = await youtubeCircuitBreaker.execute(() => downloadVideoToS3(fileUrl, bucket, fileName)) as {
+    const result = await youtubeCircuitBreaker.execute(() => downloadVideoToS3(fileUrl, bucket, fileName, {onProgress})) as {
       fileSize: number
       s3Url: string
       duration: number

--- a/src/services/notification/dispatchService.ts
+++ b/src/services/notification/dispatchService.ts
@@ -10,7 +10,12 @@ import {getUserFilesByFileId} from '#entities/queries'
 import {sendMessage} from '@mantleframework/aws'
 import {logDebug, logInfo} from '@mantleframework/observability'
 import {getRequiredEnv} from '@mantleframework/env'
-import {createDownloadStartedNotification, createFailureNotification, createMetadataNotification} from '#services/notification/transformers'
+import {
+  createDownloadProgressNotification,
+  createDownloadStartedNotification,
+  createFailureNotification,
+  createMetadataNotification
+} from '#services/notification/transformers'
 import type {YtDlpVideoInfo} from '#types/youtube'
 
 /**
@@ -46,8 +51,9 @@ export async function dispatchMetadataNotifications(fileId: string, videoInfo: Y
  *
  * @param fileId - The video ID
  * @param videoInfo - Video metadata from yt-dlp
+ * @returns The list of userIds that were notified (for reuse in progress notifications)
  */
-export async function dispatchDownloadStartedNotifications(fileId: string, videoInfo: YtDlpVideoInfo): Promise<void> {
+export async function dispatchDownloadStartedNotifications(fileId: string, videoInfo: YtDlpVideoInfo): Promise<string[]> {
   const queueUrl = getRequiredEnv('SNS_QUEUE_URL')
 
   const userFiles = await getUserFilesByFileId(fileId)
@@ -55,7 +61,7 @@ export async function dispatchDownloadStartedNotifications(fileId: string, video
 
   if (userIds.length === 0) {
     logDebug('No users waiting for file, skipping DownloadStartedNotification')
-    return
+    return []
   }
 
   const results = await Promise.allSettled(userIds.map((userId) => {
@@ -65,6 +71,31 @@ export async function dispatchDownloadStartedNotifications(fileId: string, video
   const failed = results.filter((r) => r.status === 'rejected').length
 
   logInfo('Dispatched DownloadStartedNotifications', {fileId, succeeded: userIds.length - failed, failed})
+  return userIds
+}
+
+/**
+ * Dispatch DownloadProgressNotification to a pre-fetched list of users.
+ * Reuses the userIds from dispatchDownloadStartedNotifications to avoid a DB round-trip per milestone.
+ *
+ * @param fileId - The video ID
+ * @param progressPercent - Milestone percentage (25, 50, or 75)
+ * @param userIds - Pre-fetched list of userIds waiting for this file
+ */
+export async function dispatchDownloadProgressNotifications(fileId: string, progressPercent: number, userIds: string[]): Promise<void> {
+  if (userIds.length === 0) {
+    return
+  }
+
+  const queueUrl = getRequiredEnv('SNS_QUEUE_URL')
+
+  const results = await Promise.allSettled(userIds.map((userId) => {
+    const {messageBody, messageAttributes} = createDownloadProgressNotification(fileId, progressPercent, userId)
+    return sendMessage({QueueUrl: queueUrl, MessageBody: messageBody, MessageAttributes: messageAttributes})
+  }))
+  const failed = results.filter((r) => r.status === 'rejected').length
+
+  logInfo('Dispatched DownloadProgressNotifications', {fileId, percent: progressPercent, succeeded: userIds.length - failed, failed})
 }
 
 /**

--- a/src/services/notification/transformers.ts
+++ b/src/services/notification/transformers.ts
@@ -5,7 +5,13 @@
  * This is an adapter layer that bridges domain models to infrastructure message formats.
  */
 import type {File} from '#types/domainModels'
-import type {DownloadReadyNotification, DownloadStartedNotification, FailureNotification, MetadataNotification} from '#types/notificationTypes'
+import type {
+  DownloadProgressNotification,
+  DownloadReadyNotification,
+  DownloadStartedNotification,
+  FailureNotification,
+  MetadataNotification
+} from '#types/notificationTypes'
 import type {YtDlpVideoInfo} from '#types/youtube'
 import {stringAttribute} from '@mantleframework/aws'
 
@@ -75,6 +81,25 @@ export function createDownloadStartedNotification(
   return {
     messageBody: JSON.stringify({file, notificationType: 'DownloadStartedNotification'}),
     messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('DownloadStartedNotification')}
+  }
+}
+
+/**
+ * Creates DownloadProgressNotification - sent at 25%/50%/75% download milestones
+ * @param fileId - The video ID
+ * @param percent - Download progress percentage (25, 50, or 75)
+ * @param userId - User ID to send notification to
+ * @returns SQS message body and attributes for routing
+ */
+export function createDownloadProgressNotification(
+  fileId: string,
+  percent: number,
+  userId: string
+): {messageBody: string; messageAttributes: Record<string, MessageAttributeValue>} {
+  const file: DownloadProgressNotification = {fileId, progressPercent: percent}
+  return {
+    messageBody: JSON.stringify({file, notificationType: 'DownloadProgressNotification'}),
+    messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('DownloadProgressNotification')}
   }
 }
 

--- a/src/services/youtube/youtube.ts
+++ b/src/services/youtube/youtube.ts
@@ -446,9 +446,31 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[], onProgress?: (percen
       }
     })
 
-    // Also capture stdout for any output (yt-dlp mostly uses stderr)
+    // Also capture stdout for progress and informational output
+    // yt-dlp 2026.03.17+ with --progress --newline sends progress to stdout
     ytdlp.stdout.on('data', (chunk) => {
-      logDebug('yt-dlp stdout', chunk.toString().trim())
+      const data = chunk.toString()
+      const lines = data.split('\n')
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) {
+          continue
+        }
+
+        const progress = parseProgressLine(trimmed)
+        if (progress?.percent !== undefined) {
+          // Invoke onProgress at 25% milestones (exclude 100%)
+          if (onProgress && progress.percent < 100) {
+            const milestone = Math.floor(progress.percent / 25) * 25
+            if (milestone > 0 && milestone > lastDispatchedMilestone) {
+              lastDispatchedMilestone = milestone
+              onProgress(milestone)
+            }
+          }
+        } else {
+          logDebug('yt-dlp stdout', trimmed)
+        }
+      }
     })
 
     ytdlp.on('error', (error) => {

--- a/src/services/youtube/youtube.ts
+++ b/src/services/youtube/youtube.ts
@@ -401,7 +401,7 @@ function parseProgressLine(line: string): {percent?: number; size?: string; spee
  * @param args - Command line arguments
  * @returns Promise that resolves on success, rejects with error details on failure
  */
-function execYtDlp(ytdlpBinaryPath: string, args: string[]): Promise<void> {
+function execYtDlp(ytdlpBinaryPath: string, args: string[], onProgress?: (percent: number) => void): Promise<void> {
   return new Promise((resolve, reject) => {
     const ytdlp = spawn(ytdlpBinaryPath, args, {cwd: '/tmp'})
 
@@ -409,6 +409,7 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[]): Promise<void> {
     let lastLoggedPercent = -25 // Log every 25% progress
     let lastLogTime = Date.now()
     const LOG_INTERVAL_MS = 60000 // Also log at least every 60 seconds
+    let lastDispatchedMilestone = 0 // Track onProgress milestones independently
 
     ytdlp.stderr.on('data', (chunk) => {
       const data = chunk.toString()
@@ -431,6 +432,15 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[]): Promise<void> {
             logDebug('yt-dlp progress', {percent: `${progress.percent.toFixed(1)}%`, size: progress.size, speed: progress.speed, eta: progress.eta})
             lastLoggedPercent = Math.floor(progress.percent / 25) * 25
             lastLogTime = now
+          }
+
+          // Invoke onProgress at 25% milestones only (exclude 100% — DownloadReadyNotification handles completion)
+          if (onProgress && progress.percent !== undefined && progress.percent < 100) {
+            const milestone = Math.floor(progress.percent / 25) * 25
+            if (milestone > 0 && milestone > lastDispatchedMilestone) {
+              lastDispatchedMilestone = milestone
+              onProgress(milestone)
+            }
           }
         }
       }
@@ -476,7 +486,12 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[]): Promise<void> {
  * @param key - Target S3 object key (e.g., "dQw4w9WgXcQ.mp4")
  * @returns Upload results including file size, S3 URL, and duration
  */
-export async function downloadVideoToS3(uri: string, bucket: S3BucketName, key: string): Promise<{fileSize: number; s3Url: string; duration: number}> {
+export async function downloadVideoToS3(
+  uri: string,
+  bucket: S3BucketName,
+  key: string,
+  options?: {onProgress?: (percent: number) => void}
+): Promise<{fileSize: number; s3Url: string; duration: number}> {
   const ytdlpBinaryPath = getRequiredEnv('YTDLP_BINARY_PATH')
   const tempFile = `/tmp/${key}`
 
@@ -529,7 +544,7 @@ export async function downloadVideoToS3(uri: string, bucket: S3BucketName, key: 
         ]
 
         logDebug('Phase 1: Downloading to temp file', {args: ytdlpArgs, formatSelector})
-        await execYtDlp(ytdlpBinaryPath, ytdlpArgs)
+        await execYtDlp(ytdlpBinaryPath, ytdlpArgs, options?.onProgress)
         logDebug('Phase 1 complete: Download finished', {formatSelector})
 
         // Track which format succeeded

--- a/src/types/notificationTypes.ts
+++ b/src/types/notificationTypes.ts
@@ -13,7 +13,12 @@ import type {Result} from '@mantleframework/core'
  * Discriminated union type for file notification payloads.
  * Used in SQS message attributes to route to appropriate handler.
  */
-export type FileNotificationType = 'MetadataNotification' | 'DownloadReadyNotification' | 'FailureNotification' | 'DownloadStartedNotification'
+export type FileNotificationType =
+  | 'MetadataNotification'
+  | 'DownloadReadyNotification'
+  | 'FailureNotification'
+  | 'DownloadStartedNotification'
+  | 'DownloadProgressNotification'
 
 /**
  * Notification sent when video metadata is fetched but download not yet complete.
@@ -57,6 +62,20 @@ export interface DownloadStartedNotification {
   title: string
   /** YouTube thumbnail URL (if available) */
   thumbnailUrl?: string
+}
+
+/**
+ * Notification sent at 25%/50%/75% download milestones.
+ * Allows iOS app to show server-side download progress.
+ *
+ * Sent by: StartFileUpload Lambda (during yt-dlp download, at 25% intervals)
+ * Received by: iOS app to update progress indicator
+ */
+export interface DownloadProgressNotification {
+  /** YouTube video ID (e.g., 'dQw4w9WgXcQ') */
+  fileId: string
+  /** Download progress percentage (25, 50, or 75) */
+  progressPercent: number
 }
 
 /**

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -60,7 +60,13 @@ export const downloadQueueMessageSchema = z.object({
 
 /** Schema for SQS message attributes used by SendPushNotification */
 export const pushNotificationAttributesSchema = z.object({
-  notificationType: z.enum(['MetadataNotification', 'DownloadStartedNotification', 'DownloadReadyNotification', 'FailureNotification']),
+  notificationType: z.enum([
+    'MetadataNotification',
+    'DownloadStartedNotification',
+    'DownloadReadyNotification',
+    'FailureNotification',
+    'DownloadProgressNotification'
+  ]),
   userId: z.string().min(1, 'userId is required')
 })
 


### PR DESCRIPTION
## Summary

- Adds `DownloadProgressNotification` type that fires at 25%, 50%, 75% during yt-dlp downloads
- `onProgress` callback threaded through `execYtDlp` → `downloadVideoToS3` → `youtubeTracing`
- Fire-and-forget dispatch via SQS (C58 exception documented — advisory, non-blocking)
- Pre-fetched userIds from `dispatchDownloadStartedNotifications` to avoid redundant DB reads
- `lastDispatchedPercent` guard prevents backward progress on SABR format fallback
- Fix: yt-dlp 2026.03.17 sends progress to stdout, not stderr — added stdout progress parsing

## Files changed

- `src/types/notificationTypes.ts` — `DownloadProgressNotification` type + interface
- `src/types/schemas.ts` — Added to `pushNotificationAttributesSchema` z.enum
- `src/services/notification/transformers.ts` — `createDownloadProgressNotification` transformer
- `src/services/notification/dispatchService.ts` — `dispatchDownloadProgressNotifications` + return userIds
- `src/services/youtube/youtube.ts` — `onProgress` callback + stdout progress parsing
- `src/services/download/youtubeTracing.ts` — Pass through `onProgress` in traced wrapper
- `src/lambdas/sqs/StartFileUpload/downloadOrchestrator.ts` — Wire callback with fire-and-forget pattern

## PN checklist

- [x] PN1: Type in both backend + iOS
- [x] PN2: Zod schema enum updated
- [x] PN3: Transformer function
- [x] PN4: Dispatcher with Promise.allSettled
- [x] PN5: Background push (correct default)
- [x] PN12: E2E verified on staging — 25/50/75% dispatched and received on device

## Test plan

- [x] `pnpm run typecheck` — 0 errors
- [x] `pnpm run test` — 503 passed, 0 failed
- [x] Deployed to staging, triggered test download
- [x] CloudWatch confirms `DownloadProgressNotification` dispatch at 25/50/75%
- [x] iOS device received all three progress notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)