### PR TITLE
feat: add post-migration permission validation to MigrateDSQL

### DIFF
--- a/src/lambdas/standalone/MigrateDSQL/index.ts
+++ b/src/lambdas/standalone/MigrateDSQL/index.ts
@@ -2,8 +2,8 @@ import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {defineLambda, withObservability} from '@mantleframework/core'
 import {logInfo} from '@mantleframework/observability'
-import {applyPermissions, runMigrations} from '@mantleframework/database'
-import type {MigrateResult, PermissionsResult} from '@mantleframework/database'
+import {applyPermissions, runMigrations, validatePermissions} from '@mantleframework/database'
+import type {MigrateResult, PermissionsResult, ValidatePermissionsResult} from '@mantleframework/database'
 import {DsqlClusterArn} from '@mantleframework/core'
 import {getRequiredEnv} from '@mantleframework/env'
 
@@ -14,6 +14,7 @@ defineLambda({timeout: 300})
 interface MigrateDSQLResult {
   migrations: MigrateResult
   permissions: PermissionsResult
+  validation: ValidatePermissionsResult
 }
 
 export const handler = withObservability({operationName: 'MigrateDSQL'}, async () => {
@@ -31,5 +32,8 @@ export const handler = withObservability({operationName: 'MigrateDSQL'}, async (
   // 2. Permissions (DCL) -- idempotent, re-applied every deploy
   const permissionResult = await applyPermissions({permissionsFolder: join(__dirname, 'permissions'), database, logger})
 
-  return {migrations: migrationResult, permissions: permissionResult} satisfies MigrateDSQLResult
+  // 3. Validate grants -- detect tables that DSQL silently skipped, re-apply
+  const validationResult = await validatePermissions({permissionsFolder: join(__dirname, 'permissions'), database, logger})
+
+  return {migrations: migrationResult, permissions: permissionResult, validation: validationResult} satisfies MigrateDSQLResult
 })


### PR DESCRIPTION
## Summary

- MigrateDSQL Lambda now calls `validatePermissions()` after `applyPermissions()` to detect and re-apply grants that DSQL silently skipped due to tables not existing at the time of a prior permissions run.

## Motivation

Aurora DSQL silently succeeds on `GRANT ... ON <nonexistent_table>` without raising an error. If a prior deploy was interrupted between migrations and permissions, grants appear applied but have no effect. The new validation step catches this and re-applies all grants to ensure consistency.

## Sister PRs

- `mantle` (framework): feat/database-changes-guide — adds `validatePermissions()` to `@mantleframework/database`, `mantle check migrations` CLI, trigger hash fix, and comprehensive guide

## Test plan

- [x] `npx mantle build` passes (27 functions)
- [x] Typecheck passes
- [x] Deploy to staging and invoke MigrateDSQL to verify validation step
