### PR TITLE
refactor(db): use framework ForeignKeyViolationError

### DIFF
--- a/src/db/fkEnforcement.ts
+++ b/src/db/fkEnforcement.ts
@@ -11,24 +11,11 @@
  * @see https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-unsupported-features.html
  */
 import {eq} from '@mantleframework/database/orm'
+import {ForeignKeyViolationError} from '@mantleframework/errors'
 import {getDrizzleClient} from './client.js'
 import {devices, files, users} from './schema.js'
 
-/**
- * Error thrown when a foreign key constraint would be violated.
- */
-export class ForeignKeyViolationError extends Error {
-  readonly table: string
-  readonly column: string
-  readonly value: string
-  constructor(table: string, column: string, value: string) {
-    super(`Foreign key violation: ${table}.${column} = ${value} does not exist`)
-    this.name = 'ForeignKeyViolationError'
-    this.table = table
-    this.column = column
-    this.value = value
-  }
-}
+export {ForeignKeyViolationError}
 
 /**
  * Asserts that a user exists in the database.

--- a/src/db/fkEnforcement.ts
+++ b/src/db/fkEnforcement.ts
@@ -15,7 +15,7 @@ import {ForeignKeyViolationError} from '@mantleframework/errors'
 import {getDrizzleClient} from './client.js'
 import {devices, files, users} from './schema.js'
 
-export {ForeignKeyViolationError}
+export { ForeignKeyViolationError }
 
 /**
  * Asserts that a user exists in the database.


### PR DESCRIPTION
## Summary
- Replaced local `ForeignKeyViolationError` class (20 lines) with import from `@mantleframework/errors`
- Re-exports `ForeignKeyViolationError` for backward compatibility with instance consumers
- Domain-specific assertion functions (assertUserExists, assertFileExists, etc.) unchanged
- Companion to j0nathan-ll0yd/mantle#114 (DSQL translation layer consolidation)

## Test plan
- [x] Typecheck passes
- [x] Lint passes (0 errors)
- [x] Unit tests pass
- [x] Integration tests pass

Generated with [Claude Code](https://claude.com/claude-code)