### PR TITLE
fix(notifications): include thumbnailUrl in MetadataNotification

### DIFF
--- a/src/services/notification/transformers.ts
+++ b/src/services/notification/transformers.ts
@@ -57,7 +57,8 @@ export function createMetadataNotification(
     description: truncateDescription(videoInfo.description || ''),
     publishDate: videoInfo.upload_date || (new Date().toISOString().split('T')[0] ?? new Date().toISOString()),
     contentType: 'video/mp4',
-    status: 'pending'
+    status: 'pending',
+    thumbnailUrl: videoInfo.thumbnail || undefined
   }
   return {
     messageBody: JSON.stringify({file, notificationType: 'MetadataNotification'}),

--- a/src/types/notificationTypes.ts
+++ b/src/types/notificationTypes.ts
@@ -46,6 +46,8 @@ export interface MetadataNotification {
   contentType: string
   /** Status indicator for iOS app (always 'pending' for this notification type) */
   status: 'pending'
+  /** YouTube thumbnail URL (if available) */
+  thumbnailUrl?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

- MetadataNotification was missing `thumbnailUrl` despite `videoInfo.thumbnail` being available at creation time
- iOS app cached the file to CoreData without a thumbnail URL, so thumbnails never displayed until the later DownloadStartedNotification arrived
- Adds `thumbnailUrl?: string` to the `MetadataNotification` interface and populates it from `videoInfo.thumbnail` in the transformer

## Changes

- `src/types/notificationTypes.ts`: Added `thumbnailUrl?: string` to `MetadataNotification` interface
- `src/services/notification/transformers.ts`: Added `thumbnailUrl: videoInfo.thumbnail || undefined` to the metadata notification payload

## Test plan

- [x] All 24 transformer tests pass
- [x] TypeScript compiles clean
- [x] Deploy to staging and verify thumbnail appears in iOS app on file add
