### PR TITLE
feat(notifications): push notification schema sync pipeline

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -794,3 +794,117 @@ components:
           type: string
       additionalProperties: false
       id: SubscriptionResponse
+    Notifications.DownloadProgressPayload:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        fileId:
+          type: string
+        progressPercent:
+          type: integer
+          minimum: -9007199254740991
+          maximum: 9007199254740991
+      required:
+        - fileId
+        - progressPercent
+      additionalProperties: false
+    Notifications.DownloadReadyPayload:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        fileId:
+          type: string
+        key:
+          type: string
+        size:
+          type: integer
+          minimum: -9007199254740991
+          maximum: 9007199254740991
+        url:
+          type: string
+          format: uri
+      required:
+        - fileId
+        - key
+        - size
+        - url
+      additionalProperties: false
+    Notifications.DownloadStartedPayload:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        fileId:
+          type: string
+        title:
+          type: string
+        thumbnailUrl:
+          type: string
+      required:
+        - fileId
+        - title
+      additionalProperties: false
+    Notifications.FailurePayload:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        fileId:
+          type: string
+        title:
+          type: string
+        errorCategory:
+          type: string
+        errorMessage:
+          type: string
+        retryExhausted:
+          type: boolean
+      required:
+        - fileId
+        - errorCategory
+        - errorMessage
+        - retryExhausted
+      additionalProperties: false
+    Notifications.MetadataPayload:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: object
+      properties:
+        fileId:
+          type: string
+        key:
+          type: string
+        title:
+          type: string
+        authorName:
+          type: string
+        authorUser:
+          type: string
+        description:
+          type: string
+        publishDate:
+          type: string
+        contentType:
+          type: string
+        status:
+          type: string
+          const: pending
+        thumbnailUrl:
+          type: string
+      required:
+        - fileId
+        - key
+        - title
+        - authorName
+        - authorUser
+        - description
+        - publishDate
+        - contentType
+        - status
+      additionalProperties: false
+    Notifications.NotificationType:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      type: string
+      enum:
+        - MetadataNotification
+        - DownloadStartedNotification
+        - DownloadProgressNotification
+        - DownloadReadyNotification
+        - FailureNotification

--- a/mantle.config.ts
+++ b/mantle.config.ts
@@ -90,6 +90,11 @@ export default defineConfig({
     }
   },
   authorizer: {cacheTtl: 0},
+  openapi: {
+    additionalSchemas: [
+      {source: '#types/notification-schemas', prefix: 'Notifications.'}
+    ]
+  },
   ci: {
     mantleRepo: 'j0nathan-ll0yd/mantle',
     mantleRef: 'main',

--- a/src/services/notification/transformers.ts
+++ b/src/services/notification/transformers.ts
@@ -171,21 +171,33 @@ export function transformToAPNSNotification(messageBody: string, targetArn: stri
 
 /**
  * Transform SQS message body (JSON) to APNS alert push notification
- * Used for FailureNotification types that require user attention
+ * Used for FailureNotification and DownloadReadyNotification types that require user attention
  * @param messageBody - JSON string containing file and notificationType
  * @param targetArn - SNS endpoint ARN for the device
  * @returns SNS PublishInput for APNS alert notification
  */
 export function transformToAPNSAlertNotification(messageBody: string, targetArn: string): PublishCommandInput {
   const payload = JSON.parse(messageBody)
-  const file = payload.file as FailureNotification
+  const notificationType = payload.notificationType as string
 
-  // Construct user-friendly alert message
-  const title = 'Download Failed'
-  const subtitle = file.title || file.fileId
-  const body = file.retryExhausted
-    ? `Failed after multiple attempts: ${file.errorMessage}`
-    : `Unable to download: ${file.errorMessage}`
+  let title: string
+  let subtitle: string
+  let body: string
+
+  if (notificationType === 'DownloadReadyNotification') {
+    const file = payload.file as DownloadReadyNotification
+    title = 'Download Ready'
+    subtitle = file.key
+    body = 'Your file is ready to play.'
+  } else {
+    // FailureNotification
+    const file = payload.file as FailureNotification
+    title = 'Download Failed'
+    subtitle = file.title || file.fileId
+    body = file.retryExhausted
+      ? `Failed after multiple attempts: ${file.errorMessage}`
+      : `Unable to download: ${file.errorMessage}`
+  }
 
   return {
     Message: JSON.stringify({

--- a/src/services/notification/transformers.ts
+++ b/src/services/notification/transformers.ts
@@ -5,13 +5,14 @@
  * This is an adapter layer that bridges domain models to infrastructure message formats.
  */
 import type {File} from '#types/domainModels'
-import type {
-  DownloadProgressNotification,
-  DownloadReadyNotification,
-  DownloadStartedNotification,
-  FailureNotification,
-  MetadataNotification
-} from '#types/notificationTypes'
+import type {DownloadReadyNotification, FailureNotification} from '#types/notificationTypes'
+import {
+  downloadProgressPayloadSchema,
+  downloadReadyPayloadSchema,
+  downloadStartedPayloadSchema,
+  failurePayloadSchema,
+  metadataPayloadSchema
+} from '#types/notification-schemas'
 import type {YtDlpVideoInfo} from '#types/youtube'
 import {stringAttribute} from '@mantleframework/aws'
 
@@ -48,7 +49,7 @@ export function createMetadataNotification(
   videoInfo: YtDlpVideoInfo,
   userId: string
 ): {messageBody: string; messageAttributes: Record<string, MessageAttributeValue>} {
-  const file: MetadataNotification = {
+  const file = metadataPayloadSchema.parse({
     fileId,
     key: `${fileId}.mp4`,
     title: videoInfo.title || '',
@@ -59,7 +60,7 @@ export function createMetadataNotification(
     contentType: 'video/mp4',
     status: 'pending',
     thumbnailUrl: videoInfo.thumbnail || undefined
-  }
+  })
   return {
     messageBody: JSON.stringify({file, notificationType: 'MetadataNotification'}),
     messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('MetadataNotification')}
@@ -78,7 +79,7 @@ export function createDownloadStartedNotification(
   videoInfo: YtDlpVideoInfo,
   userId: string
 ): {messageBody: string; messageAttributes: Record<string, MessageAttributeValue>} {
-  const file: DownloadStartedNotification = {fileId, title: videoInfo.title || '', thumbnailUrl: videoInfo.thumbnail}
+  const file = downloadStartedPayloadSchema.parse({fileId, title: videoInfo.title || '', thumbnailUrl: videoInfo.thumbnail})
   return {
     messageBody: JSON.stringify({file, notificationType: 'DownloadStartedNotification'}),
     messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('DownloadStartedNotification')}
@@ -97,7 +98,7 @@ export function createDownloadProgressNotification(
   percent: number,
   userId: string
 ): {messageBody: string; messageAttributes: Record<string, MessageAttributeValue>} {
-  const file: DownloadProgressNotification = {fileId, progressPercent: percent}
+  const file = downloadProgressPayloadSchema.parse({fileId, progressPercent: percent})
   return {
     messageBody: JSON.stringify({file, notificationType: 'DownloadProgressNotification'}),
     messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('DownloadProgressNotification')}
@@ -114,7 +115,7 @@ export function createDownloadReadyNotification(
   dbFile: File,
   userId: string
 ): {messageBody: string; messageAttributes: Record<string, MessageAttributeValue>} {
-  const file: DownloadReadyNotification = {fileId: dbFile.fileId, key: dbFile.key, size: dbFile.size, url: dbFile.url!}
+  const file = downloadReadyPayloadSchema.parse({fileId: dbFile.fileId, key: dbFile.key, size: dbFile.size, url: dbFile.url})
   return {
     messageBody: JSON.stringify({file, notificationType: 'DownloadReadyNotification'}),
     messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('DownloadReadyNotification')}
@@ -139,7 +140,7 @@ export function createFailureNotification(
   userId: string,
   title?: string
 ): {messageBody: string; messageAttributes: Record<string, MessageAttributeValue>} {
-  const file: FailureNotification = {fileId, title, errorCategory, errorMessage, retryExhausted}
+  const file = failurePayloadSchema.parse({fileId, title, errorCategory, errorMessage, retryExhausted})
   return {
     messageBody: JSON.stringify({file, notificationType: 'FailureNotification'}),
     messageAttributes: {userId: stringAttribute(userId), notificationType: stringAttribute('FailureNotification')}

--- a/src/types/notification-schemas.ts
+++ b/src/types/notification-schemas.ts
@@ -1,0 +1,55 @@
+/**
+ * Notification Payload Schemas
+ *
+ * Zod schemas for each push notification payload type.
+ * Used for pre-send validation in transformers and as the source of truth
+ * for TypeScript interfaces in notificationTypes.ts.
+ *
+ * @see notificationTypes.ts for derived TypeScript types
+ * @see src/services/notification/transformers.ts for pre-send validation usage
+ */
+import {z} from '@mantleframework/validation'
+
+/**
+ * Notification type string enum — single source of truth for all valid types.
+ * Replaces the inline z.enum([...]) in pushNotificationAttributesSchema.
+ */
+export const notificationTypeSchema = z.enum([
+  'MetadataNotification',
+  'DownloadStartedNotification',
+  'DownloadProgressNotification',
+  'DownloadReadyNotification',
+  'FailureNotification'
+])
+
+/** MetadataNotification payload — full video details sent after yt-dlp metadata fetch */
+export const metadataPayloadSchema = z.object({
+  fileId: z.string(),
+  key: z.string(),
+  title: z.string(),
+  authorName: z.string(),
+  authorUser: z.string(),
+  description: z.string(),
+  publishDate: z.string(),
+  contentType: z.string(),
+  status: z.literal('pending'),
+  thumbnailUrl: z.string().optional()
+})
+
+/** DownloadStartedNotification payload — sent when server begins downloading */
+export const downloadStartedPayloadSchema = z.object({fileId: z.string(), title: z.string(), thumbnailUrl: z.string().optional()})
+
+/** DownloadProgressNotification payload — sent at 25%/50%/75% milestones */
+export const downloadProgressPayloadSchema = z.object({fileId: z.string(), progressPercent: z.number().int()})
+
+/** DownloadReadyNotification payload — sent when S3 upload completes */
+export const downloadReadyPayloadSchema = z.object({fileId: z.string(), key: z.string(), size: z.number().int(), url: z.string().url()})
+
+/** FailureNotification payload — sent when download permanently fails */
+export const failurePayloadSchema = z.object({
+  fileId: z.string(),
+  title: z.string().optional(),
+  errorCategory: z.string(),
+  errorMessage: z.string(),
+  retryExhausted: z.boolean()
+})

--- a/src/types/notificationTypes.ts
+++ b/src/types/notificationTypes.ts
@@ -4,21 +4,30 @@
  * Defines the payload structures for iOS push notifications sent via APNS.
  * These notifications inform the iOS app about file download progress.
  *
+ * TypeScript interfaces are derived from Zod schemas in notification-schemas.ts.
+ * Edit the schemas there — these types are inferred automatically.
+ *
  * @see SendPushNotification Lambda for delivery implementation
+ * @see notification-schemas.ts for Zod schema definitions
  * @see {@link https://github.com/j0nathan-ll0yd/mantle-OfflineMediaDownloader/wiki/iOS/Push-Notifications | Push Notification Guide}
  */
 import type {Result} from '@mantleframework/core'
+import type {z} from '@mantleframework/validation'
+import type {
+  downloadProgressPayloadSchema,
+  downloadReadyPayloadSchema,
+  downloadStartedPayloadSchema,
+  failurePayloadSchema,
+  metadataPayloadSchema,
+  notificationTypeSchema
+} from '#types/notification-schemas'
 
 /**
  * Discriminated union type for file notification payloads.
+ * Derived from notificationTypeSchema — edit the schema to add new types.
  * Used in SQS message attributes to route to appropriate handler.
  */
-export type FileNotificationType =
-  | 'MetadataNotification'
-  | 'DownloadReadyNotification'
-  | 'FailureNotification'
-  | 'DownloadStartedNotification'
-  | 'DownloadProgressNotification'
+export type FileNotificationType = z.infer<typeof notificationTypeSchema>
 
 /**
  * Notification sent when video metadata is fetched but download not yet complete.
@@ -27,28 +36,7 @@ export type FileNotificationType =
  * Sent by: StartFileUpload Lambda (after yt-dlp fetches video info)
  * Received by: iOS app to update UI with video metadata
  */
-export interface MetadataNotification {
-  /** YouTube video ID (e.g., 'dQw4w9WgXcQ') */
-  fileId: string
-  /** S3 object key (e.g., 'dQw4w9WgXcQ.mp4') */
-  key: string
-  /** Video title from YouTube */
-  title: string
-  /** YouTube channel name */
-  authorName: string
-  /** Normalized channel username for URL construction */
-  authorUser: string
-  /** Video description (may be truncated) */
-  description: string
-  /** ISO 8601 date string of video publish date */
-  publishDate: string
-  /** MIME type, always 'video/mp4' */
-  contentType: string
-  /** Status indicator for iOS app (always 'pending' for this notification type) */
-  status: 'pending'
-  /** YouTube thumbnail URL (if available) */
-  thumbnailUrl?: string
-}
+export type MetadataNotification = z.infer<typeof metadataPayloadSchema>
 
 /**
  * Notification sent when the server begins downloading the video to S3.
@@ -57,14 +45,7 @@ export interface MetadataNotification {
  * Sent by: StartFileUpload Lambda (after metadata fetch, before S3 download)
  * Received by: iOS app to show server-side download progress indicator
  */
-export interface DownloadStartedNotification {
-  /** YouTube video ID (e.g., 'dQw4w9WgXcQ') */
-  fileId: string
-  /** Video title (available since metadata was already fetched) */
-  title: string
-  /** YouTube thumbnail URL (if available) */
-  thumbnailUrl?: string
-}
+export type DownloadStartedNotification = z.infer<typeof downloadStartedPayloadSchema>
 
 /**
  * Notification sent at 25%/50%/75% download milestones.
@@ -73,12 +54,7 @@ export interface DownloadStartedNotification {
  * Sent by: StartFileUpload Lambda (during yt-dlp download, at 25% intervals)
  * Received by: iOS app to update progress indicator
  */
-export interface DownloadProgressNotification {
-  /** YouTube video ID (e.g., 'dQw4w9WgXcQ') */
-  fileId: string
-  /** Download progress percentage (25, 50, or 75) */
-  progressPercent: number
-}
+export type DownloadProgressNotification = z.infer<typeof downloadProgressPayloadSchema>
 
 /**
  * Notification sent when download is complete and file is ready for streaming.
@@ -87,16 +63,7 @@ export interface DownloadProgressNotification {
  * Sent by: S3ObjectCreated Lambda (triggered by S3 upload completion)
  * Received by: iOS app to enable video playback
  */
-export interface DownloadReadyNotification {
-  /** YouTube video ID (e.g., 'dQw4w9WgXcQ') */
-  fileId: string
-  /** S3 object key (e.g., 'dQw4w9WgXcQ.mp4') */
-  key: string
-  /** File size in bytes */
-  size: number
-  /** CloudFront URL for streaming (uses transfer acceleration) */
-  url: string
-}
+export type DownloadReadyNotification = z.infer<typeof downloadReadyPayloadSchema>
 
 /**
  * Notification sent when a download permanently fails.
@@ -105,18 +72,7 @@ export interface DownloadReadyNotification {
  * Sent by: StartFileUpload Lambda (when download fails permanently)
  * Received by: iOS app to display failure alert
  */
-export interface FailureNotification {
-  /** YouTube video ID (e.g., 'dQw4w9WgXcQ') */
-  fileId: string
-  /** Video title (optional, if available from metadata fetch) */
-  title?: string
-  /** Error category (e.g., 'permanent', 'cookie_expired', 'rate_limited') */
-  errorCategory: string
-  /** Human-readable error message */
-  errorMessage: string
-  /** Whether retry attempts have been exhausted */
-  retryExhausted: boolean
-}
+export type FailureNotification = z.infer<typeof failurePayloadSchema>
 
 /**
  * Success payload when a notification is delivered to a device.

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -1,4 +1,5 @@
 import {z} from '@mantleframework/validation'
+import {notificationTypeSchema} from '#types/notification-schemas'
 
 // YouTube URL regex pattern
 const youtubeUrlPattern = /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(?:-nocookie)?\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|live\/|v\/)?)([\w-]+)(\S+)?$/
@@ -59,16 +60,7 @@ export const downloadQueueMessageSchema = z.object({
 })
 
 /** Schema for SQS message attributes used by SendPushNotification */
-export const pushNotificationAttributesSchema = z.object({
-  notificationType: z.enum([
-    'MetadataNotification',
-    'DownloadStartedNotification',
-    'DownloadReadyNotification',
-    'FailureNotification',
-    'DownloadProgressNotification'
-  ]),
-  userId: z.string().min(1, 'userId is required')
-})
+export const pushNotificationAttributesSchema = z.object({notificationType: notificationTypeSchema, userId: z.string().min(1, 'userId is required')})
 
 /** Validated DownloadQueueMessage type */
 export type ValidatedDownloadQueueMessage = z.infer<typeof downloadQueueMessageSchema>

--- a/test/fixtures/notification-payloads/download-progress.json
+++ b/test/fixtures/notification-payloads/download-progress.json
@@ -1,0 +1,7 @@
+{
+  "notificationType": "DownloadProgressNotification",
+  "file": {
+    "fileId": "dQw4w9WgXcQ",
+    "progressPercent": 50
+  }
+}

--- a/test/fixtures/notification-payloads/download-ready.json
+++ b/test/fixtures/notification-payloads/download-ready.json
@@ -1,0 +1,9 @@
+{
+  "notificationType": "DownloadReadyNotification",
+  "file": {
+    "fileId": "dQw4w9WgXcQ",
+    "key": "dQw4w9WgXcQ.mp4",
+    "size": 15728640,
+    "url": "https://d1example.cloudfront.net/videos/dQw4w9WgXcQ.mp4"
+  }
+}

--- a/test/fixtures/notification-payloads/download-started.json
+++ b/test/fixtures/notification-payloads/download-started.json
@@ -1,0 +1,8 @@
+{
+  "notificationType": "DownloadStartedNotification",
+  "file": {
+    "fileId": "dQw4w9WgXcQ",
+    "title": "Rick Astley - Never Gonna Give You Up",
+    "thumbnailUrl": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+  }
+}

--- a/test/fixtures/notification-payloads/failure.json
+++ b/test/fixtures/notification-payloads/failure.json
@@ -1,0 +1,10 @@
+{
+  "notificationType": "FailureNotification",
+  "file": {
+    "fileId": "dQw4w9WgXcQ",
+    "title": "Rick Astley - Never Gonna Give You Up",
+    "errorCategory": "permanent",
+    "errorMessage": "Video is unavailable in your region",
+    "retryExhausted": true
+  }
+}

--- a/test/fixtures/notification-payloads/metadata.json
+++ b/test/fixtures/notification-payloads/metadata.json
@@ -1,0 +1,15 @@
+{
+  "notificationType": "MetadataNotification",
+  "file": {
+    "fileId": "dQw4w9WgXcQ",
+    "key": "dQw4w9WgXcQ.mp4",
+    "title": "Rick Astley - Never Gonna Give You Up",
+    "authorName": "Rick Astley",
+    "authorUser": "rick_astley",
+    "description": "The official video for Never Gonna Give You Up by Rick Astley.",
+    "publishDate": "2009-10-25",
+    "contentType": "video/mp4",
+    "status": "pending",
+    "thumbnailUrl": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+  }
+}

--- a/test/services/notification/contract.test.ts
+++ b/test/services/notification/contract.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Push Notification Contract Tests
+ *
+ * Validates that fixture payloads match the Zod schemas.
+ * These fixtures are shared with the iOS repo — if a schema changes
+ * and the fixtures are updated, the iOS contract test will fail
+ * until the iOS parser is updated to match.
+ */
+import {describe, expect, it} from 'vitest'
+import {
+  downloadProgressPayloadSchema,
+  downloadReadyPayloadSchema,
+  downloadStartedPayloadSchema,
+  failurePayloadSchema,
+  metadataPayloadSchema,
+  notificationTypeSchema
+} from '#types/notification-schemas'
+import metadataFixture from '../../fixtures/notification-payloads/metadata.json' with {type: 'json'}
+import downloadStartedFixture from '../../fixtures/notification-payloads/download-started.json' with {type: 'json'}
+import downloadProgressFixture from '../../fixtures/notification-payloads/download-progress.json' with {type: 'json'}
+import downloadReadyFixture from '../../fixtures/notification-payloads/download-ready.json' with {type: 'json'}
+import failureFixture from '../../fixtures/notification-payloads/failure.json' with {type: 'json'}
+
+describe('Push Notification Contract', () => {
+  describe('notificationType field', () => {
+    it.each([
+      metadataFixture,
+      downloadStartedFixture,
+      downloadProgressFixture,
+      downloadReadyFixture,
+      failureFixture
+    ])('fixture $notificationType has a valid notificationType', (fixture) => {
+      const result = notificationTypeSchema.safeParse(fixture.notificationType)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('payload schemas', () => {
+    it('MetadataNotification fixture matches metadataPayloadSchema', () => {
+      const result = metadataPayloadSchema.safeParse(metadataFixture.file)
+      expect(result.success).toBe(true)
+    })
+
+    it('DownloadStartedNotification fixture matches downloadStartedPayloadSchema', () => {
+      const result = downloadStartedPayloadSchema.safeParse(downloadStartedFixture.file)
+      expect(result.success).toBe(true)
+    })
+
+    it('DownloadProgressNotification fixture matches downloadProgressPayloadSchema', () => {
+      const result = downloadProgressPayloadSchema.safeParse(downloadProgressFixture.file)
+      expect(result.success).toBe(true)
+    })
+
+    it('DownloadReadyNotification fixture matches downloadReadyPayloadSchema', () => {
+      const result = downloadReadyPayloadSchema.safeParse(downloadReadyFixture.file)
+      expect(result.success).toBe(true)
+    })
+
+    it('FailureNotification fixture matches failurePayloadSchema', () => {
+      const result = failurePayloadSchema.safeParse(failureFixture.file)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('schema strictness', () => {
+    it('rejects payloads with missing required fields', () => {
+      const result = metadataPayloadSchema.safeParse({fileId: 'test'})
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects invalid notificationType strings', () => {
+      const result = notificationTypeSchema.safeParse('InvalidNotification')
+      expect(result.success).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Phase 0**: Fix `transformToAPNSAlertNotification` bug — was casting all payloads as `FailureNotification`, producing `"Unable to download: undefined"` for `DownloadReadyNotification` alerts
- **Phase 1**: Formalize notification payloads as Zod schemas in `notification-schemas.ts` — single source of truth; interfaces in `notificationTypes.ts` now derived via `z.infer<>`
- **Phase 2c**: Configure `openapi.additionalSchemas` in `mantle.config.ts` pointing to notification schemas; 6 new `Notifications.*` components appear in the OpenAPI YAML
- **Phase 4a**: Pre-send validation in `transformers.ts` — each `createXxxNotification` function now validates the payload against the Zod schema before enqueueing to SQS
- **Phase 4b**: Contract test fixtures (5 JSON payloads + 12-test contract suite) validating fixtures match schemas

## Cross-repo coordination

Branch `feat/push-notification-schema-sync` across all repos:
- **mantle framework**: j0nathan-ll0yd/mantle#92 — adds `openapi.additionalSchemas` to `MantleConfig` + CLI support
- **ios-OfflineMediaDownloader**: companion PR — refactors push notification parser to use generated Codable types from the OpenAPI schema contract

## Test plan

- [x] `pnpm typecheck` passes clean
- [x] Contract tests: 12/12 pass (`npx vitest run test/services/notification/contract.test.ts`)
- [x] Pre-commit hooks pass (secrets check, dependency-cruiser, docs structure)
- [x] Deploy to staging and verify push notifications still arrive on iOS device
- [x] Verify `DownloadReadyNotification` alert now shows "Download Ready" instead of "Unable to download: undefined"