### PR TITLE
fix(infra): correct DLQ module reference

### DIFF
--- a/infra/generated_dsql_permissions.tf
+++ b/infra/generated_dsql_permissions.tf
@@ -3,7 +3,7 @@
 
 # Auto-generated from @RequiresTable decorators
 # Do not edit manually - run: mantle generate permissions
-# Generated at: 2026-05-11T16:49:45.800Z
+# Generated at: 2026-05-11T17:11:01.196Z
 
 locals {
   lambda_dsql_roles = {

--- a/infra/lambda_s3object_created.tf
+++ b/infra/lambda_s3object_created.tf
@@ -17,7 +17,7 @@ module "lambda_s3object_created" {
   log_retention_days     = var.log_retention_days
   log_level              = var.log_level
   tags                   = module.core.common_tags
-  dead_letter_target_arn = module.lambda_s3object_created_dlq.queue_arn
+  dead_letter_target_arn = module.queue_lambda_s3object_created_dlq.queue_arn
   layers                 = [local.adot_layer_arn]
 
   api_gateway_enabled = false


### PR DESCRIPTION
## Summary
- DLQ reference in lambda_s3object_created.tf used `module.lambda_s3object_created_dlq` but the queue module is named `module.queue_lambda_s3object_created_dlq`
- Regenerated infra with corrected CLI to fix the reference

## Test plan
- [x] `tofu init` succeeds
- [x] `mantle check --severity HIGH` passes