### PR TITLE
feat: add docker-compose.clone.yml for migration testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,13 @@ pnpm run deploy:production     # Deploy to production (manual, or auto via GitHu
 
 **Note**: Production deployments auto-trigger on merge to main via GitHub Actions.
 
+Before running migrations against a live stage, use these validation commands:
+
+```bash
+mantle db migrate --dry-run       # validates pending migrations in a preview schema; reports per-statement DSQL classifications (OK/INDEX/RECREATION/STRIP). No lock acquired, no mutations.
+mantle db clone --stage staging   # clones remote Aurora DSQL to local Docker PostgreSQL (port 5433) via docker-compose.clone.yml for safe local migration testing
+```
+
 ### Infrastructure Verification
 ```bash
 pnpm run deploy:check:staging    # Check staging for drift

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Convention Enforcement
 
-Conventions are enforced by `mantle check` (92 checks, C1-C92) and documented in `~/.claude/principles/mantle.md`. Architecture decisions are recorded as ADRs in `docs/wiki/Decisions/`.
+Conventions are enforced by `mantle check` (95 checks, C1-C95) and documented in `~/.claude/principles/mantle.md`. Architecture decisions are recorded as ADRs in `docs/wiki/Decisions/`.
 
 ---
 
@@ -166,7 +166,7 @@ See [System Diagrams](docs/wiki/Architecture/System-Diagrams.md) for Lambda Trig
 
 ## Conventions Reference
 
-Convention enforcement is handled by `mantle check` (92 checks) and `~/.claude/principles/mantle.md`. Key references:
+Convention enforcement is handled by `mantle check` (95 checks) and `~/.claude/principles/mantle.md`. Key references:
 
 - **Bash Scripts**: [docs/wiki/Bash/Script-Patterns.md](docs/wiki/Bash/Script-Patterns.md)
 - **Mock Patterns**: [docs/wiki/Testing/Mock-Factory-Patterns.md](docs/wiki/Testing/Mock-Factory-Patterns.md)
@@ -345,7 +345,7 @@ See `package.json` for complete command list (cleanup, integration tests, deploy
 
 ## Mantle Spec Conformance — Acknowledged Exceptions
 
-This project passes all Mantle spec checks (C1–C92) with three documented exceptions:
+This project passes all Mantle spec checks (C1–C95) with three documented exceptions:
 
 ### C6: MigrateDSQL dynamic env var substitution
 `src/lambdas/standalone/MigrateDSQL/index.ts:44` uses `process.env[varName]` for dynamic variable substitution in SQL migration files. This is intentional because the variable name is not known at compile time (comes from `${VAR_NAME}` patterns in SQL files), and `getOptionalEnv`/`getRequiredEnv` require a static string key. The eslint-disable comment documents the reason. The access is inside a function body (not module-level).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 
 ## Mantle Convention Enforcement
 
-This is a Mantle framework instance (the original project Mantle was extracted from). All code must conform to 92 convention checks (C1-C92).
+This is a Mantle framework instance (the original project Mantle was extracted from). All code must conform to 95 convention checks (C1-C95).
 
 - **Checks**: Imported above from `~/.claude/principles/mantle-checks.md`
 - **Full principles**: `~/.claude/principles/mantle.md` — rationale and deep dives

--- a/docker-compose.clone.yml
+++ b/docker-compose.clone.yml
@@ -1,0 +1,27 @@
+# Lightweight PG container for migration testing against real staging data.
+# Used by: mantle db clone --stage staging
+# Port 5433 avoids conflict with docker-compose.test.yml on 5432.
+services:
+  clone-db:
+    image: postgres:17-alpine
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off

--- a/docs/wiki/Decisions/ADR-0002-lat-md-evaluation.md
+++ b/docs/wiki/Decisions/ADR-0002-lat-md-evaluation.md
@@ -69,7 +69,7 @@ Revisit this decision if:
 3. lat.md gains institutional backing (for example, Linux Foundation or major vendor adoption)
 
 ## Related
-- Mantle convention checks (`~/.claude/principles/mantle-checks.md`), covering C1-C92
+- Mantle convention checks (`~/.claude/principles/mantle-checks.md`), covering C1-C95
 - `validate-doc-sync.sh` Check #7, expanded to scan AGENTS.md/CLAUDE.md
 - `mantle check docs`, new CLI subcommand added alongside this ADR
 - [lat.md repository](https://github.com/1st1/lat.md), the evaluated tool


### PR DESCRIPTION
## Summary
- Adds `docker-compose.clone.yml` for use with `mantle db clone --stage staging`
- Lightweight PG 17-alpine container on port 5433 (avoids conflict with test DB on 5432)
- tmpfs storage, durability off, healthcheck for --wait support
- Documentation update in AGENTS.md

## Test plan
- [ ] `mantle db clone --stage staging` test against OMD staging
- [x] Docker Compose file validated (same pattern as LP, which was tested E2E)

## Depends on
- j0nathan-ll0yd/mantle: feat/db-clone-and-dry-run