### PR TITLE
chore(deps): bump zod to 4.4.3 to align with framework catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
     "postgres": "^3.4.9",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "sideEffects": false,
   "imports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,13 +58,13 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9)
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(zod@4.4.3)
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@aws-sdk/client-cloudwatch-logs':
         specifier: 3.1045.0
@@ -5767,8 +5767,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -7429,7 +7429,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
@@ -7446,8 +7446,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9454,10 +9454,10 @@ snapshots:
       kysely: 0.28.14
       postgres: 3.4.9
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(zod@4.4.3):
     dependencies:
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9)
-      zod: 4.3.6
+      zod: 4.4.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -10515,7 +10515,7 @@ snapshots:
 
   mutation-server-protocol@0.4.1:
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   mutation-testing-elements@3.7.3: {}
 
@@ -11057,7 +11057,7 @@ snapshots:
   repomix@1.14.0(typescript@6.0.3):
     dependencies:
       '@clack/prompts': 0.11.0
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@repomix/strip-comments': 2.4.2
       '@repomix/tree-sitter-wasms': 0.1.17
       '@secretlint/core': 11.7.1
@@ -11082,7 +11082,7 @@ snapshots:
       tinypool: 2.1.0
       valibot: 1.4.0(typescript@6.0.3)
       web-tree-sitter: 0.26.8
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -11914,10 +11914,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
Aligns the instance zod version with the framework catalog pin (now at ^4.4.3).\n\n### Changes\n- Bumps direct zod dependency from 4.3.6 to 4.4.3\n- Resolves prior mismatch between drizzle-zod peer dep and instance dep\n\n### Verification\n- [x] Local CI passes (build, typecheck, lint, tests, conventions)\n- [x] `pnpm typecheck` clean with zod 4.4.3\n\n### Pre-merge checklist\n- [ ] GitHub CI passes\n\nConfidence: high\nScope-risk: narrow