### PR TITLE
ci(openspec): run strict validation + behavior-only fence in mantle ci

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
-@~/.claude/principles/mantle-checks-high.md
 @AGENTS.md
+
+<!-- Convention checks are injected per-session by the agent-enforcement retrieval
+     system (~/Repositories/agent-enforcement/rules/mantle/) — the former static
+     import of ~/.claude/principles/mantle-checks-high.md is retired. -->
 
 ## Mantle Convention Enforcement
 

--- a/mantle.config.ts
+++ b/mantle.config.ts
@@ -96,5 +96,18 @@ export default defineConfig({
       {source: '#types/notification-schemas', prefix: 'Notifications.'}
     ]
   },
-  ci: {mantleRepo: 'j0nathan-ll0yd/mantle', mantleRef: 'main', mantleAuthSecret: 'MANTLE_DEPLOY_KEY', deploy: false}
+  ci: {
+    mantleRepo: 'j0nathan-ll0yd/mantle',
+    mantleRef: 'main',
+    mantleAuthSecret: 'MANTLE_DEPLOY_KEY',
+    deploy: false,
+    customSteps: [
+      {
+        name: 'openspec-validate',
+        phase: 'validate',
+        command: 'OPENSPEC_TELEMETRY=0 DO_NOT_TRACK=1 npx -y @fission-ai/openspec@1.4.1 validate --all --strict'
+      },
+      {name: 'openspec-behavior-only', phase: 'validate', command: 'bash scripts/check-openspec-behavior-only.sh'}
+    ]
+  }
 })


### PR DESCRIPTION
## Summary

Wires the OpenSpec quality gates into `mantle ci` via `ci.customSteps` (they previously ran only when invoked by hand):

- `openspec-validate` — `openspec validate --all --strict` (pinned `@fission-ai/openspec@1.4.1`, telemetry off): spec format can no longer drift silently (the drift tether checks coverage, not format)
- `openspec-behavior-only` — `scripts/check-openspec-behavior-only.sh`: the behavior-only boundary (no restated Zod/OpenAPI shapes) now gates CI and pre-push

Both steps run in the validate phase of `mantle ci` (GitHub CI and the husky pre-push hook). Coverage remains advisory per the adoption plan — uncovered requirements do not block; this only gates the format and boundary of committed specs.

### Verification

`npx mantle ci --mode pre-push` green with both steps visible and passing.

Requires the `ci.customSteps` config-type addition from the companion mantle PR (merge that first; runtime behavior works either way since `mantle ci` reads the config dynamically).
