### PR TITLE
chore(deps): let Dependabot see the @j0nathan-ll0yd GitHub Packages scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,64 @@
+# The fifteen @j0nathan-ll0yd/* dependencies (the Mantle runtime packages plus
+# cli/config/eslint-config/testing) resolve from GitHub Packages, which requires
+# authentication even though every one of them is public -- an unauthenticated
+# GET of https://npm.pkg.github.com/@j0nathan-ll0yd%2fconfig returns 401.
+# Without this block Dependabot cannot see the internal packages at all, so a
+# published Mantle bump never reaches this app and it silently keeps building
+# against a stale tarball.
+#
+# The token must live in the *Dependabot* secret store (Settings -> Secrets and
+# variables -> Dependabot), not the Actions one: Dependabot never sees the
+# workflow GITHUB_TOKEN that .github/actions/setup-node-pnpm uses, and GitHub
+# forbids Dependabot secret names beginning with `GITHUB_`, so
+# `${{secrets.GITHUB_TOKEN}}` is not expressible here. `read:packages` is the
+# only scope required.
+#
+# Deliberately NOT set:
+#   replaces-base -- would route *every* npm dependency through GitHub Packages,
+#     which does not proxy registry.npmjs.org.
+#   scope         -- would make Dependabot regenerate .npmrc purely from these
+#     credentials and discard the committed one, dropping the supply-chain
+#     hardening in .npmrc (enable-pre-post-scripts=false, minimum-release-age).
+#     The committed `@j0nathan-ll0yd:registry=` line already does the scope
+#     mapping and Dependabot appends the credential from here.
+registries:
+  github-packages:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.GH_PACKAGES_READ_TOKEN}}
 updates:
 - commit-message:
     include: scope
     prefix: chore(deps)
   directory: /
   groups:
+    # Intentionally NOT in alphabetical order with its siblings: a dependency
+    # lands in the first group it matches, and `dev-dependencies` below has no
+    # `patterns` filter, so it would otherwise swallow the four internal
+    # devDependencies (cli, config, eslint-config, testing) into the generic
+    # dev-patch PR and split them from the eleven runtime packages.
+    #
+    # The Mantle packages are released as an interdependent set (core/database/
+    # aws/observability/... are versioned together), so N racing single-package
+    # PRs would each red typecheck until the last one merged. One grouped PR
+    # lands the set together.
+    #
+    # MAJORS ARE **NOT** DELIVERED HERE, despite `major` being listed below. The
+    # pre-existing repo-wide `- dependency-name: "*"` / `version-update:
+    # semver-major` entry in `ignore` is applied AFTER grouping and Dependabot
+    # offers no negation syntax, so semver-major bumps of @j0nathan-ll0yd/* are
+    # filtered out along with every other major. `major` is listed so this group
+    # is already correct if that repo-wide ignore is ever narrowed. Until then a
+    # Mantle major must be adopted by hand, and the Atlas package-version-drift
+    # reconciliation runner is the backstop -- as it is anyway for source that
+    # changed without a version bump, which Dependabot cannot detect at all.
+    lifegames-internal:
+      patterns:
+      - "@j0nathan-ll0yd/*"
+      update-types:
+      - major
+      - minor
+      - patch
     aws-sdk:
       patterns:
       - "@aws-sdk/*"
@@ -52,6 +107,8 @@ updates:
   - security
   open-pull-requests-limit: 10
   package-ecosystem: npm
+  registries:
+  - github-packages
   reviewers:
   - jlloyd
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,15 +43,14 @@ updates:
     # PRs would each red typecheck until the last one merged. One grouped PR
     # lands the set together.
     #
-    # MAJORS ARE **NOT** DELIVERED HERE, despite `major` being listed below. The
-    # pre-existing repo-wide `- dependency-name: "*"` / `version-update:
-    # semver-major` entry in `ignore` is applied AFTER grouping and Dependabot
-    # offers no negation syntax, so semver-major bumps of @j0nathan-ll0yd/* are
-    # filtered out along with every other major. `major` is listed so this group
-    # is already correct if that repo-wide ignore is ever narrowed. Until then a
-    # Mantle major must be adopted by hand, and the Atlas package-version-drift
-    # reconciliation runner is the backstop -- as it is anyway for source that
-    # changed without a version bump, which Dependabot cannot detect at all.
+    # MAJORS ARE NOW DELIVERED HERE. The repo-wide `- dependency-name: "*"` /
+    # `version-update:semver-major` ignore that used to filter every major out of
+    # this group -- it was applied AFTER grouping, and Dependabot offers no
+    # negation syntax -- has been REMOVED deliberately. A Mantle major arrives as
+    # part of this one grouped PR instead of having to be adopted by hand and
+    # noticed by the Atlas package-version-drift reconciliation runner after the
+    # fact. That runner remains the backstop for the case Dependabot cannot see
+    # at all: source that changed without any version bump.
     lifegames-internal:
       patterns:
       - "@j0nathan-ll0yd/*"
@@ -99,9 +98,12 @@ updates:
   - dependency-name: "dprint"
   - dependency-name: "eslint"
   - dependency-name: "@typescript-eslint/*"
-  - dependency-name: "*"
-    update-types:
-    - version-update:semver-major
+  # NOTE: there is deliberately no repo-wide `- dependency-name: "*"` /
+  # `version-update:semver-major` entry here. It was removed on purpose: this repo
+  # now receives ALL majors, third-party included, and the named entries above are
+  # the only exclusions. Every one of those is a full ignore (all update types) with
+  # a stated reason, so re-adding a blanket major ignore would silently re-suppress
+  # the @j0nathan-ll0yd/* group majors this change exists to deliver.
   labels:
   - dependencies
   - security


### PR DESCRIPTION
## Why

Dependabot could not see **any** of the fifteen internal packages this app depends on
(the Mantle runtime set plus `cli`/`config`/`eslint-config`/`testing`).

GitHub Packages requires authentication **even for public packages** — verified:

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://npm.pkg.github.com/@j0nathan-ll0yd%2fconfig
401
$ curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $(gh auth token)" https://npm.pkg.github.com/@j0nathan-ll0yd%2fconfig
200
```

`.github/dependabot.yml` had no `registries:` entry for that host, so Dependabot never
resolved the scope. A published Mantle bump never reached this app: the caret range still
matched, nothing went red, and the build silently kept resolving a stale tarball.

## What changed

- Top-level `registries.github-packages` (`type: npm-registry`, `url: https://npm.pkg.github.com`).
- The npm `updates` entry now references it.
- A `lifegames-internal` group bundling `@j0nathan-ll0yd/*` into **one** PR. The Mantle
  packages are released as an interdependent set, so per-package PRs would race and each
  red the typecheck until the last one merged.
- The group is declared **first**, intentionally out of alphabetical order with its
  siblings: a dependency lands in the first group it matches, and `dev-dependencies` has
  no `patterns` filter, so it would otherwise swallow `cli`/`config`/`eslint-config`/
  `testing` into the generic dev-patch PR and split them from the runtime packages.

## Majors: NOW DELIVERED (owner decision, changed in this PR)

The repo-wide ignore that used to filter every major out of this group

```yaml
  - dependency-name: "*"
    update-types:
    - version-update:semver-major
```

has been **removed**. It was applied *after* grouping, and Dependabot has no negation
syntax, so the `major` listed in the `lifegames-internal` group's `update-types` was dead
on arrival — `@j0nathan-ll0yd/*` majors were filtered out along with every other major and
had to be adopted by hand. Rather than carry a group whose most important update type never
fires, the blanket ignore goes.

**This repo now receives ALL majors, third-party included.** That is deliberate.

The sixteen named ignores survive untouched, and every one of them is a *full* ignore (all
update types) with a stated reason, so the exclusion set is now entirely explicit:

`@aws-sdk/*`, `drizzle-orm`, `drizzle-kit`, `zod`, `better-auth`, `@better-auth/*`,
`@opentelemetry/*`, `typescript`, `@typescript/native`, `vitest`, `@vitest/*`, `vite`,
`unbuild`, `dprint`, `eslint`, `@typescript-eslint/*`

The **targeted** `pnpm/action-setup` semver-major ignore in the `github-actions` block is a
different, deliberately narrow rule and is left alone. A comment now marks the deliberate
absence of the npm wildcard entry so it is not restored as an oversight.

The Atlas `package-version-drift` reconciliation runner remains the backstop regardless:
Dependabot only ever sees versions that were actually *published*. If a package's source
changes and the version is never bumped, the registry is unchanged and Dependabot has
nothing to report. That is precisely the gap PR #596 closes.

## Deliberately NOT set

| Option | Why not |
| --- | --- |
| `replaces-base: true` | Would route **every** npm dependency through GitHub Packages, which does not proxy `registry.npmjs.org`. |
| `scope: "@j0nathan-ll0yd"` | Would make Dependabot regenerate `.npmrc` purely from credentials and discard the committed one — dropping this repo's supply-chain hardening (`enable-pre-post-scripts=false`, `minimum-release-age=3d`). |

The committed `@j0nathan-ll0yd:registry=` line already does the scope mapping and
Dependabot appends the credential from the `registries:` block.

## ⚠️ Required before this takes effect

`GH_PACKAGES_READ_TOKEN` must be added as a **Dependabot** secret
(Settings → Secrets and variables → **Dependabot**), scope `read:packages`.

This is *not* the Actions secret store. Dependabot has a separate one and never sees the
workflow `GITHUB_TOKEN` that `.github/actions/setup-node-pnpm` uses; GitHub also forbids
Dependabot secret names beginning with `GITHUB_`, so `${{secrets.GITHUB_TOKEN}}` is not
expressible in this file. This repo's only existing Dependabot secret is
`MANTLE_DEPLOY_KEY`, which is the wrong privilege for a package read.

Until the secret exists Dependabot will report a registry auth error on the Dependabot
page — visible, not silent.

## Validation

Config errors in `dependabot.yml` fail *silently*, so this was validated three ways:

1. **YAML parse** — `yaml.safe_load`.
2. **JSON Schema** — SchemaStore `dependabot-2.0.json`, checked *differentially* against
   `origin/main` so a pre-existing deviation cannot launder a new one into a pass.
3. **Semantic known-answer assertions** — registry shape, secret-name rules, group is
   first, no `replaces-base`/`scope`, and majors-reach-consumer == expected (`False` here,
   asserted from the wildcard ignore).

Five negative-control mutations were confirmed to **fail** the validator (removed
registry, `GITHUB_`-prefixed secret, `replaces-base`, group demoted/shadowed, wildcard
major ignore) — a gate that can never fail is as dangerous as one that never runs.

**Re-validated after removing the wildcard major ignore**, with the majors-reach-consumer
assertion now inverted to expect `True`:

```text
PASS  .github/dependabot.yml
  schema (schemastore dependabot-2.0, draft-07): valid
  version: 2   update blocks: 2   registries: github-packages
  npm ignore entries: 16
  repo-wide "*" + semver-major ignore: 0 (REMOVED as intended)
  lifegames-internal group update-types: ["major","minor","patch"]
VALIDATOR_EXIT=0
```

Proven able to fail on all three axes, not just asserted: the **pre-change** file reds the
blanket-ignore assertion (`1 (STILL PRESENT -- FAIL)`), an unknown key reds the schema pass
(`data/updates/0 must NOT have additional properties`), and bad indentation reds the YAML
parse (`Nested mappings are not allowed in compact mappings at line 3`).

The repo's own pre-commit gates ran on this commit: secret scan, `dependency-cruiser`
(no violations, 89 modules / 204 dependencies), docs-structure check.

### Pre-existing finding (not fixed here)

The schema check reports one violation on **both** `origin/main` and this branch:
`updates[0]: 'reviewers' was unexpected`. GitHub has marked `reviewers` as *closing down*
(it no longer appears in the dotcom options reference). It is currently tolerated, so this
PR leaves it alone rather than silently changing PR-assignment behavior; the documented
replacement is a `CODEOWNERS` file. Flagging it because when it is finally removed, the
whole config will fail — exactly the silent-failure mode this PR is about.



## Second pre-existing finding, also not fixed here

`@aws-sdk/*` appears **both** as a full `ignore` entry and as an `aws-sdk` update group
(`update-types: [minor, patch]`). Ignores are applied after grouping, so that group is
unreachable — it can never produce a PR. Flagging rather than fixing: deleting the ignore
and deleting the group are opposite decisions with opposite consequences, and which one is
right is the owner's call, not a cleanup.
