### PR TITLE
chore(infra): native S3 state locking + allowedStages staging guard

### DIFF
--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -3,11 +3,10 @@
 
 terraform {
   backend "s3" {
-    bucket               = "mantle-offlinemediadownloader-tfstate"
-    key                  = "infra.tfstate"
-    region               = "us-west-2"
-    encrypt              = true
-    dynamodb_table       = "TerraformStateLock"
-    workspace_key_prefix = "env"
+    bucket       = "mantle-offlinemediadownloader-tfstate"
+    key          = "infra.tfstate"
+    region       = "us-west-2"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/mantle.config.ts
+++ b/mantle.config.ts
@@ -9,10 +9,15 @@ export default defineConfig({
       key: 'infra.tfstate',
       region: 'us-west-2',
       encrypt: true,
-      dynamodbTable: 'TerraformStateLock',
-      workspaceKeyPrefix: 'env'
+      // OpenTofu-native locking (LP parity, 2026-07-19); DynamoDB table and the
+      // inert workspaceKeyPrefix (mantle never selects a workspace) dropped.
+      useLockfile: true
     }
   },
+  // The single default-workspace state holds ONLY staging resources. A production
+  // deploy would rename everything staging->prod, destroying the live stack; the
+  // CLI refuses it until stage-scoped state keys land (mantle Phase 2d).
+  allowedStages: ['staging'],
   customVariables: [
     {
       name: 'resource_prefix',


### PR DESCRIPTION
## Summary

LP-parity convergence of Terraform state management (companion to mantle #269 and LP #157):

- Replace DynamoDB locking (`TerraformStateLock`) with OpenTofu-native `use_lockfile` (S3 conditional writes). The table has been deleted; the lock now appears transiently as `infra.tfstate.tflock`.
- Drop `workspaceKeyPrefix: 'env'` -- it was inert: it only applies to non-default workspaces and mantle never selects one, so state has always lived at `infra.tfstate`.
- Add `allowedStages: ['staging']`: the single default-workspace state holds ONLY staging resources (315 addresses, zero prod), so a prod-stage deploy would rename everything and destroy the live stack. The CLI now hard-refuses any non-staging stage (dry-run included) until stage-scoped state keys land (mantle Phase 2d).
- Bucket hardened to LP parity: TLS-deny policy + 90-day noncurrent-version lifecycle added (versioning, AES256, public-access-block already present).

## Migration evidence

- `tofu init -reconfigure` (state location unchanged; only lock config changed)
- `state list` == 315 stable; DSQL cluster address present; state object byte-identical pre/post
- Post-migration `tofu plan` == **No changes** (container lambda image var pinned to deployed `44fd44981264`)
- Native lock verified acquired and released; disallowed-stage dry-run deploy exits 1 pre-tofu
- Off-repo state backup retained: `~/omd-tfstate.post-lockfile-migration.json`