### PR TITLE
chore: pnpm 10.27 → 11.13 — npm retired the legacy audit endpoints

### DIFF
--- a/.github/workflows/auto-update-graphrag.yml
+++ b/.github/workflows/auto-update-graphrag.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Build mantle packages
         working-directory: ../mantle
         run: pnpm build
-      - name: Refresh bin links after mantle build
-        run: pnpm install
+      # pnpm 11: bins skipped at install time (linked CLI dist did not exist yet)
+      # are NEVER recreated by a later plain or --force install — only a clean
+      # install relinks them. Warm-store reinstall costs ~7s.
+      - name: Reinstall to link mantle bins after build
+        run: rm -rf node_modules && pnpm install --frozen-lockfile
 
       - name: Generate dependency graph
         run: npx mantle generate graph

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,8 +55,11 @@ jobs:
       - name: Build mantle packages
         working-directory: ../mantle
         run: pnpm build
-      - name: Refresh bin links after mantle build
-        run: pnpm install
+      # pnpm 11: bins skipped at install time (linked CLI dist did not exist yet)
+      # are NEVER recreated by a later plain or --force install — only a clean
+      # install relinks them. Warm-store reinstall costs ~7s.
+      - name: Reinstall to link mantle bins after build
+        run: rm -rf node_modules && pnpm install --frozen-lockfile
 
       - uses: ./.github/actions/setup-homebrew-tools
 

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -37,8 +37,11 @@ jobs:
       - name: Build mantle packages
         working-directory: ../mantle
         run: pnpm build
-      - name: Refresh bin links after mantle build
-        run: pnpm install
+      # pnpm 11: bins skipped at install time (linked CLI dist did not exist yet)
+      # are NEVER recreated by a later plain or --force install — only a clean
+      # install relinks them. Warm-store reinstall costs ~7s.
+      - name: Reinstall to link mantle bins after build
+        run: rm -rf node_modules && pnpm install --frozen-lockfile
 
       - uses: ./.github/actions/setup-homebrew-tools
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -153,8 +153,11 @@ jobs:
       - name: Build mantle packages
         working-directory: ../mantle
         run: pnpm build
-      - name: Refresh bin links after mantle build
-        run: pnpm install
+      # pnpm 11: bins skipped at install time (linked CLI dist did not exist yet)
+      # are NEVER recreated by a later plain or --force install — only a clean
+      # install relinks them. Warm-store reinstall costs ~7s.
+      - name: Reinstall to link mantle bins after build
+        run: rm -rf node_modules && pnpm install --frozen-lockfile
 
       - uses: ./.github/actions/setup-homebrew-tools
 
@@ -227,8 +230,11 @@ jobs:
       - name: Build mantle packages
         working-directory: ../mantle
         run: pnpm build
-      - name: Refresh bin links after mantle build
-        run: pnpm install
+      # pnpm 11: bins skipped at install time (linked CLI dist did not exist yet)
+      # are NEVER recreated by a later plain or --force install — only a clean
+      # install relinks them. Warm-store reinstall costs ~7s.
+      - name: Reinstall to link mantle bins after build
+        run: rm -rf node_modules && pnpm install --frozen-lockfile
 
       - uses: ./.github/actions/setup-homebrew-tools
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=24.0.0",
     "pnpm": ">=10.27.0"
   },
-  "packageManager": "pnpm@10.27.0",
+  "packageManager": "pnpm@11.13.0",
   "type": "module",
   "scripts": {
     "adr:new": "./bin/adr-new.sh",
@@ -174,29 +174,5 @@
     "vite": "^8.1.3",
     "vitest": "^4.1.9",
     "vitest-monocart-coverage": "^4.0.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "qs": ">=6.14.1",
-      "drizzle-zod>zod": "^4.3.4",
-      "undici-types": "7.16.0",
-      "ws": ">=8.20.1",
-      "protobufjs": ">=7.5.8",
-      "shell-quote": ">=1.8.4",
-      "hono": ">=4.12.25",
-      "esbuild": ">=0.28.1"
-    },
-    "onlyBuiltDependencies": [
-      "@modelcontextprotocol/ext-apps",
-      "@swc/core",
-      "core-js",
-      "dprint",
-      "esbuild",
-      "msw",
-      "onnxruntime-node",
-      "protobufjs",
-      "sharp"
-    ],
-    "auditConfig": {}
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,3 +72,17 @@ allowBuilds:
 
   # MCP tools
   "@modelcontextprotocol/ext-apps": true  # MCP Inspector extension apps
+
+  # Migrated from package.json pnpm.onlyBuiltDependencies (pnpm 11 drop)
+  "@swc/core": true             # TS/JS transform native binary
+  "sharp": true                 # Image processing native binary
+
+overrides:
+  'qs': '>=6.14.1'
+  'drizzle-zod>zod': '^4.3.4'
+  'undici-types': '7.16.0'
+  'ws': '>=8.20.1'
+  'protobufjs': '>=7.5.8'
+  'shell-quote': '>=1.8.4'
+  'hono': '>=4.12.25'
+  'esbuild': '>=0.28.1'


### PR DESCRIPTION
The dependency-check workflow's `pnpm audit --audit-level=high` fails with HTTP 410: npm retired the legacy audit endpoints (full retirement **2026-07-15**). pnpm 11 switched to the bulk advisory endpoint ([pnpm/pnpm#11268](https://github.com/pnpm/pnpm/pull/11268), [pnpm 11.0 release notes](https://pnpm.io/blog/releases/11.0)).

## Changes
- `packageManager: pnpm@11.13.0`
- pnpm 11 no longer reads the package.json `pnpm` field ([settings docs](https://pnpm.io/settings)). This repo's `pnpm-workspace.yaml` was already v11-shaped (`strictDepBuilds`, `allowBuilds`, `minimumReleaseAge`): merged the two entries that existed only in package.json (`@swc/core`, `sharp`) into the existing `allowBuilds` map; moved `overrides` across verbatim.

## Verification (local)
- `pnpm install` clean under 11.13.0 (husky prepare ran)
- `pnpm audit --audit-level=high` → **No known vulnerabilities found**, exit 0 (was 410)

Sibling PRs: mantle#254, mantle-LifegamesPortal#135, design-system-Lifegames (9→11).