### PR TITLE
chore: add Paseo worktree lifecycle config (paseo.json)

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,20 @@
+{
+  "_notes": [
+    "Paseo worktree lifecycle. MAIN resolves the main checkout from the worktree's git-common-dir — no machine paths hardcoded.",
+    "../mantle symlink is required by link:../mantle/packages/* deps and by scripts that invoke ../mantle/packages/cli/dist/index.mjs directly; it must point at a BUILT mantle checkout.",
+    ".env holds SOPS/TF_VAR secrets (gitignored, no .env.example) — copied from main checkout. The age key lives outside the repo (~/.config/sops/age/keys.txt) and is shared.",
+    "pnpm build runs decrypt-cookies.sh and needs that age key; yt-dlp/ffmpeg binaries download on demand (pnpm update:ytdlp / update:ffmpeg).",
+    "tfstate is remote (S3 + DynamoDB lock) — safe across worktrees; run `cd infra && terraform init` only for infra work.",
+    "Teardown stops this worktree's compose project only, freeing ports 4566/5432. Do NOT run integration tests concurrently across worktrees — host ports are fixed."
+  ],
+  "worktree": {
+    "setup": [
+      "MAIN=\"$(dirname \"$(git rev-parse --path-format=absolute --git-common-dir)\")\" && ln -sfn \"$(dirname \"$MAIN\")/mantle\" ../mantle",
+      "MAIN=\"$(dirname \"$(git rev-parse --path-format=absolute --git-common-dir)\")\" && { cp \"$MAIN/.env\" .env 2>/dev/null || true; } && { cp \"$MAIN/.envrc\" .envrc 2>/dev/null || true; }",
+      "pnpm install"
+    ],
+    "teardown": [
+      "pnpm localstack:stop >/dev/null 2>&1 || true"
+    ]
+  }
+}


### PR DESCRIPTION
Setup/teardown commands run by Paseo when creating/removing a git worktree workspace for this repo, so fresh worktrees are functional (../mantle symlink, .env with SOPS/TF_VAR secrets from the main checkout, pnpm install; teardown stops this worktree's LocalStack project). Part of the estate-wide Paseo trial — see agent-enforcement `docs/paseo-orchestration.md`. Safe to delete to revert.