### PR TITLE
fix(infra): disable CloudWatch custom metrics in production and fix MigrateDSQL

### DIFF
--- a/infra/environments/production.tfvars
+++ b/infra/environments/production.tfvars
@@ -16,6 +16,9 @@ api_quota_limit          = 10000
 # Protect production data
 dsql_deletion_protection = true
 
+# Disable custom CloudWatch metrics to stay within AWS Free Tier
+disable_metrics = true
+
 # Production concurrency
 reserved_concurrency_start_file_upload = 10
 

--- a/infra/migrate_dsql.tf
+++ b/infra/migrate_dsql.tf
@@ -18,14 +18,14 @@ module "lambda_migrate_dsql" {
   tags               = module.core.common_tags
   timeout            = 300
 
-  environment_variables = {
+  environment_variables = merge(local.common_lambda_env, {
     DSQL_ENDPOINT     = module.database.cluster_endpoint
     DSQL_REGION       = module.core.region
     DSQL_ROLE_NAME    = "admin"
     METRICS_NAMESPACE = "MediaDownloader"
     AWS_ACCOUNT_ID    = module.core.account_id
     RESOURCE_PREFIX   = module.core.name_prefix
-  }
+  })
 
   additional_policy_arns = [module.database.admin_connect_policy_arn]
 }


### PR DESCRIPTION
Add \`disable_metrics = true\` to \`infra/environments/production.tfvars\` to stay within AWS Free Tier.

Fix \`MigrateDSQL\` Lambda to inherit \`POWERTOOLS_METRICS_DISABLED\` from \`common_lambda_env\` via \`merge()\` instead of using a hardcoded env var block that excluded it.

**Files changed:**
- \`infra/environments/production.tfvars\` - add disable_metrics
- \`infra/migrate_dsql.tf\` - merge with common_lambda_env

**CI:** All 9 checks passed.