### PR TITLE
fix(webhook,infra): ensure user_files association + route multi-auth through authorizer

### DIFF
--- a/src/lambdas/api/feedly/webhook.post.ts
+++ b/src/lambdas/api/feedly/webhook.post.ts
@@ -9,7 +9,7 @@
  * Output: APIGatewayProxyResult with file metadata
  */
 import {buildValidatedResponse, defineLambda, emitEvent} from '@mantleframework/core'
-import {addAnnotation, addMetadata, endSpan, logError, logInfo, metrics, MetricUnit, startSpan} from '@mantleframework/observability'
+import {addAnnotation, addMetadata, endSpan, logInfo, metrics, MetricUnit, startSpan} from '@mantleframework/observability'
 import {createIdempotencyStore, IdempotencyConfig, makeIdempotent} from '@mantleframework/resilience'
 import {defineApiHandler, z} from '@mantleframework/validation'
 defineLambda({bind: {SNS_QUEUE_URL: 'SendPushNotification'}})
@@ -24,6 +24,11 @@ import type {WebhookProcessingInput, WebhookProcessingResult} from '#types/lambd
 /**
  * Core webhook processing logic - wrapped with idempotency.
  * Idempotency ensures duplicate webhook calls return the same response.
+ *
+ * IMPORTANT: The file record MUST exist before associating it to the user.
+ * The user_files junction table association must happen AFTER addFile() for new files,
+ * otherwise the association silently fails (Promise.allSettled swallows the error)
+ * and the file becomes invisible to GET /files which uses an INNER JOIN through user_files.
  */
 async function processWebhookRequest(input: WebhookProcessingInput): Promise<WebhookProcessingResult> {
   const {fileId, userId, articleURL, correlationId} = input
@@ -33,29 +38,33 @@ async function processWebhookRequest(input: WebhookProcessingInput): Promise<Web
   addMetadata(span, 'userId', userId)
 
   try {
-    const [assocResult, fileResult] = await Promise.allSettled([associateFileToUser(fileId, userId), getFile(fileId)])
-    const file = fileResult.status === 'fulfilled' ? fileResult.value : undefined
-    if (assocResult.status === 'rejected') {
-      logError('Failed to associate file to user', {fileId, userId, error: String(assocResult.reason)})
+    // Step 1: Check if file already exists
+    const file = await getFile(fileId)
+
+    // Step 2: Create file record if it doesn't exist yet
+    if (!file) {
+      await addFile(fileId, articleURL, correlationId)
+      addMetadata(span, 'newFile', true)
     }
 
+    // Step 3: Associate file to user AFTER file is guaranteed to exist
+    await associateFileToUser(fileId, userId)
+
+    // Step 4: If file is already downloaded, notify user immediately
     if (file && file.status === FileStatus.Downloaded) {
       await sendFileNotification(file, userId)
       addMetadata(span, 'action', 'dispatched')
       endSpan(span)
       return {statusCode: 200, status: ResponseStatus.Dispatched}
-    } else {
-      if (!file) {
-        await addFile(fileId, articleURL, correlationId)
-        addMetadata(span, 'newFile', true)
-      }
-      const eventDetail: DownloadRequestedDetail = {fileId, userId, sourceUrl: articleURL, correlationId, requestedAt: new Date().toISOString()}
-      await emitEvent({detailType: 'DownloadRequested', detail: eventDetail})
-      logInfo('Published DownloadRequested event', {fileId, correlationId})
-      addMetadata(span, 'action', 'accepted')
-      endSpan(span)
-      return {statusCode: 202, status: ResponseStatus.Accepted}
     }
+
+    // Step 5: File is new or still processing — emit download event
+    const eventDetail: DownloadRequestedDetail = {fileId, userId, sourceUrl: articleURL, correlationId, requestedAt: new Date().toISOString()}
+    await emitEvent({detailType: 'DownloadRequested', detail: eventDetail})
+    logInfo('Published DownloadRequested event', {fileId, correlationId})
+    addMetadata(span, 'action', 'accepted')
+    endSpan(span)
+    return {statusCode: 202, status: ResponseStatus.Accepted}
   } catch (error) {
     endSpan(span, error as Error)
     throw error

--- a/test/lambdas/api/feedly/webhook.post.test.ts
+++ b/test/lambdas/api/feedly/webhook.post.test.ts
@@ -193,22 +193,87 @@ describe('WebhookFeedly Lambda', () => {
     expect(metrics.addMetric).toHaveBeenCalledWith('WebhookProcessed', 'Count', 1)
   })
 
-  it('should handle associateFileToUser failure gracefully', async () => {
+  it('should propagate associateFileToUser failure as error', async () => {
     vi.mocked(associateFileToUser).mockRejectedValue(new Error('DB error'))
     vi.mocked(getFile).mockResolvedValue(null as never)
     vi.mocked(createFile).mockResolvedValue(undefined as never)
     vi.mocked(createFileDownload).mockResolvedValue(undefined as never)
     vi.mocked(emitEvent).mockResolvedValue(undefined as never)
 
-    const result = await handler({
+    await expect(
+      handler({
+        context: {awsRequestId: 'req-1'},
+        userId: 'user-1',
+        body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+        metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+      })
+    ).rejects.toThrow('DB error')
+
+    // File should be created before association is attempted
+    expect(createFile).toHaveBeenCalled()
+    expect(createFileDownload).toHaveBeenCalled()
+    // Event should NOT be emitted since association failed
+    expect(emitEvent).not.toHaveBeenCalled()
+  })
+
+  it('should call associateFileToUser AFTER addFile for new files', async () => {
+    const callOrder: string[] = []
+    vi.mocked(getFile).mockResolvedValue(null as never)
+    vi.mocked(createFile).mockImplementation(async () => {
+      callOrder.push('createFile')
+      return undefined as never
+    })
+    vi.mocked(createFileDownload).mockImplementation(async () => {
+      callOrder.push('createFileDownload')
+      return undefined as never
+    })
+    vi.mocked(associateFileToUser).mockImplementation(async () => {
+      callOrder.push('associateFileToUser')
+      return undefined as never
+    })
+    vi.mocked(emitEvent).mockResolvedValue(undefined as never)
+
+    await handler({
       context: {awsRequestId: 'req-1'},
       userId: 'user-1',
       body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
       metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
     })
 
-    // Should still process successfully despite association failure
-    expect(result.statusCode).toBe(202)
+    // Association MUST happen after file creation to avoid orphaned user_files rows
+    expect(callOrder.indexOf('createFile')).toBeLessThan(callOrder.indexOf('associateFileToUser'))
+    expect(callOrder.indexOf('createFileDownload')).toBeLessThan(callOrder.indexOf('associateFileToUser'))
+  })
+
+  it('should associate file to user even for already-downloaded files', async () => {
+    vi.mocked(associateFileToUser).mockResolvedValue(undefined as never)
+    vi.mocked(getFile).mockResolvedValue(
+      {
+        fileId: 'dQw4w9WgXcQ',
+        size: 1000,
+        authorName: 'A',
+        authorUser: 'a',
+        publishDate: '2024-01-01',
+        description: 'D',
+        key: 'dQw4w9WgXcQ.mp4',
+        contentType: 'video/mp4',
+        title: 'Test',
+        status: 'Downloaded',
+        url: 'https://cdn/file.mp4'
+      } as never
+    )
+    vi.mocked(sendMessage).mockResolvedValue({MessageId: 'msg-1'} as never)
+
+    await handler({
+      context: {awsRequestId: 'req-1'},
+      userId: 'user-1',
+      body: {articleURL: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'},
+      metadata: {correlationId: 'corr-1', traceId: 'trace-1'}
+    })
+
+    // Association must always be called, even for existing downloaded files
+    // (handles the case where a second user requests an already-downloaded file)
+    expect(associateFileToUser).toHaveBeenCalledWith('dQw4w9WgXcQ', 'user-1')
   })
 
   it('should extract videoID from article URL', async () => {


### PR DESCRIPTION
## Summary

- **Root cause 1 (webhook):** `Promise.allSettled` in Feedly webhook ran `associateFileToUser` concurrently with file creation — for new files, the association INSERT executed before the file record existed, silently failing.
- **Root cause 2 (infra):** `FilesGet` and `DeviceRegister` had `authorization = "NONE"` in API Gateway, bypassing the custom authorizer entirely. Requests reached the handler with no auth context, causing the anonymous branch (default-file-only) to execute even for authenticated users.
- **Root cause 3 (generator):** Mantle CLI's `buildAuthorizationBlock` mapped `auth: 'authorizer-optional'` to `authorization = "NONE"`, which is why the infra bug existed in the first place.

## Fixes

1. **Webhook:** Sequential flow — check/create file → then associate to user. Association failures now propagate instead of being swallowed.
2. **Infra:** Changed `FilesGet` and `DeviceRegister` to `authorization = "CUSTOM"` + `authorizer_id`, then regenerated all `.tf` files via `mantle generate infra`.
3. **Mantle CLI generator:** `buildAuthorizationBlock` now maps both `'authorizer'` and `'authorizer-optional'` to `CUSTOM` auth. Validation also updated.

## Critical constraint: authorizer TTL

Authorizer MUST stay at `ttl = 0`. TTL > 0 causes API Gateway to add `method.request.header.Authorization` to `identity_source`, which blocks anonymous requests on multi-auth paths before the authorizer Lambda even runs.

## Companion PR

- iOS client fix: https://github.com/j0nathan-ll0yd/ios-OfflineMediaDownloader/pull/62

## Test plan

- [x] `npx mantle build` succeeds (20 functions)
- [x] `npx vitest run test/lambdas/api/feedly/webhook.post.test.ts` — 8 tests pass
- [x] Pre-commit hooks pass (secrets, dependency architecture, docs structure)
- [x] Deploy to staging and verify `GET /files?status=all` returns all files for authenticated user
- [x] Verify Feedly webhook creates proper `user_files` association for new files
- [x] Full E2E: add video via Feedly -> server download -> local download -> refresh -> video persists
- [x] All infra files generated by `mantle generate infra` (no hand-written `.tf` files)
- [x] 547 CLI unit tests pass after generator change

## Commits in this PR

- `7e86b366` fix(infra): route multi-auth endpoints through custom authorizer
- `085c8943` chore(infra): regenerate all tf via mantle generate infra
