### PR TITLE
fix(ci): give the drift gate a registry token before it is needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,3 +291,11 @@ jobs:
         # verdict (engine missing/unreachable/killed). Any other code is the engine's own
         # verdict, forwarded verbatim.
         run: node scripts/check-package-versions.mjs
+        env:
+          # Latent here rather than live: this repo publishes nothing today, so the run stops
+          # at NO_PUBLISHABLE_PACKAGES and never reaches the registry. The moment OMD publishes
+          # its first package the missing credential would turn this gate permanently red with
+          # INDETERMINATE, exactly as it did in mantle-LifegamesPortal. A job-level
+          # `packages: read` permission scopes the workflow token but does NOT place it in a
+          # run step's environment. Mirrors mantle ci.yml and design-system ci.yml.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Latent here rather than live: this repo publishes nothing today, so the run stops at `NO_PUBLISHABLE_PACKAGES` and never reaches the registry.

The moment OMD publishes its first package, the missing credential would turn this gate **permanently red** with `INDETERMINATE` — which is exactly what happened in `mantle-LifegamesPortal`, where the same step had the same gap and the repo *does* publish:

```
@j0nathan-ll0yd/portal-contract  1.0.0  -  INDETERMINATE
    no registry token. GitHub Packages rejects anonymous reads even for public packages.
exit 3
```

A job-level `packages: read` permission scopes the workflow token but does **not** place it in a run step environment; it has to be passed explicitly. Mirrors `mantle` ci.yml (`NODE_AUTH_TOKEN`) and `design-system-Lifegames` ci.yml (`GITHUB_TOKEN`), both of which already do.
