### PR TITLE
feat(config): consume @j0nathan-ll0yd/config for dprint + tsconfig base

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -23,6 +23,17 @@ runs:
           echo "::notice::pnpm cache MISS - installing dependencies fresh"
         fi
 
+    # The @j0nathan-ll0yd scope (shared dprint + tsconfig config) lives on GitHub
+    # Packages, which requires auth even for reads. pnpm ignores the token in the
+    # committed project .npmrc, so it must be written to a trusted config here,
+    # before install. Uses the run's GITHUB_TOKEN; the calling job must grant
+    # `permissions: packages: read`.
+    - name: Authenticate to GitHub Packages
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ github.token }}
+      run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
+
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/auto-update-graphrag.yml
+++ b/.github/workflows/auto-update-graphrag.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches: [main, master]
 
+# packages: read lets the run's GITHUB_TOKEN pull @j0nathan-ll0yd/config
+# (shared dprint + tsconfig) from GitHub Packages during install.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   typecheck:
     name: Type Check
@@ -38,6 +44,15 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) lives on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during this FIRST install —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install mantle dependencies
         working-directory: ../mantle
         run: pnpm install --frozen-lockfile
@@ -81,6 +96,15 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) lives on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during this FIRST install —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install mantle dependencies
         working-directory: ../mantle
         run: pnpm install --frozen-lockfile
@@ -120,6 +144,15 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) lives on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during this FIRST install —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install mantle dependencies
         working-directory: ../mantle
         run: pnpm install --frozen-lockfile
@@ -161,6 +194,15 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) lives on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during this FIRST install —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install mantle dependencies
         working-directory: ../mantle
         run: pnpm install --frozen-lockfile
@@ -200,6 +242,15 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) lives on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during this FIRST install —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install mantle dependencies
         working-directory: ../mantle
         run: pnpm install --frozen-lockfile
@@ -239,6 +290,15 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) lives on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during this FIRST install —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install mantle dependencies
         working-directory: ../mantle
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
 
     steps:
       - name: Checkout code
@@ -42,6 +43,15 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      # @j0nathan-ll0yd/config (shared dprint + tsconfig) is on GitHub Packages,
+      # which requires auth even for reads. Mantle also consumes it, so pnpm's
+      # supply-chain check fetches its metadata during the mantle install below —
+      # authenticate before any install. pnpm config set writes the global config,
+      # so the token covers both the ../mantle install and the project install.
+      - name: Authenticate to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install and build mantle (before project install)
         run: |
           cd ../mantle

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,8 +4,13 @@ on:
   pull_request:
     branches: [main]
 
+# packages: read must be granted here so the reusable full-ci / integration
+# calls below can pass it through to unit-tests.yml / integration-tests.yml,
+# whose install jobs read @j0nathan-ll0yd/config from GitHub Packages. A caller
+# cannot grant a called workflow more than it holds, so this is the ceiling.
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
@@ -18,6 +23,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -65,6 +71,7 @@ jobs:
     if: always()
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Check all jobs succeeded
         run: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Check AWS credentials configuration
         id: check-creds

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -132,6 +133,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -209,6 +211,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -271,6 +274,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/update-agents.yml
+++ b/.github/workflows/update-agents.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      packages: read # read @j0nathan-ll0yd/config from GitHub Packages
 
     steps:
       - name: Checkout code

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,14 @@
 # ============================================================================
+# GITHUB PACKAGES REGISTRY (scoped)
+# ============================================================================
+# The @j0nathan-ll0yd scope (shared config: dprint + tsconfig base) is published
+# to GitHub Packages, not the public npm registry. Only the registry mapping
+# lives here — pnpm refuses env-expanded credentials in a committed .npmrc, so
+# auth comes from a trusted source instead: locally from ~/.npmrc, and in CI
+# from the `pnpm config set …_authToken` steps in .github/workflows/*.
+@j0nathan-ll0yd:registry=https://npm.pkg.github.com
+
+# ============================================================================
 # PNPM-SPECIFIC CONFIGURATION
 # ============================================================================
 # This project uses pnpm exclusively (enforced via packageManager in package.json)

--- a/config/dprint.json
+++ b/config/dprint.json
@@ -1,71 +1,7 @@
 {
   "$schema": "https://dprint.dev/schemas/v0.json",
 
-  "lineWidth": 157,
-  "indentWidth": 2,
-  "useTabs": false,
-  "newLineKind": "lf",
-
-  "typescript": {
-    "quoteStyle": "preferSingle",
-    "jsx.quoteStyle": "preferSingle",
-    "quoteProps": "asNeeded",
-
-    "semiColons": "asi",
-
-    "trailingCommas": "never",
-
-    "bracePosition": "sameLine",
-    "nextControlFlowPosition": "sameLine",
-    "singleBodyPosition": "nextLine",
-    "useBraces": "whenNotSingleLine",
-
-    "operatorPosition": "sameLine",
-    "binaryExpression.operatorPosition": "sameLine",
-    "binaryExpression.preferSingleLine": true,
-    "conditionalExpression.operatorPosition": "nextLine",
-
-    "arrowFunction.useParentheses": "force",
-
-    "objectExpression.preferSingleLine": true,
-    "objectExpression.trailingCommas": "never",
-
-    "arrayExpression.preferSingleLine": false,
-    "arrayExpression.trailingCommas": "never",
-
-    "arguments.preferSingleLine": true,
-    "arguments.preferHanging": "always",
-    "arguments.trailingCommas": "never",
-    "parameters.preferSingleLine": true,
-    "parameters.trailingCommas": "never",
-
-    "preferHanging": false,
-
-    "memberExpression.linePerExpression": false,
-    "memberExpression.preferSingleLine": true,
-
-    "importDeclaration.forceMultiLine": "never",
-    "importDeclaration.sortNamedImports": "caseInsensitive",
-    "importDeclaration.spaceSurroundingNamedImports": false,
-    "module.sortImportDeclarations": "maintain",
-    "module.sortExportDeclarations": "maintain",
-
-    "typeLiteral.separatorKind": "semiColon",
-    "typeLiteral.preferSingleLine": true,
-    "typeAnnotation.spaceBeforeColon": false,
-
-    "spaceSurroundingProperties": false,
-    "binaryExpression.spaceSurroundingBitwiseAndArithmeticOperator": true,
-
-    "ifStatement.useBraces": "whenNotSingleLine",
-    "whileStatement.bracePosition": "sameLine",
-    "forStatement.useBraces": "whenNotSingleLine"
-  },
-
-  "json": {
-    "indentWidth": 2,
-    "trailingCommas": "never"
-  },
+  "extends": "../node_modules/@j0nathan-ll0yd/config/dprint.json",
 
   "includes": [
     "../src/**/*.{ts,tsx,js,jsx}",
@@ -83,10 +19,5 @@
     "**/.git",
     "../.omc/**",
     "../infra/**"
-  ],
-
-  "plugins": [
-    "https://plugins.dprint.dev/typescript-0.93.4.wasm",
-    "https://plugins.dprint.dev/json-0.19.4.wasm"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
+    "@j0nathan-ll0yd/config": "^1.1.0",
     "@lancedb/lancedb": "^0.31.0",
     "@mantleframework/cli": "link:../mantle/packages/cli",
     "@mantleframework/eslint-config": "link:../mantle/packages/eslint-config",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0
+      '@j0nathan-ll0yd/config':
+        specifier: ^1.1.0
+        version: 1.1.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
       '@lancedb/lancedb':
         specifier: ^0.31.0
         version: 0.31.0(apache-arrow@18.1.0)
@@ -1285,6 +1288,11 @@ packages:
   '@istanbuljs/schema@0.1.6':
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
+
+  '@j0nathan-ll0yd/config@1.1.0':
+    resolution: {integrity: sha512-7NXjZLSbJKmIYs0W0t7dHapfqVre+QHvNqnbFq2D6P6vbKoUz6tHE8LD+A3+ootsFriXPpuMDHFRCasZbvm5ww==, tarball: https://npm.pkg.github.com/download/@j0nathan-ll0yd/config/1.1.0/6a4c4c6905b56c7c068d5916089c3ea998eb0ded}
+    peerDependencies:
+      eslint: '>=10.0.0'
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -5424,6 +5432,13 @@ packages:
     resolution: {integrity: sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==}
     engines: {node: '>= 16.0.0'}
 
+  typescript-eslint@8.64.0:
+    resolution: {integrity: sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -6839,6 +6854,17 @@ snapshots:
       minipass: 7.1.3
 
   '@istanbuljs/schema@0.1.6': {}
+
+  '@j0nathan-ll0yd/config@1.1.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint/js': 10.0.1(eslint@10.7.0(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.7.0(jiti@2.7.0)
+      typescript-eslint: 8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -11082,6 +11108,17 @@ snapshots:
       qs: 6.15.3
       tunnel: 0.0.6
       underscore: 1.13.8
+
+  typescript-eslint@8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.7.0(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@6.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,8 +39,12 @@ trustPolicyExclude:
 
 # Packages excluded from minimum release age (same-day security/compat patches)
 # ast-v8-to-istanbul: both 1.0.2 and 1.0.3 published 2026-05-31; needed by @vitest/coverage-v8
+# @j0nathan-ll0yd/config@1.1.0: first-party shared config (dprint + tsconfig base) on
+#   GitHub Packages; our own package, gates format/typecheck adoption, so it is
+#   exempt from the release-age delay.
 minimumReleaseAgeExclude:
   - 'ast-v8-to-istanbul'
+  - '@j0nathan-ll0yd/config@1.1.0'
 
 # Block exotic protocols in transitive dependencies
 # Direct deps can use git/tarball, subdeps cannot (common attack vector)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@j0nathan-ll0yd/config/tsconfig-base.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "module": "esnext",
@@ -6,9 +7,6 @@
     "lib": ["ES2025"],
     "outDir": "./dist",
     "rootDir": ".",
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "noUncheckedIndexedAccess": true,
     "types": ["node"],
     "moduleResolution": "bundler",
     "customConditions": ["source"],
@@ -34,12 +32,7 @@
     "noUnusedParameters": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "erasableSyntaxOnly": true,
-    "moduleDetection": "force"
+    "erasableSyntaxOnly": true
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
## Summary

Adopts the shared `@j0nathan-ll0yd/config@^1.1.0` package (published on GitHub Packages) as the single source of truth for **dprint formatting** and the **tsconfig type-safety floor**, replacing the copies previously inlined in this repo. ESLint is intentionally out of scope — this repo keeps `@mantleframework/eslint-config`.

## Changes

**Consume the package**
- `package.json`: add `@j0nathan-ll0yd/config` `^1.1.0` to `devDependencies`.
- `.npmrc`: map the `@j0nathan-ll0yd` scope to GitHub Packages; auth via `${GITHUB_TOKEN}` env (no literal token committed).
- `pnpm-workspace.yaml`: exempt `@j0nathan-ll0yd/config@1.1.0` from the `minimumReleaseAge` gate (pnpm 11 reads release-age settings here, not `.npmrc`).
- `pnpm-lock.yaml`: regenerated.

**dprint** (`config/dprint.json`)
- Now `extends` `../node_modules/@j0nathan-ll0yd/config/dprint.json`.
- Local `typescript`/`json`/`plugins` blocks and top-level primitives removed; repo-specific `includes`/`excludes` kept.
- **Zero formatting churn** — `dprint check` is clean (the package's `typescript` block is byte-for-byte identical to what was inlined here).

**tsconfig** (`tsconfig.json`)
- Now `extends` `@j0nathan-ll0yd/config/tsconfig-base.json`.
- Removed flags now inherited from the base: `strict`, `verbatimModuleSyntax`, `noUncheckedIndexedAccess`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `resolveJsonModule`, `skipLibCheck`, `moduleDetection`.
- Kept OMD-specific options: `ES2025` target/lib, `customConditions`, `paths`, `allowSyntheticDefaultImports`, `noImplicitThis`, `noUnusedLocals/Parameters`, `noImplicitAny`, `erasableSyntaxOnly`, etc.
- `tsconfig.test.json` (extends `./tsconfig.json`) resolves unchanged.

**CI GitHub-Packages auth** (required because `dprint.json`/`tsconfig.json` now resolve a node_modules package that lives on GitHub Packages — auth is needed even for reads)
- `setup-node-pnpm` composite: authenticates to GitHub Packages (via the run's `GITHUB_TOKEN`) before install — covers all self-hosted workflows that use it.
- `ci.yml` (ubuntu) and `integration-tests.yml`: inline auth step before the project install.
- Every job that installs now carries `packages: read`.

## Verification (local)
- `dprint check --config config/dprint.json` → **clean, zero churn**
- `pnpm run typecheck` (TS6) + `check:test:types` → **green**
- `pnpm run typecheck:ts7` (native, advisory) → **green**
- `pnpm run lint` → **0 errors** (24 pre-existing style warnings)
- `noImplicitReturns` fixes required: **none** (repo already set it; base sets it too)

> Note: the container-Lambda step of `mantle ci --mode pre-push` cannot run in this worktree (missing `SOPS_AGE_KEY` to decrypt yt-dlp cookies) — unrelated to this change (no docker/cookies/build files touched). CI runs the full gate with the proper secret.