### PR TITLE
fix(docker): pin ffmpeg to BtbN immutable autobuild

### DIFF
--- a/docker/Dockerfile.download
+++ b/docker/Dockerfile.download
@@ -37,8 +37,12 @@ ADD https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86
 RUN cd /tmp && unzip deno.zip && chmod +x deno && mv deno /opt/bin/deno && rm deno.zip
 
 # --- ffmpeg + ffprobe (static build for stream muxing and analysis) ---
-ADD https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz /tmp/ffmpeg.tar.xz
-RUN cd /tmp && tar xf ffmpeg.tar.xz --wildcards '*/ffmpeg' '*/ffprobe' --strip-components=1 \
+# BtbN/FFmpeg-Builds is pinned to an immutable autobuild tag so this URL never silently
+# changes. Bump FFMPEG_BUILD and FFMPEG_ASSET together when refreshing.
+ARG FFMPEG_BUILD=autobuild-2026-06-08-14-24
+ARG FFMPEG_ASSET=ffmpeg-n7.1.4-9-gc06af95f12-linux64-gpl-7.1
+ADD https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BUILD}/${FFMPEG_ASSET}.tar.xz /tmp/ffmpeg.tar.xz
+RUN cd /tmp && tar xf ffmpeg.tar.xz --wildcards '*/bin/ffmpeg' '*/bin/ffprobe' --strip-components=2 \
   && chmod +x ffmpeg ffprobe && mv ffmpeg ffprobe /opt/bin/ && rm ffmpeg.tar.xz
 
 # --- yt-dlp cookies (SOPS-encrypted in repo, decrypted before build) ---


### PR DESCRIPTION
## Summary

`johnvansickle.com` started serving a corrupt `ffmpeg-release-amd64-static.tar.xz` (`xz: File format not recognized`), breaking the `StartFileUpload` container Lambda build on main (see run [27170826282](https://github.com/j0nathan-ll0yd/mantle-OfflineMediaDownloader/actions/runs/27170826282)). The URL was unversioned, so there was no safe known-good payload to roll back to.

Switching to [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds), pinned to the immutable autobuild tag `autobuild-2026-06-08-14-24`. This matches the rest of `Dockerfile.download`, where every binary (yt-dlp, bgutil, deno) is already pinned via an `ARG`.

## Changes

- `docker/Dockerfile.download`: replace the johnvansickle URL with BtbN. Asset filename and internal layout differ (`<topdir>/bin/{ffmpeg,ffprobe}` instead of `<topdir>/{ffmpeg,ffprobe}`), so the tar extract grows to `--strip-components=2` with `bin/` in the wildcard pattern.
- New `FFMPEG_BUILD` + `FFMPEG_ASSET` ARGs so future bumps are a one-line change. They must be updated together — BtbN encodes the commit hash into the asset filename.

## Verification

Extracted in the actual Lambda base image (`public.ecr.aws/lambda/nodejs:24-x86_64`):

```
ffmpeg version n7.1.4-9-gc06af95f12-20260608 Copyright (c) 2000-2026 the FFmpeg developers
ffprobe version n7.1.4-9-gc06af95f12-20260608 Copyright (c) 2007-2026 the FFmpeg developers
```

## Test plan

- [x] Manual extract test in `public.ecr.aws/lambda/nodejs:24-x86_64`
- [x] CI green on this PR (full `mantle build` exercises the real container layer)
- [ ] After merge, smoke-test a yt-dlp download in staging to confirm runtime stream muxing still works

## Notes

This PR only addresses the OMD build failure. LP's matching main-failure (TS2883 on `@types/aws-lambda`) was already fixed by #92.
