### PR TITLE
fix(ci): add gh CLI setup for self-hosted runners

### DIFF
--- a/.github/actions/setup-gh/action.yml
+++ b/.github/actions/setup-gh/action.yml
@@ -1,0 +1,29 @@
+name: 'Setup GitHub CLI'
+description: 'Install GitHub CLI (gh) if not already available'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install gh CLI
+      shell: bash
+      run: |
+        if command -v gh &> /dev/null; then
+          echo "gh already installed: $(gh --version | head -1)"
+          exit 0
+        fi
+
+        GH_VERSION="2.74.1"
+        ARCH="$(uname -m)"
+        case "$ARCH" in
+          aarch64|arm64) ARCH="arm64" ;;
+          x86_64)        ARCH="amd64" ;;
+          *)             echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+
+        INSTALL_DIR="${RUNNER_TOOL_CACHE:-/tmp}/gh-cli"
+        mkdir -p "$INSTALL_DIR"
+        curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" \
+          | tar xz --strip-components=1 -C "$INSTALL_DIR"
+
+        echo "${INSTALL_DIR}/bin" >> "$GITHUB_PATH"
+        echo "gh ${GH_VERSION} installed to ${INSTALL_DIR}/bin"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 concurrency:
   group: integration-tests-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   integration-tests:

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -58,6 +58,7 @@ jobs:
         run: mkdir -p reports/mutation
 
       - uses: ./.github/actions/build-project
+      - uses: ./.github/actions/setup-gh
 
       - name: Download previous incremental file
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Quick validation (no build required)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 concurrency:
   group: unit-tests-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   # Parallel job 1: Validation checks (TypeSpec, API docs, config)

--- a/.github/workflows/update-agents.yml
+++ b/.github/workflows/update-agents.yml
@@ -25,6 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: ./.github/actions/setup-node-pnpm
+      - uses: ./.github/actions/setup-gh
 
       - name: Update AGENTS.md with recent PRs
         run: pnpm run update:agents:prs

--- a/.github/workflows/update-yt-dlp.yml
+++ b/.github/workflows/update-yt-dlp.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-gh
 
       - name: Check for yt-dlp updates
         id: check


### PR DESCRIPTION
## Summary
- Created `.github/actions/setup-gh/` composite action that downloads the gh CLI binary directly (no Homebrew, no sudo needed)
- Added the action to `update-agents.yml`, `update-yt-dlp.yml`, and `mutation-tests.yml`
- Set `cancel-in-progress: false` on `pr-checks.yml`, `unit-tests.yml`, and `integration-tests.yml` — self-hosted runners should queue jobs, not cancel in-progress runs
- Fixes the update-agents workflow failure introduced by #507 (self-hosted runner migration)

## Test plan
- [ ] Re-run the failed `update-agents` workflow and verify it passes
- [ ] Verify no CI runs are cancelled when multiple commits are pushed in quick succession