### PR TITLE
fix(prune-devices): prune permanent APNS token failures and skip smoke-test device

### DIFF
--- a/src/lambdas/scheduled/PruneDevices/index.ts
+++ b/src/lambdas/scheduled/PruneDevices/index.ts
@@ -11,7 +11,7 @@
 import {defineLambda, defineScheduledHandler} from '@j0nathan-ll0yd/core'
 import {getOptionalEnv, getRequiredEnv} from '@j0nathan-ll0yd/env'
 import {UnexpectedError} from '@j0nathan-ll0yd/errors'
-import {addMetadata, endSpan, logDebug, logError, logInfo, metrics, MetricUnit, startSpan} from '@j0nathan-ll0yd/observability'
+import {addMetadata, endSpan, logDebug, logError, logInfo, logWarn, metrics, MetricUnit, startSpan} from '@j0nathan-ll0yd/observability'
 import {deleteUserDevicesByDeviceId, getAllDevices} from '#entities/queries'
 import type {Apns2Error} from '#errors/custom-errors'
 import {deleteDevice} from '#services/device/deviceService'
@@ -31,6 +31,13 @@ defineLambda({
 
 // Re-export types for external consumers
 export type { PruneDevicesResult } from '#types/lambda'
+
+/**
+ * Reserved synthetic device seeded by `bin/test-registerDevice.sh` for remote smoke tests. Its token
+ * is an all-zeros placeholder that APNS permanently rejects (400 BadDeviceToken), so it is excluded
+ * from health checks — otherwise every run would prune it and the smoke-test fixture would vanish.
+ */
+const RESERVED_TEST_DEVICE_ID = '00000000-0000-0000-0000-000000000001'
 
 /** Fetch all devices from the database */
 async function getDevices(): Promise<Device[]> {
@@ -63,19 +70,45 @@ async function dispatchHealthCheckNotificationToDeviceToken(token: string): Prom
     logDebug('apnProvider.send =>', result as unknown as Record<string, unknown>)
     return {statusCode: 200}
   } catch (err) {
-    logError('apnProvider.send =>', {error: err instanceof Error ? err.message : String(err)})
+    // A structured APNS rejection (has a `reason`) is an expected outcome of a health check — the
+    // whole point of this job is to surface dead tokens. Log it at WARN, not ERROR, so it does not
+    // trip alerting; the caller decides whether the reason is permanent (prune) or transient (skip).
     if (err && typeof err === 'object' && 'reason' in err) {
       const apnsError = err as Apns2Error
+      logWarn('apnProvider.send => APNS rejection', {statusCode: apnsError.statusCode, reason: apnsError.reason})
       return {statusCode: Number(apnsError.statusCode), reason: apnsError.reason}
     }
+    // No reason means an unexpected transport/library failure, not a token verdict — this is a real error.
+    logError('apnProvider.send => unexpected failure', {error: err instanceof Error ? err.message : String(err)})
     throw new UnexpectedError('Unexpected result from APNS')
   }
 }
 
-/** Check if a device token is disabled (APNS returns 410) */
-async function isDeviceDisabled(token: string): Promise<boolean> {
+/**
+ * APNS `reason` values that indicate the token is permanently invalid and can never receive a push.
+ * `Unregistered` (410) — app uninstalled. `BadDeviceToken` / `DeviceTokenNotForTopic` (400) — token
+ * malformed or registered against a different environment/topic. All three warrant pruning; every
+ * other reason (e.g. `TooManyRequests`, `InternalServerError`, `ServiceUnavailable`) is transient.
+ * @see https://developer.apple.com/documentation/usernotifications/handling-notification-responses-from-apns
+ */
+const PERMANENT_APNS_REASONS = new Set(['Unregistered', 'BadDeviceToken', 'DeviceTokenNotForTopic'])
+
+/**
+ * Health-check a device token and decide whether it is permanently invalid (safe to prune).
+ * Returns false for both healthy tokens and transient failures — a transient failure logs a warning
+ * and leaves the device in place so it is re-checked on the next run rather than deleted in error.
+ */
+async function isDeviceTokenPermanentlyInvalid(token: string): Promise<boolean> {
   const apnsResponse = await dispatchHealthCheckNotificationToDeviceToken(token)
-  return apnsResponse.statusCode === 410
+  if (apnsResponse.statusCode === 200) {
+    return false
+  }
+  if (apnsResponse.reason && PERMANENT_APNS_REASONS.has(apnsResponse.reason)) {
+    return true
+  }
+  // Non-200 without a permanent reason: transient (rate limit, APNS outage). Keep the device, retry next run.
+  logWarn('Transient APNS failure; leaving device in place', {statusCode: apnsResponse.statusCode, reason: apnsResponse.reason})
+  return false
 }
 
 const scheduled = defineScheduledHandler({operationName: 'PruneDevices', schedule: {expression: 'rate(1 day)'}, timeout: 300})
@@ -92,14 +125,21 @@ export const handler = scheduled(async (): Promise<PruneDevicesResult> => {
 
   for (const device of devices) {
     const deviceId = device.deviceId
+
+    // The reserved smoke-test device carries an intentionally-invalid token; never health-check or prune it.
+    if (deviceId === RESERVED_TEST_DEVICE_ID) {
+      logDebug('Skipping reserved smoke-test device', {deviceId})
+      continue
+    }
+
     logInfo('Verifying device', {deviceId})
 
     let shouldPrune = false
     let pruneReason = ''
 
-    if (await isDeviceDisabled(device.token)) {
+    if (await isDeviceTokenPermanentlyInvalid(device.token)) {
       shouldPrune = true
-      pruneReason = 'APNS 410'
+      pruneReason = 'APNS token permanently invalid'
     } else if (device.lastSeenAt && device.lastSeenAt < staleThreshold) {
       shouldPrune = true
       pruneReason = 'lastSeenAt stale'

--- a/test/lambdas/scheduled/PruneDevices/index.test.ts
+++ b/test/lambdas/scheduled/PruneDevices/index.test.ts
@@ -36,6 +36,7 @@ vi.mock('@j0nathan-ll0yd/observability',
     logDebug: vi.fn(),
     logError: vi.fn(),
     logInfo: vi.fn(),
+    logWarn: vi.fn(),
     metrics: {addMetric: vi.fn()},
     MetricUnit: {Count: 'Count'},
     startSpan: vi.fn(() => ({}))
@@ -112,7 +113,7 @@ describe('PruneDevices Lambda', () => {
     expect(result.devicesPruned).toBe(0)
   })
 
-  it('should prune disabled device (APNS 410)', async () => {
+  it('should prune device unregistered by APNS (410 Unregistered)', async () => {
     vi.mocked(getAllDevices).mockResolvedValue([mockDevice])
     mockApnsSend.mockRejectedValue({reason: 'Unregistered', statusCode: 410})
     vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined as never)
@@ -125,6 +126,45 @@ describe('PruneDevices Lambda', () => {
     expect(deleteUserDevicesByDeviceId).toHaveBeenCalledWith('dev-1')
     expect(deleteDevice).toHaveBeenCalledWith(mockDevice)
     expect(metrics.addMetric).toHaveBeenCalledWith('DevicesPruned', 'Count', 1)
+  })
+
+  it('should prune device with a permanently-invalid token (400 BadDeviceToken)', async () => {
+    vi.mocked(getAllDevices).mockResolvedValue([mockDevice])
+    mockApnsSend.mockRejectedValue({reason: 'BadDeviceToken', statusCode: 400})
+    vi.mocked(deleteUserDevicesByDeviceId).mockResolvedValue(undefined as never)
+    vi.mocked(deleteDevice).mockResolvedValue(undefined)
+
+    const result = await handler()
+
+    expect(result.devicesChecked).toBe(1)
+    expect(result.devicesPruned).toBe(1)
+    expect(deleteUserDevicesByDeviceId).toHaveBeenCalledWith('dev-1')
+    expect(deleteDevice).toHaveBeenCalledWith(mockDevice)
+  })
+
+  it('should NOT prune on a transient APNS failure (429 TooManyRequests)', async () => {
+    vi.mocked(getAllDevices).mockResolvedValue([mockDevice])
+    mockApnsSend.mockRejectedValue({reason: 'TooManyRequests', statusCode: 429})
+
+    const result = await handler()
+
+    expect(result.devicesChecked).toBe(1)
+    expect(result.devicesPruned).toBe(0)
+    expect(deleteUserDevicesByDeviceId).not.toHaveBeenCalled()
+    expect(deleteDevice).not.toHaveBeenCalled()
+  })
+
+  it('should skip the reserved smoke-test device without health-checking or pruning it', async () => {
+    const reservedDevice = {...mockDevice, deviceId: '00000000-0000-0000-0000-000000000001', token: '0'.repeat(64)}
+    vi.mocked(getAllDevices).mockResolvedValue([reservedDevice])
+
+    const result = await handler()
+
+    expect(result.devicesChecked).toBe(1)
+    expect(result.devicesPruned).toBe(0)
+    expect(mockApnsSend).not.toHaveBeenCalled()
+    expect(deleteUserDevicesByDeviceId).not.toHaveBeenCalled()
+    expect(deleteDevice).not.toHaveBeenCalled()
   })
 
   it('should record error when device deletion fails', async () => {


### PR DESCRIPTION
## Root cause

`staging-PruneDevices` was health-checking the **`RemoteTestDevice`** — a synthetic smoke-test fixture (`device_id 00000000-…-000000000001`) seeded idempotently by `bin/test-registerDevice.sh` with an **all-zeros APNS token**. Apple's sandbox permanently rejects that token with **`400 BadDeviceToken`**. Two compounding bugs:

1. **Wrong log severity** — the caught APNS rejection was logged via `logError`, so an *expected* dead-token verdict tripped alerting.
2. **Pruning-logic gap** — the health check only treated **`410 Unregistered`** as prune-worthy. A `400 BadDeviceToken` device was never pruned, so it re-failed on **every daily run** (the "consistent" error).

The job never crashed (`PruneDevices completed`). Diagnosis confirmed from CloudWatch logs (1 of 8 devices errored, 7 succeeded) plus the DSQL `devices` table.

## Changes

`src/lambdas/scheduled/PruneDevices/index.ts`:
- Log structured APNS rejections at `logWarn`; reserve `logError` for unexpected transport failures with no `reason`.
- Classify permanent failures (`Unregistered`, `BadDeviceToken`, `DeviceTokenNotForTopic`) as prune-worthy; leave transient failures (`429`/`5xx`) in place for the next run.
- Skip the reserved smoke-test device so it is never health-checked or pruned.

`test/lambdas/scheduled/PruneDevices/index.test.ts`:
- Added `logWarn` to the observability mock; added cases for `BadDeviceToken` pruning, transient no-prune, and reserved-device skip.

## Verification
- Unit tests: 9 passed
- `tsc --noEmit`: clean · `eslint`: clean
- `mantle check --severity HIGH`: all 131 files passed
- Integration tests remain compatible (`BadDeviceToken` still prunes; `InternalError` still doesn't
EOF
)