### PR TITLE
fix(build): decrypt-cookies fails loud instead of leaving a 0-byte cookie file

### DIFF
--- a/bin/decrypt-cookies.sh
+++ b/bin/decrypt-cookies.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
+
+# decrypt-cookies.sh
+# Decrypts the SOPS-encrypted YouTube cookies used by the yt-dlp layer/container.
+# Writes atomically (decrypt to a temp file, then mv) so a failed or empty
+# decryption never leaves a 0-byte youtube-cookies.txt behind — a stale empty
+# file would be skipped on the next run and baked into the Docker image.
+
 set -euo pipefail
 
 COOKIES_ENC="layers/yt-dlp/cookies/youtube-cookies.enc"
 COOKIES_TXT="layers/yt-dlp/cookies/youtube-cookies.txt"
 
-if [[ -f "$COOKIES_TXT" ]]; then
+# -s (non-empty), not -f: a 0-byte file from any source is not a valid artifact.
+if [[ -s "$COOKIES_TXT" ]]; then
   echo "Cookies already decrypted, skipping"
   exit 0
 fi
 
 if [[ ! -f "$COOKIES_ENC" ]]; then
-  echo "ERROR: Encrypted cookies file not found: $COOKIES_ENC"
+  echo "ERROR: Encrypted cookies file not found: $COOKIES_ENC" >&2
   exit 1
 fi
 
@@ -22,5 +30,22 @@ if ! command -v sops &> /dev/null; then
   exit 0
 fi
 
-sops decrypt --output-type binary "$COOKIES_ENC" > "$COOKIES_TXT"
+# Temp file lives beside the target so the mv is an atomic same-filesystem rename.
+tmp="$(mktemp "${COOKIES_TXT}.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+if ! sops decrypt --output-type binary "$COOKIES_ENC" > "$tmp"; then
+  echo "ERROR: sops failed to decrypt $COOKIES_ENC" >&2
+  echo "       SOPS_AGE_KEY_FILE must point to the age key (default: \$HOME/.config/sops/age/keys.txt)" >&2
+  exit 1
+fi
+
+if [[ ! -s "$tmp" ]]; then
+  echo "ERROR: sops produced an empty decryption of $COOKIES_ENC" >&2
+  echo "       Refusing to write a 0-byte $COOKIES_TXT" >&2
+  exit 1
+fi
+
+mv "$tmp" "$COOKIES_TXT"
+trap - EXIT
 echo "Decrypted cookies to $COOKIES_TXT"


### PR DESCRIPTION
## The silent failure

`bin/decrypt-cookies.sh` gates the `build` and `build:ci` scripts (`package.json:16-17`), and the cookies it produces are baked into the `StartFileUpload` container image via `docker/Dockerfile.download`.

The old line 25 was:

```bash
sops decrypt --output-type binary "$COOKIES_ENC" > "$COOKIES_TXT"
```

The shell `>` redirect creates and truncates `youtube-cookies.txt` to 0 bytes **before** `sops` ever runs. When sops fails — most commonly `SOPS_AGE_KEY_FILE` not exported, or the age key not at the default `$HOME/.config/sops/age/keys.txt` — `set -e` exits 1, but a 0-byte `youtube-cookies.txt` is left on disk.

On the **next** run, the early guard `if [[ -f "$COOKIES_TXT" ]]` saw that empty file, printed `Cookies already decrypted, skipping` and exited 0. The build then proceeded and baked an empty cookie file into the image. YouTube bot-detection failures at download time were the first symptom, far from the cause.

Reproduced against the pre-fix script with a stubbed failing `sops`:

```
run 1 (sops fails):
    exit code: 1
    cookies.txt size=0 bytes        <-- 0-byte leftover
run 2 (the silent failure):
    Cookies already decrypted, skipping
    exit code: 0                    <-- build proceeds with empty cookies
```

## The fix — atomic write, fail loud

1. Decrypt to a `mktemp` file placed **beside** the target, so the final `mv` is an atomic same-filesystem rename. (Matches the existing pattern in `bin/update-yt-dlp.sh:36-40`.)
2. `trap 'rm -f "$tmp"' EXIT` so any failure path cleans up and leaves **no** `youtube-cookies.txt`.
3. A failed `sops decrypt` prints an actionable stderr message naming `SOPS_AGE_KEY_FILE` and its default location, then exits 1.
4. An empty decryption (`[[ ! -s "$tmp" ]]`) is rejected — a 0-byte cookies file is never written.
5. `mv` only on success, then the trap is cleared.
6. Defense in depth: the early skip guard moves from `-f` to `-s` (non-empty), so a stale 0-byte file from *any* source re-attempts decryption instead of being trusted.

The `sops`-not-installed placeholder branch is unchanged — that placeholder is deliberate for sops-less local builds and is non-empty (74 bytes).

## Test evidence

`shellcheck bin/decrypt-cookies.sh` clean at default severity and at `--severity=error` (what `.github/workflows/unit-tests.yml:158` runs).

All cases run against copies of the script in throwaway temp dirs with a stubbed `sops`. No real cookies were decrypted; no `youtube-cookies.txt` is committed (it stays gitignored).

| # | Scenario | Exit code | `youtube-cookies.txt` | Temp leftovers |
|---|----------|-----------|------------------------|----------------|
| 1 | `sops` fails (`SOPS_AGE_KEY_FILE=/nonexistent`) | 1 | does not exist | 0 |
| 2 | `sops` succeeds, emits nothing | 1 | does not exist | 0 |
| 3 | Happy path | 0 | 65 bytes | 0 |
| 4 | Idempotency — re-run with valid cookies present | 0 | 65 bytes, `already decrypted, skipping` | 0 |
| 5 | Stale 0-byte file planted, then valid decrypt | 0 | 28 bytes (re-decrypted, not skipped) | 0 |
| 6 | `sops` not on PATH | 0 | 74-byte placeholder preserved | 0 |

Cases 1 and 2 print actionable errors to stderr:

```
ERROR: sops failed to decrypt layers/yt-dlp/cookies/youtube-cookies.enc
       SOPS_AGE_KEY_FILE must point to the age key (default: $HOME/.config/sops/age/keys.txt)

ERROR: sops produced an empty decryption of layers/yt-dlp/cookies/youtube-cookies.enc
       Refusing to write a 0-byte layers/yt-dlp/cookies/youtube-cookies.txt
```

Same two-run scenario as the baseline reproduction above, with the fix applied — both runs fail loudly and no artifact is ever left behind:

```
run 1: exit code: 1, cookies.txt: DOES NOT EXIST
run 2: exit code: 1, cookies.txt: DOES NOT EXIST
```

## Context

Surfaced during the pnpm baseline work (decision 0032, #606). Standalone fix — unrelated to pnpm itself. No deploy.
