### PR TITLE
chore(deps): adopt pnpm baseline per decision 0032

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,51 +6,7 @@
 # lives here — pnpm refuses env-expanded credentials in a committed .npmrc, so
 # auth comes from a trusted source instead: locally from ~/.npmrc, and in CI
 # from the `pnpm config set …_authToken` steps in .github/workflows/*.
-@j0nathan-ll0yd:registry=https://npm.pkg.github.com
-
-# ============================================================================
-# PNPM-SPECIFIC CONFIGURATION
-# ============================================================================
-# This project uses pnpm exclusively (enforced via packageManager in package.json)
-# Settings below are pnpm-specific - npm warnings about "unknown project config"
-# can be safely ignored if npm is accidentally invoked
 #
-# ============================================================================
-# SECURITY HARDENING: Lifecycle Script Protection
-# ============================================================================
-# Disable all lifecycle scripts by default (pnpm v10+ feature)
-# This prevents malicious packages from executing code during installation
-# Protects against: Typosquatting, supply chain attacks, AI-hallucinated packages
-enable-pre-post-scripts=false
-
-# Explicitly allowlist packages requiring scripts (AUDIT BEFORE ADDING)
-# Approved packages listed in package.json pnpm.onlyBuiltDependencies:
-#   onnxruntime-node: ONNX Runtime native bindings (for @huggingface/transformers)
-#   sharp: Image processing native addon (transitive dep of @huggingface/transformers)
-
-# Supply chain security - delay installation of newly published packages
-# Protects against rapid malware deployment attacks
-minimum-release-age=3d
-
-# Exclude specific packages from minimum-release-age (security patches)
-# tar@7.5.3: Fixes GHSA-8qq5-rm4j-mr97 (path traversal vulnerability)
-minimum-release-age-exclude[]=tar
-
-# ============================================================================
-# PERFORMANCE OPTIMIZATION
-# ============================================================================
-# Use hard links (faster, disk-efficient)
-package-import-method=hardlink
-
-# Strict peer dependencies (catch compatibility issues)
-strict-peer-dependencies=false
-
-# Hoist pattern (compatibility with some tools)
-shamefully-hoist=false
-
-# ============================================================================
-# FUTURE: WORKSPACE CONFIGURATION
-# ============================================================================
-# Enable when migrating to monorepo architecture
-# recursive-install=false
-# link-workspace-packages=true
+# Registry mapping ONLY, per atlas decision 0032 item 4: pnpm 11 does not read
+# pnpm settings from .npmrc. Every pnpm setting lives in pnpm-workspace.yaml.
+@j0nathan-ll0yd:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=10.27.0"
+    "pnpm": ">=11.0.0"
   },
   "packageManager": "pnpm@11.13.0",
   "type": "module",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,11 @@ trustPolicyExclude:
 #   exempt from the release-age delay.
 minimumReleaseAgeExclude:
   - 'ast-v8-to-istanbul'
+  # tar: security fast-track, translated from the retired .npmrc
+  # `minimum-release-age-exclude[]=tar` (atlas 0032 item 4). Originally added for
+  # tar@7.5.3, which fixes GHSA-8qq5-rm4j-mr97 (path traversal); kept bare so the
+  # next patch in that line is not delayed behind the 24h floor either.
+  - 'tar'
   # Bare package names cover every later version; version-qualified exclusions
   # silently reintroduce the first-publish failure on the next release.
   - '@j0nathan-ll0yd/config'


### PR DESCRIPTION
Brings this repo to the canonical estate pnpm baseline ratified in **atlas decision 0032 — _Estate-wide package-manager standardization_** (Phase 1: field normalization on the already-pnpm repos).

Root build config only — no published-package source changes, so **no version bump / changeset**.

## Changes

### 1. `package.json` — `engines.pnpm` floor (decision item 2)

`>=10.27.0` → `>=11.0.0`. The old floor was **stale**: it sat below the `pnpm@11.13.0` that this repo's own `packageManager` field already declares (finding F3). `engines` is a compatibility floor pinning the pnpm *major*; `packageManager`/Corepack still governs the exact version.

### 2. `.npmrc` — registry mapping only (decision item 4)

pnpm 11 **does not read pnpm settings from `.npmrc`**, so every pnpm line in the file was inert. Per item 4, each was confirmed-dead or translated before deletion rather than silently discarded:

| Setting | Disposition |
| --- | --- |
| `enable-pre-post-scripts=false` | Dead — dropped. Lifecycle scripts are already blocked by default and governed by `allowBuilds` in `pnpm-workspace.yaml`. |
| `minimum-release-age=3d` | **Already silently dead** (F5) — `pnpm-workspace.yaml`'s `minimumReleaseAge: 1440` wins under pnpm 11, so the 3-day intent was never in effect. Not resurrected; the 1440 (24h) floor stays. |
| `minimum-release-age-exclude[]=tar` | **Translated** → `minimumReleaseAgeExclude` (see below). |
| `package-import-method=hardlink` | Dead — dropped (pnpm 11 default). |
| `strict-peer-dependencies=false` | Dead — dropped. |
| `shamefully-hoist=false` | Dead — dropped (pnpm default). |

The registry-mapping comment block and the deliberate **absence of any `_authToken` line** are preserved — auth continues to come from `~/.npmrc` locally and `pnpm config set` in CI, per decision 0015.

### 3. `pnpm-workspace.yaml` — carry the one live intent forward

Adds `tar` to the existing `minimumReleaseAgeExclude`, preserving the security fast-track for the **GHSA-8qq5-rm4j-mr97** (path traversal) patch that the retired `.npmrc` line encoded. Listed bare so the next patch in that line isn't delayed behind the 24h floor either.

`minimumReleaseAge: 1440` and `trustPolicy: no-downgrade` are unchanged — both already satisfy item 5 (and `trustPolicy` is the recommended-not-enforced bonus the decision notes this repo already carries).

## Verification

- `pnpm install --frozen-lockfile` — **lockfile byte-identical**, SHA-256 `9900be7a…37b5` before and after, clean `git status`. Supply-chain policy verification passed on all 1245 entries.
- **No `WARN` / ignored-setting lines** remain in install output (grep for `warn|ignor|unknown` returns nothing).
- `pnpm lint` — exit 0.
- `pnpm typecheck` — exit 0 (source + test projects).
- Pre-push `mantle ci --mode pre-push` — **13 passed, 4 skipped, 0 failed**.

## Notes

No Surface Sweep required: this touches no data contract or `surfaces.yaml`-registered artifact — build-toolchain config only, as the decision's Consequences section records.
