### PR TITLE
chore: reduce CloudWatch costs — disable metrics in staging, remove dashboard

### DIFF
--- a/infra/environments/production.tfvars
+++ b/infra/environments/production.tfvars
@@ -16,9 +16,6 @@ api_quota_limit          = 10000
 # Protect production data
 dsql_deletion_protection = true
 
-# Monitoring
-enable_cloudwatch_dashboard = false # Use AWS Console on-demand ($3/month savings)
-
 # Production concurrency
 reserved_concurrency_start_file_upload = 10
 

--- a/infra/environments/staging.tfvars
+++ b/infra/environments/staging.tfvars
@@ -19,8 +19,8 @@ api_quota_limit          = 1000
 # Allow destruction in staging
 dsql_deletion_protection = false
 
-# Disable monitoring to reduce costs
-enable_cloudwatch_dashboard = false
+# Disable metrics emission in staging (POWERTOOLS_METRICS_DISABLED)
+disable_metrics = true
 
 # Disable reserved concurrency in staging (low-quota account)
 reserved_concurrency_start_file_upload = -1

--- a/infra/eventbridge.tf
+++ b/infra/eventbridge.tf
@@ -2,11 +2,12 @@
 # To customize, remove the first line and this file will be skipped on re-generation.
 
 module "eventbridge" {
-  source      = "../../mantle/modules/eventbridge"
-  bus_name    = "MediaDownloader"
-  name_prefix = module.core.name_prefix
-  tags        = module.core.common_tags
-  enable_dlq  = true
+  source          = "../../mantle/modules/eventbridge"
+  bus_name        = "MediaDownloader"
+  name_prefix     = module.core.name_prefix
+  tags            = module.core.common_tags
+  enable_dlq      = true
+  enable_dlq_alarm = false
 }
 
 # Rule: Route DownloadRequested events to DownloadQueue

--- a/infra/generated_dsql_permissions.tf
+++ b/infra/generated_dsql_permissions.tf
@@ -3,7 +3,7 @@
 
 # Auto-generated from @RequiresTable decorators
 # Do not edit manually - run: mantle generate permissions
-# Generated at: 2026-05-05T15:19:23.447Z
+# Generated at: 2026-05-05T23:17:04.203Z
 
 locals {
   lambda_dsql_roles = {

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -22,5 +22,6 @@ locals {
     LOG_LEVEL                          = var.log_level
     ENVIRONMENT                        = var.environment
     METRICS_NAMESPACE                  = "MediaDownloader"
+    POWERTOOLS_METRICS_DISABLED        = var.disable_metrics ? "true" : ""
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -36,6 +36,12 @@ variable "log_retention_days" {
   default     = 14
 }
 
+variable "disable_metrics" {
+  description = "Disable CloudWatch custom metrics emission (sets POWERTOOLS_METRICS_DISABLED)"
+  type        = bool
+  default     = false
+}
+
 variable "dsql_endpoint" {
   description = "Aurora DSQL cluster endpoint (set after initial provisioning or pass from database module)"
   type        = string
@@ -195,12 +201,6 @@ variable "dsql_deletion_protection" {
   description = "Enable deletion protection for DSQL cluster"
   type        = bool
   default     = true
-}
-
-variable "enable_cloudwatch_dashboard" {
-  description = "Enable CloudWatch dashboard (costs $3/month per environment)"
-  type        = bool
-  default     = false
 }
 
 variable "cors_allowed_origins" {

--- a/mantle.config.ts
+++ b/mantle.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     {name: 'api_throttle_rate_limit', type: 'number', description: 'API Gateway throttle rate limit', default: '50'},
     {name: 'api_quota_limit', type: 'number', description: 'API Gateway daily quota limit', default: '10000'},
     {name: 'dsql_deletion_protection', type: 'bool', description: 'Enable deletion protection for DSQL cluster', default: 'true'},
-    {name: 'enable_cloudwatch_dashboard', type: 'bool', description: 'Enable CloudWatch dashboard (costs $3/month per environment)', default: 'false'},
+
     {
       name: 'cors_allowed_origins',
       type: 'list(string)',
@@ -36,6 +36,7 @@ export default defineConfig({
   ],
   eventbridge: {
     bus: 'MediaDownloader',
+    dlqAlarm: false,
     sqsTargets: [
       {
         detailType: 'DownloadRequested',
@@ -52,7 +53,8 @@ export default defineConfig({
   },
   observability: {
     adot: true,
-    metricsNamespace: 'MediaDownloader'
+    metricsNamespace: 'MediaDownloader',
+    disableMetrics: true
   },
   secrets: {
     provider: 'sops',

--- a/permissions/permissions.sql
+++ b/permissions/permissions.sql
@@ -1,6 +1,6 @@
 -- Per-Lambda PostgreSQL roles with fine-grained table permissions
 -- Auto-generated from @RequiresTable decorators
--- Generated at: 2026-05-05T15:19:23.447Z
+-- Generated at: 2026-05-05T23:17:04.203Z
 
 -- CREATE ROLES
 


### PR DESCRIPTION
## Summary
- Add `disable_metrics = true` to staging tfvars to suppress CloudWatch custom metric emission via `POWERTOOLS_METRICS_DISABLED`
- Remove `enable_cloudwatch_dashboard` variable (dashboards removed entirely)
- Set `dlqAlarm: false` in eventbridge config to remove unused DLQ alarm
- Regenerate infrastructure via `mantle generate infra`

## Motivation
CloudWatch costs $17.30/mo across accounts. OMD staging was emitting 50+ custom metrics unnecessarily. Dashboards ($3/mo) and DLQ alarms ($3.64/mo) provided no value at current scale.

## Changes
- `mantle.config.ts`: Added `disableMetrics: true` to observability, `dlqAlarm: false` to eventbridge, removed `enable_cloudwatch_dashboard` from customVariables
- `infra/environments/staging.tfvars`: Replaced `enable_cloudwatch_dashboard = false` with `disable_metrics = true`
- `infra/environments/production.tfvars`: Removed `enable_cloudwatch_dashboard` (no longer a variable)
- Regenerated infra: `locals.tf`, `variables.tf`, `eventbridge.tf` updated

## Cost Impact
- Staging metrics: ~$0.82/mo → $0 (POWERTOOLS_METRICS_DISABLED=true)
- Dashboards: $3/mo → $0 (variable removed)
- DLQ alarms: savings from removing unused alarm
- Production metrics remain active

## Test plan
- [ ] `mantle generate infra` produces expected output
- [ ] Deploy to staging succeeds
- [ ] Verify Lambda env vars include `POWERTOOLS_METRICS_DISABLED=true` in staging
- [ ] Verify production Lambdas do NOT have `POWERTOOLS_METRICS_DISABLED=true`
- [ ] Confirm no CloudWatch PutMetricData calls from staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)