### PR TITLE
feat(mcp): register DevTools MCP server for Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,8 @@ deployment-logs/
 # Mantle CLI temp directories
 .mantle-openapi-tmp-*
 
+# Terraform variable overrides (contains secrets)
+infra/terraform.tfvars
+
 # Config coverage reports (generated)
 config/coverage/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "mantle": {
+      "command": "node",
+      "args": ["../mantle/packages/cli/dist/mcp/mcp-entry.mjs"]
+    },
+    "devtools": {
+      "type": "http",
+      "url": "https://fs5icedcqpemzm2th4zdrk33ra0fvula.lambda-url.us-west-2.on.aws/",
+      "headers": {
+        "Authorization": "Bearer ${DEVTOOLS_OMD_TOKEN}"
+      }
+    }
+  }
+}

--- a/infra/outputs_custom.tf
+++ b/infra/outputs_custom.tf
@@ -1,0 +1,4 @@
+output "dev_tools_function_url" {
+  description = "DevTools MCP server Function URL"
+  value       = module.lambda_dev_tools.function_url
+}


### PR DESCRIPTION
## Summary
- Add `.mcp.json` with DevTools HTTP MCP server registration so Claude Code discovers AWS operational tools automatically
- Add `infra/outputs_custom.tf` to expose DevTools function URL as Terraform output
- Add `infra/terraform.tfvars` to `.gitignore` to prevent bearer token from being committed

## Test plan
- [x] Verified DevTools Lambda Function URL responds correctly via curl
- [x] Verified Claude Code discovers and calls DevTools tools from both monorepo and standalone repo contexts
- [x] `verify_credentials`, `fetch_lambda_logs`, `list_s3_objects` all confirmed working