### PR TITLE
fix(lint): apply unicorn v66 auto-fixes from shared eslint-config

### DIFF
--- a/graphrag/extract.ts
+++ b/graphrag/extract.ts
@@ -420,7 +420,7 @@ function extractAwsServices(deps: string[], awsServices: ServiceMetadata[]): str
       }
     }
   }
-  return Array.from(services)
+  return [...services]
 }
 
 /**
@@ -469,7 +469,7 @@ function extractExternalServices(deps: string[], externalServices: ServiceMetada
       services.add('GitHub')
     }
   }
-  return Array.from(services)
+  return [...services]
 }
 
 /**
@@ -494,7 +494,9 @@ function extractEntities(deps: string[], knownEntities: string[]): string[] {
     if (queryMatch) {
       const queryModule = queryMatch[1]
       const mappedEntities = queryModuleToEntities[queryModule] || []
-      mappedEntities.forEach((e) => entities.add(e))
+      for (const e of mappedEntities) {
+        entities.add(e)
+      }
     }
 
     // Match src/entities/queries barrel import (without specific file)
@@ -516,7 +518,7 @@ function extractEntities(deps: string[], knownEntities: string[]): string[] {
       }
     }
   }
-  return Array.from(entities)
+  return [...entities]
 }
 
 /**
@@ -796,22 +798,22 @@ async function main() {
     console.log('Relationship Types:', stats.relationshipTypes)
 
     console.log('\nMost Connected Nodes:')
-    stats.mostConnected.forEach((item) => {
+    for (const item of stats.mostConnected) {
       console.log(`  ${item.node}: ${item.connections} connections`)
-    })
+    }
 
     if (stats.lambdaChains.length > 0) {
       console.log('\nLambda Invocation Chains:')
-      stats.lambdaChains.forEach((chain) => {
+      for (const chain of stats.lambdaChains) {
         console.log('  ' + chain.join(' → '))
-      })
+      }
     }
 
     if (stats.missingMetadata.length > 0) {
       console.log('\n⚠️  Lambdas missing metadata in graphrag/metadata.json:')
-      stats.missingMetadata.forEach((name) => {
+      for (const name of stats.missingMetadata) {
         console.log(`  - ${name}`)
-      })
+      }
     }
   } catch (error) {
     console.error('Error extracting knowledge graph:', error)

--- a/graphrag/query.ts
+++ b/graphrag/query.ts
@@ -330,9 +330,9 @@ async function main() {
   console.log('\n=== Multi-hop Reasoning ===')
   const paths = query.findPaths('lambda:StartFileUpload', 'lambda:SendPushNotification')
   console.log('Paths from StartFileUpload to SendPushNotification:')
-  paths.forEach((path, i) => {
+  for (const [i, path] of paths.entries()) {
     console.log(`  Path ${i + 1}: ${path.join(' → ')}`)
-  })
+  }
 
   // Impact analysis
   console.log('\n=== Impact Analysis ===')

--- a/scripts/embeddings.ts
+++ b/scripts/embeddings.ts
@@ -21,5 +21,5 @@ async function getExtractor(): Promise<FeatureExtractionPipeline> {
 export async function generateEmbedding(text: string): Promise<number[]> {
   const model = await getExtractor()
   const output = await model(text, {pooling: 'mean', normalize: true})
-  return Array.from(output.data as Float32Array)
+  return [...output.data as Float32Array]
 }

--- a/scripts/extract-youtube-cookies-chrome.mjs
+++ b/scripts/extract-youtube-cookies-chrome.mjs
@@ -24,13 +24,13 @@ function findChromeExecutable() {
   if (platform === 'darwin') {
     // macOS
     return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-  } else if (platform === 'win32') {
+  }
+  if (platform === 'win32') {
     // Windows
     return 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
-  } else {
-    // Linux
-    return '/usr/bin/google-chrome'
   }
+  // Linux
+  return '/usr/bin/google-chrome'
 }
 
 // Convert Puppeteer cookies to Netscape format

--- a/scripts/indexCodebase.ts
+++ b/scripts/indexCodebase.ts
@@ -205,7 +205,7 @@ async function createChunk(node: any, type: string, name: string, filePath: stri
 
   // Extract documentation if present
   const jsDoc = extractJsDoc(node)
-  const docSection = jsDoc ? `\nDocumentation: ${jsDoc.replace(/\/\*\*|\*\/|\n\s*\*/g, ' ').trim()}\n` : ''
+  const docSection = jsDoc ? `\nDocumentation: ${jsDoc.replaceAll(/\/\*\*|\*\/|\n\s*\*/g, ' ').trim()}\n` : ''
 
   // Create enhanced context header for better conceptual query matching
   const contextHeader = `File: ${filePath}

--- a/scripts/searchCodebase.ts
+++ b/scripts/searchCodebase.ts
@@ -25,7 +25,7 @@ const QUERY_EXPANSIONS: Record<string, string[]> = {
  * Type boost factors - higher values boost certain types for specific queries
  */
 const TYPE_BOOSTS: Record<string, number> = {
-  function: 1.0,
+  function: 1,
   class: 0.95,
   interface: 0.9,
   variable: 0.85,
@@ -84,7 +84,7 @@ function applyTypeBoost(results: SearchResult[], query: string): SearchResult[] 
   const typespecBoost = lowerQuery.includes('api') || lowerQuery.includes('schema') ? 1.1 : 0.9
 
   return results.map((r) => {
-    let boost = TYPE_BOOSTS[r.type] || 1.0
+    let boost = TYPE_BOOSTS[r.type] || 1
     if (r.type === 'documentation') {
       boost = docBoost
     } else if (r.type.startsWith('typespec')) {
@@ -98,7 +98,7 @@ function applyTypeBoost(results: SearchResult[], query: string): SearchResult[] 
  * Search the codebase with optional query expansion and type boosting
  */
 export async function search(query: string, options: SearchOptions = {}): Promise<SearchResult[]> {
-  const {limit = 5, expand = true, maxDistance = 1.0} = options
+  const {limit = 5, expand = true, maxDistance = 1} = options
 
   const db = await lancedb.connect(DB_DIR)
   const table = await db.openTable(TABLE_NAME)
@@ -136,7 +136,7 @@ Results for query: "${query}"
     console.log(`--- Result (Distance: ${distanceStr}) ---`)
     console.log(`File: ${result.filePath}:${result.startLine}`)
     console.log(`Type: ${result.type}, Name: ${result.name}`)
-    console.log(`Preview: ${result.text.substring(0, 100).replace(/\n/g, ' ')}...`)
+    console.log(`Preview: ${result.text.slice(0, 100).replaceAll('\n', ' ')}...`)
     console.log()
   }
 }

--- a/src/domain/auth/sessionService.ts
+++ b/src/domain/auth/sessionService.ts
@@ -22,13 +22,13 @@ import type {SessionPayload} from '#types/util'
  * @throws UnauthorizedError if token is invalid or expired
  */
 export async function validateSessionToken(token: string): Promise<SessionPayload> {
-  logDebug('validateSessionToken: validating token', {tokenLength: token.length, tokenPrefix: token.substring(0, 8)})
+  logDebug('validateSessionToken: validating token', {tokenLength: token.length, tokenPrefix: token.slice(0, 8)})
 
   // Use index for O(1) lookup
   const session = await getSessionByToken(token)
 
   if (!session) {
-    logError('validateSessionToken: session not found', {tokenPrefix: token.substring(0, 8), tokenLength: token.length})
+    logError('validateSessionToken: session not found', {tokenPrefix: token.slice(0, 8), tokenLength: token.length})
     throw new UnauthorizedError('Invalid session token')
   }
 

--- a/src/domain/error/authErrorClassifier.ts
+++ b/src/domain/error/authErrorClassifier.ts
@@ -31,16 +31,16 @@ export function classifyAuthError(error: Error): ErrorClassification {
       retryable: true,
       retryDelayMs: 1000,
       maxRetries: 3,
-      reason: `Transient auth service error: ${message.substring(0, 100)}`,
+      reason: `Transient auth service error: ${message.slice(0, 100)}`,
       createIssue: false
     }
   }
 
   // Check for invalid credentials
   if (AUTH_INVALID_PATTERNS.some((p) => message.includes(p))) {
-    return {category: 'auth_invalid', retryable: false, maxRetries: 0, reason: `Invalid authentication: ${message.substring(0, 100)}`, createIssue: false}
+    return {category: 'auth_invalid', retryable: false, maxRetries: 0, reason: `Invalid authentication: ${message.slice(0, 100)}`, createIssue: false}
   }
 
   // Default: treat as invalid auth (user needs to take action)
-  return {category: 'auth_invalid', retryable: false, maxRetries: 0, reason: `Auth failure: ${message.substring(0, 100)}`, createIssue: false}
+  return {category: 'auth_invalid', retryable: false, maxRetries: 0, reason: `Auth failure: ${message.slice(0, 100)}`, createIssue: false}
 }

--- a/src/domain/error/databaseErrorClassifier.ts
+++ b/src/domain/error/databaseErrorClassifier.ts
@@ -52,7 +52,7 @@ export function classifyDatabaseError(error: Error): ErrorClassification {
       retryable: true,
       retryDelayMs: 500,
       maxRetries: 3,
-      reason: `Transient database error: ${message.substring(0, 100)}`,
+      reason: `Transient database error: ${message.slice(0, 100)}`,
       createIssue: false
     }
   }
@@ -66,7 +66,7 @@ export function classifyDatabaseError(error: Error): ErrorClassification {
       category: 'permanent',
       retryable: false,
       maxRetries: 0,
-      reason: `Database constraint error: ${message.substring(0, 100)}`,
+      reason: `Database constraint error: ${message.slice(0, 100)}`,
       createIssue: true,
       issuePriority: 'high'
     }
@@ -80,7 +80,7 @@ export function classifyDatabaseError(error: Error): ErrorClassification {
       retryable: true,
       retryDelayMs: 1000,
       maxRetries: 2,
-      reason: `Unknown database error: ${message.substring(0, 100)}`,
+      reason: `Unknown database error: ${message.slice(0, 100)}`,
       createIssue: false
     }
   }
@@ -91,7 +91,7 @@ export function classifyDatabaseError(error: Error): ErrorClassification {
     retryable: true,
     retryDelayMs: 1000,
     maxRetries: 2,
-    reason: `Unknown database error: ${message.substring(0, 100)}`,
+    reason: `Unknown database error: ${message.slice(0, 100)}`,
     createIssue: false
   }
 }

--- a/src/domain/error/externalApiErrorClassifier.ts
+++ b/src/domain/error/externalApiErrorClassifier.ts
@@ -39,7 +39,7 @@ export function classifyExternalApiError(error: Error, serviceName: string): Err
       retryable: true,
       retryDelayMs: 60000, // 1 minute for rate limits
       maxRetries: 3,
-      reason: `${serviceName} rate limit: ${message.substring(0, 100)}`,
+      reason: `${serviceName} rate limit: ${message.slice(0, 100)}`,
       createIssue: false
     }
   }
@@ -51,7 +51,7 @@ export function classifyExternalApiError(error: Error, serviceName: string): Err
       retryable: true,
       retryDelayMs: 5000,
       maxRetries: 3,
-      reason: `${serviceName} transient error: ${message.substring(0, 100)}`,
+      reason: `${serviceName} transient error: ${message.slice(0, 100)}`,
       createIssue: false
     }
   }
@@ -62,7 +62,7 @@ export function classifyExternalApiError(error: Error, serviceName: string): Err
       category: 'permanent',
       retryable: false,
       maxRetries: 0,
-      reason: `${serviceName} client error: ${message.substring(0, 100)}`,
+      reason: `${serviceName} client error: ${message.slice(0, 100)}`,
       createIssue: true,
       issuePriority: 'normal'
     }
@@ -73,7 +73,7 @@ export function classifyExternalApiError(error: Error, serviceName: string): Err
     category: 'permanent',
     retryable: false,
     maxRetries: 0,
-    reason: `${serviceName} error: ${message.substring(0, 100)}`,
+    reason: `${serviceName} error: ${message.slice(0, 100)}`,
     createIssue: true,
     issuePriority: 'normal'
   }

--- a/src/domain/video/errorClassifier.ts
+++ b/src/domain/video/errorClassifier.ts
@@ -208,7 +208,7 @@ export function classifyVideoError(error: Error, videoInfo?: SchedulingVideoInfo
       retryable: true,
       retryAfter: calculateExponentialBackoff(retryCount),
       maxRetries: DEFAULT_MAX_RETRIES.transient,
-      reason: `Transient error detected: ${errorMessage.substring(0, 100)}`,
+      reason: `Transient error detected: ${errorMessage.slice(0, 100)}`,
       createIssue: false
     }
   }
@@ -220,7 +220,7 @@ export function classifyVideoError(error: Error, videoInfo?: SchedulingVideoInfo
       retryable: true,
       retryAfter: calculateExponentialBackoff(retryCount),
       maxRetries: DEFAULT_MAX_RETRIES.transient,
-      reason: `SABR streaming restriction detected - format fallback may resolve: ${errorMessage.substring(0, 100)}`,
+      reason: `SABR streaming restriction detected - format fallback may resolve: ${errorMessage.slice(0, 100)}`,
       createIssue: false
     }
   }
@@ -231,7 +231,7 @@ export function classifyVideoError(error: Error, videoInfo?: SchedulingVideoInfo
       category: 'permanent',
       retryable: false,
       maxRetries: DEFAULT_MAX_RETRIES.permanent,
-      reason: `Permanent failure: ${errorMessage.substring(0, 200)}`,
+      reason: `Permanent failure: ${errorMessage.slice(0, 200)}`,
       createIssue: true,
       issuePriority: 'normal'
     }
@@ -244,7 +244,7 @@ export function classifyVideoError(error: Error, videoInfo?: SchedulingVideoInfo
     retryable: true,
     retryAfter: calculateExponentialBackoff(retryCount),
     maxRetries: DEFAULT_MAX_RETRIES.transient,
-    reason: `Unknown error, treating as transient: ${errorMessage.substring(0, 100)}`,
+    reason: `Unknown error, treating as transient: ${errorMessage.slice(0, 100)}`,
     createIssue: false
   }
 }

--- a/src/integrations/github/errorFingerprint.ts
+++ b/src/integrations/github/errorFingerprint.ts
@@ -9,7 +9,7 @@ export type { FingerprintInput, FingerprintResult } from '#types/errorFingerprin
  */
 function normalizeStackFrame(frame: string): string {
   // Remove line:column patterns like :123:45 or :123
-  let normalized = frame.replace(/:\d+(?::\d+)?/g, '')
+  let normalized = frame.replaceAll(/:\d+(?::\d+)?/g, '')
 
   // Remove absolute paths, keep only filename
   normalized = normalized.replace(/.*[/\\]([^/\\]+)$/, '$1')
@@ -89,7 +89,7 @@ export function generateErrorFingerprint(input: FingerprintInput): FingerprintRe
   const hashInput = components.join('|')
   const hash = createHash('sha256').update(hashInput).digest('hex')
 
-  return {fingerprint: `error-fp-${hash.substring(0, 12)}`, summary: components.join(', ')}
+  return {fingerprint: `error-fp-${hash.slice(0, 12)}`, summary: components.join(', ')}
 }
 
 /**

--- a/src/lambdas/api/device/event.post.ts
+++ b/src/lambdas/api/device/event.post.ts
@@ -21,7 +21,7 @@ export const handler = api(async ({event, context, userId, body}) => {
 
   if (userId) {
     const userDevices = await getUserDevicesByDeviceId(deviceId)
-    if (!userDevices.some((ud) => ud.userId === userId)) {
+    if (userDevices.every((ud) => !(ud.userId === userId))) {
       return buildValidatedResponse(context, 403)
     }
   }

--- a/src/lambdas/api/device/register.post.ts
+++ b/src/lambdas/api/device/register.post.ts
@@ -96,12 +96,12 @@ export const handler = api(async ({context, userId, userStatus, body}) => {
     const userDevices = await getUserDevices(userId)
     if (userDevices.length === 1) {
       return buildValidatedResponse(context, 200, {endpointArn: device.endpointArn}, deviceRegistrationResponseSchema)
-    } else {
-      const subscriptionArn = await getSubscriptionArnFromEndpointAndTopic(device.endpointArn, pushNotificationTopicArn)
-      await unsubscribeEndpointToTopic(subscriptionArn)
-      return buildValidatedResponse(context, 201, {endpointArn: platformEndpoint.EndpointArn}, deviceRegistrationResponseSchema)
     }
-  } else if (userStatus === UserStatus.Anonymous) {
+    const subscriptionArn = await getSubscriptionArnFromEndpointAndTopic(device.endpointArn, pushNotificationTopicArn)
+    await unsubscribeEndpointToTopic(subscriptionArn)
+    return buildValidatedResponse(context, 201, {endpointArn: platformEndpoint.EndpointArn}, deviceRegistrationResponseSchema)
+  }
+  if (userStatus === UserStatus.Anonymous) {
     await subscribeEndpointToTopic(device.endpointArn, pushNotificationTopicArn)
   }
 

--- a/src/lambdas/api/user/login.post.ts
+++ b/src/lambdas/api/user/login.post.ts
@@ -65,7 +65,7 @@ export const handler = api(async ({event, context, body}) => {
   logInfo('LoginUser: Better Auth sign-in successful', {
     userId: result.user.id,
     sessionToken: 'present',
-    sessionId: session.id.substring(0, 8),
+    sessionId: session.id.slice(0, 8),
     expiresAt: session.expiresAt
   })
 

--- a/src/lambdas/api/user/register.post.ts
+++ b/src/lambdas/api/user/register.post.ts
@@ -96,7 +96,7 @@ export const handler = api(async ({event, context, body}) => {
   logInfo('RegisterUser: Better Auth sign-in/registration successful', {
     userId: result.userId,
     sessionToken: 'present',
-    sessionId: result.sessionId.substring(0, 8),
+    sessionId: result.sessionId.slice(0, 8),
     expiresAt: result.expiresAt,
     isNewUser: result.isNewUser
   })

--- a/src/lambdas/s3/S3ObjectCreated/index.ts
+++ b/src/lambdas/s3/S3ObjectCreated/index.ts
@@ -26,9 +26,8 @@ async function getFileByFilename(fileName: string): Promise<File> {
   logDebug('query file by key =>', {count: files.length})
   if (files.length > 0) {
     return files[0] as File
-  } else {
-    throw new NotFoundError('Unable to locate file')
   }
+  throw new NotFoundError('Unable to locate file')
 }
 
 /** Get user IDs who have requested a given file */
@@ -53,10 +52,10 @@ function logDispatchResults(results: PromiseSettledResult<unknown>[], userIds: s
   const failedResults = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
 
   if (failedResults.length > 0) {
-    failedResults.forEach((failure) => {
+    for (const failure of failedResults) {
       const userId = userIds[results.indexOf(failure)]
       logError('Failed to dispatch notification', {fileId, userId, error: failure.reason instanceof Error ? failure.reason.message : String(failure.reason)})
-    })
+    }
     logInfo('S3ObjectCreated completed with partial failures', {fileId, totalUsers: userIds.length, succeeded, failed: failedResults.length})
   } else {
     logInfo('All notifications dispatched successfully', {fileId, userCount: userIds.length})

--- a/src/lambdas/scheduled/PruneDevices/index.ts
+++ b/src/lambdas/scheduled/PruneDevices/index.ts
@@ -67,9 +67,8 @@ async function dispatchHealthCheckNotificationToDeviceToken(token: string): Prom
     if (err && typeof err === 'object' && 'reason' in err) {
       const apnsError = err as Apns2Error
       return {statusCode: Number(apnsError.statusCode), reason: apnsError.reason}
-    } else {
-      throw new UnexpectedError('Unexpected result from APNS')
     }
+    throw new UnexpectedError('Unexpected result from APNS')
   }
 }
 

--- a/src/lambdas/sqs/SendPushNotification/pushHelpers.ts
+++ b/src/lambdas/sqs/SendPushNotification/pushHelpers.ts
@@ -42,9 +42,8 @@ export async function getDevice(deviceId: string): Promise<Device> {
   logDebug('getDevice =>', (device as unknown as Record<string, unknown>) ?? {found: false})
   if (device) {
     return device as Device
-  } else {
-    throw new UnexpectedError(providerFailureErrorMessage)
   }
+  throw new UnexpectedError(providerFailureErrorMessage)
 }
 
 /**
@@ -111,11 +110,11 @@ export function processNotificationResults(
       failed: failed.length,
       disabledEndpoints: disabledEndpoints.length
     })
-    failed.forEach((r) => {
+    for (const r of failed) {
       if (isErr(r)) {
         logError('Device notification failed', {deviceId: r.error.deviceId, error: r.error.error, endpointDisabled: r.error.endpointDisabled})
       }
-    })
+    }
   }
 
   return {succeeded, failed, disabledEndpoints}

--- a/src/lambdas/sqs/StartFileUpload/downloadOrchestrator.ts
+++ b/src/lambdas/sqs/StartFileUpload/downloadOrchestrator.ts
@@ -119,7 +119,7 @@ export async function processDownloadRequest(message: ValidatedDownloadQueueMess
     key: fileName,
     size: uploadResult.fileSize,
     authorName: videoInfo.uploader || 'Unknown',
-    authorUser: (videoInfo.uploader || 'unknown').toLowerCase().replace(/\s+/g, '_'),
+    authorUser: (videoInfo.uploader || 'unknown').toLowerCase().replaceAll(/\s+/g, '_'),
     title: videoInfo.title,
     description: videoInfo.description || '',
     publishDate: videoInfo.upload_date || new Date().toISOString(),

--- a/src/lambdas/sqs/StartFileUpload/s3Recovery.ts
+++ b/src/lambdas/sqs/StartFileUpload/s3Recovery.ts
@@ -71,7 +71,7 @@ export async function recoverFromS3(message: ValidatedDownloadQueueMessage, s3Si
     key: fileName,
     size: s3Size,
     authorName: videoInfo?.uploader || 'Unknown',
-    authorUser: (videoInfo?.uploader || 'unknown').toLowerCase().replace(/\s+/g, '_'),
+    authorUser: (videoInfo?.uploader || 'unknown').toLowerCase().replaceAll(/\s+/g, '_'),
     title: videoInfo?.title || fileId,
     description: videoInfo?.description || '',
     publishDate: videoInfo?.upload_date || new Date().toISOString(),

--- a/src/lambdas/standalone/ApiGatewayAuthorizer/index.ts
+++ b/src/lambdas/standalone/ApiGatewayAuthorizer/index.ts
@@ -80,7 +80,7 @@ export const handler = authorizer(async ({event, headers, queryStringParameters,
 
   let principalId = 'anonymous'
   let userStatus: UserStatus = UserStatus.Anonymous
-  const pathPart = event.path.substring(1)
+  const pathPart = event.path.slice(1)
   const multiAuthPaths = getRequiredEnv('MULTI_AUTHENTICATION_PATH_PARTS').split(',')
 
   // Framework normalizes headers to lowercase per HTTP/2 spec (C90).

--- a/src/services/notification/transformers.ts
+++ b/src/services/notification/transformers.ts
@@ -35,7 +35,7 @@ export function truncateDescription(description: string): string {
   if (!description || description.length <= MAX_DESCRIPTION_LENGTH) {
     return description || ''
   }
-  return description.substring(0, MAX_DESCRIPTION_LENGTH - 3) + '...'
+  return description.slice(0, Math.max(0, MAX_DESCRIPTION_LENGTH - 3)) + '...'
 }
 
 /**
@@ -55,7 +55,7 @@ export function createMetadataNotification(
     key: `${fileId}.mp4`,
     title: videoInfo.title || '',
     authorName: videoInfo.uploader || 'Unknown',
-    authorUser: (videoInfo.uploader || 'unknown').toLowerCase().replace(/\s+/g, '_'),
+    authorUser: (videoInfo.uploader || 'unknown').toLowerCase().replaceAll(/\s+/g, '_'),
     description: truncateDescription(videoInfo.description || ''),
     publishDate: videoInfo.upload_date || (new Date().toISOString().split('T')[0] ?? new Date().toISOString()),
     contentType: 'video/mp4',

--- a/src/services/youtube/youtube.ts
+++ b/src/services/youtube/youtube.ts
@@ -58,18 +58,18 @@ function runLayerDiagnostics(binaryPath: string): void {
   try {
     checks['yt-dlp-version'] = execSync(`${binaryPath} --version`, {timeout: 5000}).toString().trim()
   } catch (e) {
-    checks['yt-dlp-version'] = `error: ${String(e).substring(0, 200)}`
+    checks['yt-dlp-version'] = `error: ${String(e).slice(0, 200)}`
   }
 
   // Check if deno is executable
   try {
     checks['deno-version'] = execSync('/opt/bin/deno --version', {timeout: 5000}).toString().split('\n')[0]?.trim()
   } catch (e) {
-    checks['deno-version'] = `error: ${String(e).substring(0, 200)}`
+    checks['deno-version'] = `error: ${String(e).slice(0, 200)}`
   }
 
   // Check PATH
-  checks['PATH'] = getOptionalEnv('PATH', '').substring(0, 300)
+  checks['PATH'] = getOptionalEnv('PATH', '').slice(0, 300)
 
   logDebug('Layer diagnostics', checks)
 }
@@ -258,7 +258,7 @@ function getVideoInfo(binaryPath: string, args: string[]): Promise<YtDlpVideoInf
     proc.on('close', (code) => {
       // Always log stderr for debugging yt-dlp client/format behavior
       if (stderr) {
-        logDebug('yt-dlp stderr', {stderr: stderr.substring(0, 8000)})
+        logDebug('yt-dlp stderr', {stderr: stderr.slice(0, 8000)})
       }
       if (code === 0) {
         try {
@@ -458,7 +458,9 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[], onProgress?: (percen
         }
 
         const progress = parseProgressLine(trimmed)
-        if (progress?.percent !== undefined) {
+        if (progress?.percent === undefined) {
+          logDebug('yt-dlp stdout', trimmed)
+        } else {
           // Invoke onProgress at 25% milestones (exclude 100%)
           if (onProgress && progress.percent < 100) {
             const milestone = Math.floor(progress.percent / 25) * 25
@@ -467,8 +469,6 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[], onProgress?: (percen
               onProgress(milestone)
             }
           }
-        } else {
-          logDebug('yt-dlp stdout', trimmed)
         }
       }
     })
@@ -478,7 +478,9 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[], onProgress?: (percen
     })
 
     ytdlp.on('exit', (code) => {
-      if (code !== 0) {
+      if (code === 0) {
+        resolve()
+      } else {
         logError('yt-dlp stderr output', {stderr})
 
         if (isCookieExpirationError(stderr)) {
@@ -486,8 +488,6 @@ function execYtDlp(ytdlpBinaryPath: string, args: string[], onProgress?: (percen
         } else {
           reject(new UnexpectedError(`yt-dlp exited with code ${code}: ${stderr}`))
         }
-      } else {
-        resolve()
       }
     })
   })

--- a/test/integration/globalSetup.ts
+++ b/test/integration/globalSetup.ts
@@ -85,12 +85,12 @@ function adaptMigrationForSchema(migrationSql: string, schema: string): string {
 
   // Convert Aurora DSQL specific syntax for regular PostgreSQL:
   // - CREATE INDEX ASYNC → CREATE INDEX (Aurora DSQL uses async index creation)
-  adapted = adapted.replace(/CREATE INDEX ASYNC/g, 'CREATE INDEX')
+  adapted = adapted.replaceAll('CREATE INDEX ASYNC', 'CREATE INDEX')
 
   // Convert UUID to TEXT for test simplicity with regular PostgreSQL
   // Better Auth uses `generateId: false` which sends DEFAULT for id columns
-  adapted = adapted.replace(/UUID PRIMARY KEY DEFAULT gen_random_uuid\(\)/g, 'TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text')
-  adapted = adapted.replace(/UUID NOT NULL/g, 'TEXT NOT NULL')
+  adapted = adapted.replaceAll('UUID PRIMARY KEY DEFAULT gen_random_uuid()', 'TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text')
+  adapted = adapted.replaceAll('UUID NOT NULL', 'TEXT NOT NULL')
 
   return adapted
 }
@@ -131,7 +131,7 @@ function validateAdaptations(adapted: string): void {
  */
 function parseSqlStatements(sql: string): string[] {
   // Remove SQL comments
-  const noComments = sql.replace(/--.*$/gm, '')
+  const noComments = sql.replaceAll(/--.*$/gm, '')
 
   // Split by semicolons, filter empty statements
   return noComments.split(';').map((s) => s.trim()).filter((s) => s.length > 0)
@@ -211,7 +211,7 @@ export async function setup(): Promise<void> {
           await sql.unsafe(statement)
         } catch (stmtError) {
           // Log the failing statement for debugging — include first 120 chars
-          const preview = statement.substring(0, 120).replace(/\n/g, ' ')
+          const preview = statement.slice(0, 120).replaceAll('\n', ' ')
           console.error(`[globalSetup] Statement ${i + 1}/${schemaStatements.length} failed in ${schemaName}: ${preview}`)
           console.error(`[globalSetup] Error:`, stmtError)
           throw stmtError

--- a/test/integration/helpers/flaky-tracker.ts
+++ b/test/integration/helpers/flaky-tracker.ts
@@ -20,12 +20,14 @@ const retriedTests: Array<{testName: string; attempt: number; duration: number}>
  * @param durationMs - How long the successful attempt took
  */
 export function logFlakyTest(testName: string, attempt: number, durationMs = 0): void {
-  if (attempt > 1) {
-    retriedTests.push({testName, attempt, duration: durationMs})
-
-    // Always log flaky tests as warnings
-    console.warn(`[FLAKY] Test "${testName}" passed on attempt ${attempt}${durationMs ? ` (${durationMs}ms)` : ''}`)
+  if (!(attempt > 1)) {
+    return
   }
+
+  retriedTests.push({testName, attempt, duration: durationMs})
+
+  // Always log flaky tests as warnings
+  console.warn(`[FLAKY] Test "${testName}" passed on attempt ${attempt}${durationMs ? ` (${durationMs}ms)` : ''}`)
 }
 
 /**

--- a/test/integration/helpers/test-data.ts
+++ b/test/integration/helpers/test-data.ts
@@ -44,7 +44,7 @@ export function createMockFile(id: string, status: FileStatus, partial?: Partial
  * @param partial - Partial device fields to override defaults
  */
 export function createMockDevice(partial?: Partial<Device>): Partial<Device> {
-  const deviceId = partial?.deviceId || `device-${Math.random().toString(36).substring(7)}`
+  const deviceId = partial?.deviceId || `device-${Math.random().toString(36).slice(7)}`
   return {
     deviceId,
     name: partial?.name || 'Test iPhone',
@@ -62,7 +62,7 @@ export function createMockDevice(partial?: Partial<Device>): Partial<Device> {
  */
 export function createMockUser(partial?: Partial<User> & {userId?: string}): Partial<User> {
   // Support both 'id' (domain type) and 'userId' (legacy tests) for backwards compatibility
-  const id = partial?.id || partial?.userId || `user-${Math.random().toString(36).substring(7)}`
+  const id = partial?.id || partial?.userId || `user-${Math.random().toString(36).slice(7)}`
   return {
     id,
     email: partial?.email || `${id}@example.com`,

--- a/test/integration/workflows/apiGatewayAuth.workflow.integration.test.ts
+++ b/test/integration/workflows/apiGatewayAuth.workflow.integration.test.ts
@@ -39,7 +39,7 @@ const TEST_USAGE_PLAN_ID = 'test-usage-plan'
 function createAuthorizerEvent(options: {path?: string; resource?: string; headers?: Record<string, string>} = {}): APIGatewayRequestAuthorizerEvent {
   // Extract token from Authorization header if present
   const authHeader = options.headers?.Authorization
-  const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : undefined
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined
 
   const baseEvent = createMockAPIGatewayRequestAuthorizerEvent({token, path: options.path ?? '/resource', apiKey: TEST_API_KEY})
 

--- a/test/integration/workflows/eventChain.e2e.integration.test.ts
+++ b/test/integration/workflows/eventChain.e2e.integration.test.ts
@@ -131,7 +131,7 @@ describe('Event Chain E2E Integration Tests', () => {
     })
 
     test('should preserve correlation ID through event chain', async () => {
-      const correlationId = `trace-${Date.now()}-${Math.random().toString(36).substring(7)}`
+      const correlationId = `trace-${Date.now()}-${Math.random().toString(36).slice(7)}`
 
       await publishDownloadRequestedEvent(TEST_EVENT_BUS, 'correlation-test', 'https://youtube.com/watch?v=test', correlationId)
 

--- a/test/lambdas/api/user/login.post.test.ts
+++ b/test/lambdas/api/user/login.post.test.ts
@@ -49,12 +49,12 @@ function createMockAuth(overrides: {signInSocialResult?: object; getSessionResul
       token: 'test-token',
       user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
     }
-  const getSessionResult = overrides.getSessionResult !== undefined
-    ? overrides.getSessionResult
-    : {
+  const getSessionResult = overrides.getSessionResult === undefined
+    ? {
       session: {id: 'session-1', token: 'test-token', userId: 'user-1', expiresAt: new Date(Date.now() + 86400000), createdAt: now, updatedAt: now},
       user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
     }
+    : overrides.getSessionResult
   return {api: {signInSocial: vi.fn().mockResolvedValue(signInSocialResult), getSession: vi.fn().mockResolvedValue(getSessionResult)}}
 }
 

--- a/test/lambdas/api/user/register.post.test.ts
+++ b/test/lambdas/api/user/register.post.test.ts
@@ -53,12 +53,12 @@ function createMockAuth(overrides: {signInSocialResult?: object; getSessionResul
       token: 'test-token',
       user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
     }
-  const getSessionResult = overrides.getSessionResult !== undefined
-    ? overrides.getSessionResult
-    : {
+  const getSessionResult = overrides.getSessionResult === undefined
+    ? {
       session: {id: 'session-1', token: 'test-token', userId: 'user-1', expiresAt: new Date(Date.now() + 86400000), createdAt: now, updatedAt: now},
       user: {id: 'user-1', email: 'test@example.com', emailVerified: true, name: 'Test', createdAt: now, updatedAt: now}
     }
+    : overrides.getSessionResult
 
   return {api: {signInSocial: vi.fn().mockResolvedValue(signInSocialResult), getSession: vi.fn().mockResolvedValue(getSessionResult)}}
 }


### PR DESCRIPTION
## Summary

- Applies `--fix` changes across 31 files (src + test) inherited from the unicorn v66 upgrade in `@mantleframework/eslint-config` (mantle PR #210)
- Mostly `prefer-string-replace-all`, `prefer-spread`, `no-zero-fractions`, plus `no-for-each` conversions in graphrag scripts and `no-useless-else` in device registration handler
- No behavioral changes — mechanical auto-fixes only

## Verification

- lint: PASS (0 errors, exit 0)
- typecheck: PASS (graphrag/ runs via tsx, outside tsc --noEmit scope)
- CI pipeline: 8 passed, 1 skipped

Refs #208