### PR TITLE
fix(infra): regenerate for cli 2.7.0; harden pre-deploy-check

### DIFF
--- a/bin/pre-deploy-check.sh
+++ b/bin/pre-deploy-check.sh
@@ -133,14 +133,20 @@ main() {
 
   echo -e "${GREEN}✓${NC} Remote backend configured (backend.tf)"
 
-  # Ensure terraform is initialized with the backend
+  # Ensure terraform is initialized with the backend AND that the module cache is
+  # current. The presence of .terraform is NOT sufficient: a cache installed while
+  # the module `source` addresses pointed somewhere else (for example the sibling
+  # ../../mantle checkout before the registry cutover) makes every subsequent tofu
+  # command fail with "Module source has changed", which used to abort this script
+  # with no diagnostic. `tofu init` is idempotent and re-installs modules whenever
+  # their source addresses change, so run it unconditionally and let it self-heal.
   cd "${TERRAFORM_DIR}"
-  if [[ ! -d ".terraform" ]]; then
-    echo "  Initializing backend..."
-    if ! tofu init -input=false > /dev/null 2>&1; then
-      echo -e "${RED}ERROR: Failed to initialize terraform backend${NC}"
-      exit 1
-    fi
+  echo "  Initializing backend and module cache..."
+  if ! INIT_OUTPUT=$(tofu init -input=false -no-color 2>&1); then
+    echo -e "${RED}ERROR: Failed to initialize terraform backend${NC}"
+    echo ""
+    echo "$INIT_OUTPUT"
+    exit 1
   fi
   echo "  State backend: S3 (remote)"
   echo ""
@@ -148,11 +154,28 @@ main() {
   # Mantle uses NO terraform workspaces: the default workspace's state key is
   # already stage-scoped (infra-staging.tfstate). Pin the container image var from
   # live state so an unchanged image does not read as drift (deploy injects it).
-  IMAGE_URI=$(tofu state show module.lambda_start_file_upload.aws_lambda_function.function 2> /dev/null | sed -n 's/^ *image_uri *= *"\(.*\)".*/\1/p' | head -1)
+  # Reading the image from state is best-effort: a missing resource is fine (the
+  # plan still runs, an image-only diff just reads as drift). But it must never
+  # fail SILENTLY -- stderr was previously sent to /dev/null while `set -o pipefail`
+  # made the failing pipeline abort the whole script, so a hard tofu error such as
+  # "Module source has changed" surfaced only as a bare exit 1 with no message.
+  # Capture stderr, disable -e for the duration, and report whatever went wrong.
+  set +e
+  IMAGE_STATE=$(tofu state show module.lambda_start_file_upload.aws_lambda_function.function 2>&1)
+  IMAGE_STATE_EXIT=$?
+  set -e
+
   IMAGE_VAR_ARGS=()
-  if [[ -n "${IMAGE_URI}" ]]; then
-    IMAGE_VAR_ARGS+=("-var=image_uri_start_file_upload=${IMAGE_URI}")
-    echo -e "${GREEN}ok${NC} Pinned container image: ${IMAGE_URI##*/}"
+  if [[ ${IMAGE_STATE_EXIT} -ne 0 ]]; then
+    echo -e "${YELLOW}warn${NC} Could not read the container image from state (tofu exit ${IMAGE_STATE_EXIT}):"
+    echo "    ${IMAGE_STATE//$'\n'/$'\n'    }"
+    echo "  Continuing without a pinned image; an unchanged image may read as drift."
+  else
+    IMAGE_URI=$(echo "${IMAGE_STATE}" | sed -n 's/^ *image_uri *= *"\(.*\)".*/\1/p' | head -1)
+    if [[ -n "${IMAGE_URI}" ]]; then
+      IMAGE_VAR_ARGS+=("-var=image_uri_start_file_upload=${IMAGE_URI}")
+      echo -e "${GREEN}ok${NC} Pinned container image: ${IMAGE_URI##*/}"
+    fi
   fi
 
   # Run tofu plan with detailed exit code
@@ -160,7 +183,10 @@ main() {
 
   # Capture plan output and exit code
   set +e
-  PLAN_OUTPUT=$(tofu plan -var-file="${TFVARS_FILE}" "${IMAGE_VAR_ARGS[@]}" -detailed-exitcode -input=false -no-color 2>&1)
+  # ${arr[@]+"${arr[@]}"} expands to nothing when the array is empty instead of
+  # tripping `set -u`. The empty case is now reachable: the image lookup above
+  # warns and continues where it previously aborted the script.
+  PLAN_OUTPUT=$(tofu plan -var-file="${TFVARS_FILE}" ${IMAGE_VAR_ARGS[@]+"${IMAGE_VAR_ARGS[@]}"} -detailed-exitcode -input=false -no-color 2>&1)
   PLAN_EXIT=$?
   set -e
 
@@ -187,12 +213,23 @@ main() {
       echo "$PLAN_OUTPUT" | grep -E "^(  #|Plan:)" || echo "$PLAN_OUTPUT"
       echo ""
 
-      # Count additions, changes, deletions
-      ADD_COUNT=$(echo "$PLAN_OUTPUT" | grep -c "will be created" || echo 0)
-      CHANGE_COUNT=$(echo "$PLAN_OUTPUT" | grep -c "will be updated" || echo 0)
-      DESTROY_COUNT=$(echo "$PLAN_OUTPUT" | grep -c "will be destroyed" || echo 0)
+      # Report tofu's own "Plan: X to add, Y to change, Z to destroy." line verbatim
+      # rather than re-deriving counts. The previous hand-rolled tally was wrong in
+      # two ways: `grep -c` prints 0 AND exits 1 when there are no matches, so the
+      # `|| echo 0` fallback appended a SECOND zero and produced garbled multi-line
+      # output ("+0\n0 to add"); and it matched only "will be created"/"will be
+      # destroyed", so a resource that "must be replaced" -- a destroy plus a
+      # re-create -- was counted as neither and silently reported as "-0 to destroy".
+      # Under-reporting a destroy in a deploy gate is the exact failure this check
+      # exists to prevent.
+      PLAN_SUMMARY=$(echo "$PLAN_OUTPUT" | grep -E "^Plan: " | tail -1)
+      REPLACE_COUNT=$(echo "$PLAN_OUTPUT" | grep -cE "must be replaced" || true)
 
-      echo "Summary: +${ADD_COUNT} to add, ~${CHANGE_COUNT} to change, -${DESTROY_COUNT} to destroy"
+      echo "Summary: ${PLAN_SUMMARY:-<tofu emitted no Plan: line>}"
+      if [[ "${REPLACE_COUNT}" -gt 0 ]]; then
+        echo -e "${RED}WARNING:${NC} ${REPLACE_COUNT} resource(s) must be REPLACED (destroy + re-create):"
+        echo "$PLAN_OUTPUT" | grep -E "must be replaced" | sed 's/^ *#/    /'
+      fi
       echo ""
 
       if [[ "$FORCE" == "true" ]]; then

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -2,7 +2,7 @@
 # To customize, remove the first line and this file will be skipped on re-generation.
 
 module "database" {
-  source = "../../mantle/modules/database/aurora-dsql"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/database/aurora-dsql"
 
   name_prefix         = module.core.name_prefix
   tags                = module.core.common_tags

--- a/infra/dynamodb_idempotency.tf
+++ b/infra/dynamodb_idempotency.tf
@@ -3,7 +3,7 @@
 
 # DynamoDB table: idempotency
 module "dynamodb_idempotency" {
-  source              = "../../mantle/modules/dynamodb"
+  source              = "../node_modules/@j0nathan-ll0yd/cli/modules/dynamodb"
   table_name          = "idempotency"
   name_prefix         = module.core.name_prefix
   tags                = module.core.common_tags

--- a/infra/eventbridge.tf
+++ b/infra/eventbridge.tf
@@ -2,7 +2,7 @@
 # To customize, remove the first line and this file will be skipped on re-generation.
 
 module "eventbridge" {
-  source           = "../../mantle/modules/eventbridge"
+  source           = "../node_modules/@j0nathan-ll0yd/cli/modules/eventbridge"
   bus_name         = "MediaDownloader"
   name_prefix      = module.core.name_prefix
   tags             = module.core.common_tags

--- a/infra/lambda_api_gateway_authorizer.tf
+++ b/infra/lambda_api_gateway_authorizer.tf
@@ -4,7 +4,7 @@
 # --- ApiGatewayAuthorizer ---
 
 module "lambda_api_gateway_authorizer" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "ApiGatewayAuthorizer"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_cleanup_expired_records.tf
+++ b/infra/lambda_cleanup_expired_records.tf
@@ -4,7 +4,7 @@
 # --- CleanupExpiredRecords ---
 
 module "lambda_cleanup_expired_records" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name            = "CleanupExpiredRecords"
   name_prefix              = module.core.name_prefix

--- a/infra/lambda_dev_tools.tf
+++ b/infra/lambda_dev_tools.tf
@@ -4,7 +4,7 @@
 # --- DevTools ---
 
 module "lambda_dev_tools" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "DevTools"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_device_event.tf
+++ b/infra/lambda_device_event.tf
@@ -4,7 +4,7 @@
 # --- DeviceEvent ---
 
 module "lambda_device_event" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "DeviceEvent"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_device_register.tf
+++ b/infra/lambda_device_register.tf
@@ -4,7 +4,7 @@
 # --- DeviceRegister ---
 
 module "lambda_device_register" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "DeviceRegister"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_endpoint_cleanup_helpers.tf
+++ b/infra/lambda_endpoint_cleanup_helpers.tf
@@ -4,7 +4,7 @@
 # --- EndpointCleanupHelpers ---
 
 module "lambda_endpoint_cleanup_helpers" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "EndpointCleanupHelpers"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_feedly_webhook.tf
+++ b/infra/lambda_feedly_webhook.tf
@@ -4,7 +4,7 @@
 # --- FeedlyWebhook ---
 
 module "lambda_feedly_webhook" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "FeedlyWebhook"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_files_by_id_delete.tf
+++ b/infra/lambda_files_by_id_delete.tf
@@ -4,7 +4,7 @@
 # --- FilesByIdDelete ---
 
 module "lambda_files_by_id_delete" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "FilesByIdDelete"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_files_get.tf
+++ b/infra/lambda_files_get.tf
@@ -4,7 +4,7 @@
 # --- FilesGet ---
 
 module "lambda_files_get" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "FilesGet"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_log_notifier.tf
+++ b/infra/lambda_log_notifier.tf
@@ -4,7 +4,7 @@
 # --- LogNotifier ---
 
 module "lambda_log_notifier" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "LogNotifier"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_prune_devices.tf
+++ b/infra/lambda_prune_devices.tf
@@ -4,7 +4,7 @@
 # --- PruneDevices ---
 
 module "lambda_prune_devices" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name            = "PruneDevices"
   name_prefix              = module.core.name_prefix

--- a/infra/lambda_s3object_created.tf
+++ b/infra/lambda_s3object_created.tf
@@ -4,7 +4,7 @@
 # --- S3ObjectCreated ---
 
 module "lambda_s3object_created" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name            = "S3ObjectCreated"
   name_prefix              = module.core.name_prefix

--- a/infra/lambda_send_push_notification.tf
+++ b/infra/lambda_send_push_notification.tf
@@ -4,7 +4,7 @@
 # --- SendPushNotification ---
 
 module "lambda_send_push_notification" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "SendPushNotification"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_start_file_upload.tf
+++ b/infra/lambda_start_file_upload.tf
@@ -33,7 +33,7 @@ resource "aws_ecr_lifecycle_policy" "start_file_upload" {
 }
 
 module "lambda_start_file_upload" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name                  = "StartFileUpload"
   name_prefix                    = module.core.name_prefix

--- a/infra/lambda_user_delete.tf
+++ b/infra/lambda_user_delete.tf
@@ -4,7 +4,7 @@
 # --- UserDelete ---
 
 module "lambda_user_delete" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "UserDelete"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_user_login.tf
+++ b/infra/lambda_user_login.tf
@@ -4,7 +4,7 @@
 # --- UserLogin ---
 
 module "lambda_user_login" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "UserLogin"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_user_logout.tf
+++ b/infra/lambda_user_logout.tf
@@ -4,7 +4,7 @@
 # --- UserLogout ---
 
 module "lambda_user_logout" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "UserLogout"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_user_refresh.tf
+++ b/infra/lambda_user_refresh.tf
@@ -4,7 +4,7 @@
 # --- UserRefresh ---
 
 module "lambda_user_refresh" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "UserRefresh"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_user_register.tf
+++ b/infra/lambda_user_register.tf
@@ -4,7 +4,7 @@
 # --- UserRegister ---
 
 module "lambda_user_register" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "UserRegister"
   name_prefix        = module.core.name_prefix

--- a/infra/lambda_user_subscribe.tf
+++ b/infra/lambda_user_subscribe.tf
@@ -4,7 +4,7 @@
 # --- UserSubscribe ---
 
 module "lambda_user_subscribe" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "UserSubscribe"
   name_prefix        = module.core.name_prefix

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -21,13 +21,13 @@ provider "aws" {
 }
 
 module "core" {
-  source       = "../../mantle/modules/core"
+  source       = "../node_modules/@j0nathan-ll0yd/cli/modules/core"
   project_name = var.project_name
   environment  = var.environment
 }
 
 module "api" {
-  source      = "../../mantle/modules/api-gateway"
+  source      = "../node_modules/@j0nathan-ll0yd/cli/modules/api-gateway"
   name_prefix = module.core.name_prefix
   tags        = module.core.common_tags
 

--- a/infra/migrate_dsql.tf
+++ b/infra/migrate_dsql.tf
@@ -5,7 +5,7 @@
 # Runs schema migrations and applies per-Lambda permissions on every deploy.
 
 module "lambda_migrate_dsql" {
-  source = "../../mantle/modules/lambda"
+  source = "../node_modules/@j0nathan-ll0yd/cli/modules/lambda"
 
   function_name      = "MigrateDSQL"
   name_prefix        = module.core.name_prefix

--- a/infra/observability.tf
+++ b/infra/observability.tf
@@ -9,7 +9,7 @@
 #   API Gateway 5XX: 1
 #   Total: 10 alarm-metrics -> 0 billable -> ~$0.00/month
 module "observability" {
-  source      = "../../mantle/modules/observability"
+  source      = "../node_modules/@j0nathan-ll0yd/cli/modules/observability"
   name_prefix = module.core.name_prefix
   tags        = module.core.common_tags
 

--- a/infra/queue_DownloadQueue.tf
+++ b/infra/queue_DownloadQueue.tf
@@ -3,7 +3,7 @@
 
 # SQS queue: DownloadQueue
 module "queue_DownloadQueue" {
-  source                     = "../../mantle/modules/queue"
+  source                     = "../node_modules/@j0nathan-ll0yd/cli/modules/queue"
   queue_name                 = "DownloadQueue"
   name_prefix                = module.core.name_prefix
   tags                       = module.core.common_tags

--- a/infra/queue_EndpointEvents.tf
+++ b/infra/queue_EndpointEvents.tf
@@ -3,7 +3,7 @@
 
 # SQS queue: EndpointEvents
 module "queue_EndpointEvents" {
-  source                     = "../../mantle/modules/queue"
+  source                     = "../node_modules/@j0nathan-ll0yd/cli/modules/queue"
   queue_name                 = "EndpointEvents"
   name_prefix                = module.core.name_prefix
   tags                       = module.core.common_tags

--- a/infra/queue_SendPushNotification.tf
+++ b/infra/queue_SendPushNotification.tf
@@ -3,7 +3,7 @@
 
 # SQS queue: SendPushNotification
 module "queue_SendPushNotification" {
-  source                     = "../../mantle/modules/queue"
+  source                     = "../node_modules/@j0nathan-ll0yd/cli/modules/queue"
   queue_name                 = "SendPushNotification"
   name_prefix                = module.core.name_prefix
   tags                       = module.core.common_tags

--- a/infra/queue_lambda_s3object_created_dlq.tf
+++ b/infra/queue_lambda_s3object_created_dlq.tf
@@ -3,7 +3,7 @@
 
 # SQS queue: lambda_s3object_created_dlq
 module "queue_lambda_s3object_created_dlq" {
-  source                     = "../../mantle/modules/queue"
+  source                     = "../node_modules/@j0nathan-ll0yd/cli/modules/queue"
   queue_name                 = "lambda_s3object_created_dlq"
   name_prefix                = module.core.name_prefix
   tags                       = module.core.common_tags

--- a/infra/storage_files.tf
+++ b/infra/storage_files.tf
@@ -3,7 +3,7 @@
 
 # S3 bucket + CloudFront distribution for files
 module "storage_files" {
-  source               = "../../mantle/modules/storage"
+  source               = "../node_modules/@j0nathan-ll0yd/cli/modules/storage"
   bucket_name          = "files"
   name_prefix          = module.core.name_prefix
   project_name         = var.project_name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -66,43 +66,10 @@ variable "reserved_client_ip" {
   default     = ""
 }
 
-variable "apns_team" {
-  description = "apns team"
-  type        = string
-  default     = ""
-}
-
-variable "apns_key_id" {
-  description = "apns key id"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "apns_signing_key" {
-  description = "apns signing key"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "apns_default_topic" {
-  description = "apns default topic"
-  type        = string
-  default     = ""
-}
-
 variable "apns_host" {
   description = "apns host"
   type        = string
   default     = ""
-}
-
-variable "github_personal_token" {
-  description = "github personal token"
-  type        = string
-  default     = ""
-  sensitive   = true
 }
 
 variable "path" {
@@ -133,26 +100,6 @@ variable "ytdlp_binary_path" {
   description = "ytdlp binary path"
   type        = string
   default     = ""
-}
-
-variable "auth_secret" {
-  description = "auth secret"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "apple_client_id" {
-  description = "apple client id"
-  type        = string
-  default     = ""
-}
-
-variable "apple_client_secret" {
-  description = "apple client secret"
-  type        = string
-  default     = ""
-  sensitive   = true
 }
 
 variable "apple_app_bundle_identifier" {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@huggingface/transformers": "^4.2.0",
-    "@j0nathan-ll0yd/cli": "^2.2.1",
+    "@j0nathan-ll0yd/cli": "^2.7.0",
     "@j0nathan-ll0yd/config": "^1.2.1",
     "@j0nathan-ll0yd/eslint-config": "^1.1.0",
     "@j0nathan-ll0yd/testing": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@26.1.1)
       '@j0nathan-ll0yd/cli':
-        specifier: ^2.2.1
-        version: 2.6.0(@aws-lambda-powertools/jmespath@2.34.0)(@aws-sdk/client-api-gateway@3.1101.0)(@aws-sdk/client-cloudwatch@3.1101.0)(@aws-sdk/client-sns@3.1101.0)(@aws-sdk/dsql-signer@3.1101.0)(@aws-sdk/lib-dynamodb@3.1101.0(@aws-sdk/client-dynamodb@3.1101.0))(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@middy/core@7.7.2)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(kysely@0.29.4)(postgres@3.4.9))(kysely@0.29.4)(postgres@3.4.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)(vitest@4.1.10)(zod@4.4.3)
+        specifier: ^2.7.0
+        version: 2.7.0(@aws-lambda-powertools/jmespath@2.34.0)(@aws-sdk/client-api-gateway@3.1101.0)(@aws-sdk/client-cloudwatch@3.1101.0)(@aws-sdk/client-sns@3.1101.0)(@aws-sdk/dsql-signer@3.1101.0)(@aws-sdk/lib-dynamodb@3.1101.0(@aws-sdk/client-dynamodb@3.1101.0))(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@middy/core@7.7.2)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(kysely@0.29.4)(postgres@3.4.9))(kysely@0.29.4)(postgres@3.4.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)(vitest@4.1.10)(zod@4.4.3)
       '@j0nathan-ll0yd/config':
         specifier: ^1.2.1
         version: 1.2.1(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
@@ -1367,8 +1367,8 @@ packages:
   '@j0nathan-ll0yd/aws@1.0.1':
     resolution: {integrity: sha512-Q90XHR7KfA/6qAyNZ38QH4Awi+VFPkA3HKVdELDlt5vHcB5u2yfXK85tPdprGvktEBIuDu59ShCtu6+ub3lA1A==, tarball: https://npm.pkg.github.com/download/@j0nathan-ll0yd/aws/1.0.1/5b3618abffc624ee7040701b028f8714df24645e}
 
-  '@j0nathan-ll0yd/cli@2.6.0':
-    resolution: {integrity: sha512-0rF3k02ipcAzgoti2ORBfrSWIMWaCffnIE14YjmPhgWh+13U2i93wW0h+hTh170iNa8UzBT1A3mrHlPxUL0FLQ==, tarball: https://npm.pkg.github.com/download/@j0nathan-ll0yd/cli/2.6.0/a489e435c86bb7ed1aca7a6d6e57065950997c10}
+  '@j0nathan-ll0yd/cli@2.7.0':
+    resolution: {integrity: sha512-Dtgba82wzmWPj3YJ7bh8nJi+ywU0y69k7OCkAOT0LAMdOHH1nfsSrXiQnFk5HAhjh0TTNcUo3SyfM58n6xw0Yg==, tarball: https://npm.pkg.github.com/download/@j0nathan-ll0yd/cli/2.7.0/d91d1f36c9cf3fd1339b52471b44d3736a20558a}
     hasBin: true
     peerDependencies:
       typescript: 5.9.2 || 5.9.3 || 6.0.3
@@ -7523,7 +7523,7 @@ snapshots:
       - '@redis/client'
       - '@valkey/valkey-glide'
 
-  '@j0nathan-ll0yd/cli@2.6.0(@aws-lambda-powertools/jmespath@2.34.0)(@aws-sdk/client-api-gateway@3.1101.0)(@aws-sdk/client-cloudwatch@3.1101.0)(@aws-sdk/client-sns@3.1101.0)(@aws-sdk/dsql-signer@3.1101.0)(@aws-sdk/lib-dynamodb@3.1101.0(@aws-sdk/client-dynamodb@3.1101.0))(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@middy/core@7.7.2)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(kysely@0.29.4)(postgres@3.4.9))(kysely@0.29.4)(postgres@3.4.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)(vitest@4.1.10)(zod@4.4.3)':
+  '@j0nathan-ll0yd/cli@2.7.0(@aws-lambda-powertools/jmespath@2.34.0)(@aws-sdk/client-api-gateway@3.1101.0)(@aws-sdk/client-cloudwatch@3.1101.0)(@aws-sdk/client-sns@3.1101.0)(@aws-sdk/dsql-signer@3.1101.0)(@aws-sdk/lib-dynamodb@3.1101.0(@aws-sdk/client-dynamodb@3.1101.0))(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@middy/core@7.7.2)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(kysely@0.29.4)(postgres@3.4.9))(kysely@0.29.4)(postgres@3.4.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)(vitest@4.1.10)(zod@4.4.3)':
     dependencies:
       '@aws-sdk/client-dynamodb': 3.1101.0
       '@aws-sdk/client-eventbridge': 3.1101.0


### PR DESCRIPTION
## Summary

Unblocks OMD staging, which has been un-deployable since #605. Bumps `@j0nathan-ll0yd/cli` to `2.7.0`, regenerates `infra/`, and fixes three bugs in `bin/pre-deploy-check.sh`.

**No infrastructure has been applied.** This PR carries the regenerated infra plus a read-only `tofu plan` for review. The staging apply is a separate human-gated step — please approve the plan below before anyone runs it.

## What broke, and why

PR #605 (lockfile refresh) bumped `@j0nathan-ll0yd/cli` **2.2.1 -> 2.6.0**. From 2.6.0 the generator resolves Terraform modules out of `node_modules`, but the committed `infra/*.tf` still carried the pre-cutover `../../mantle/modules` sibling-checkout paths (last generated at #517).

The consequences compounded:

1. The local `.terraform` module cache no longer matched the committed `.tf`, so **every** `tofu` command failed with `Module source has changed`.
2. `bin/pre-deploy-check.sh:151` piped that error to `/dev/null` while `set -o pipefail` aborted the script — so the gate exited `1` with **no output at all**.
3. Regenerating on 2.6.0 alone would have made things worse. Its `emitDefault` rule (`!(isSensitive && meta.required)`) emitted five secrets as **required variables with no default**:

   `apns_key_id`, `apns_signing_key`, `auth_secret`, `apple_client_secret`, `github_personal_token`

   Nothing in `infra/` consumes them — the real secrets flow through `data.sops_file.secrets.data[...]`. And neither `mantle deploy` nor `mantle deploy --dry-run` supplies them (`dist/index.mjs:12293` passes only the tfvars file, `-var=environment`, and image URIs; the CLI never injects `TF_VAR_*`). Staging would have gone from _gate-blocked_ to _undeployable_.

`@j0nathan-ll0yd/cli@2.7.0` fixes this upstream by excluding secrets-bound env vars from variable emission (`dist/index.mjs:10459`, `|| secretsBoundEnvVars.has(name)`).

## The regeneration is a semantic no-op — how to verify

**1. The two module trees are byte-identical.** Aggregate SHA-256 over all 45 module `.tf` files:

```
fb2625769f6a2e10ca3ea886b0004b378d603d5280000ff05de9421a0df2983d  ~/Repositories/mantle/modules          (old path)
fb2625769f6a2e10ca3ea886b0004b378d603d5280000ff05de9421a0df2983d  node_modules/@j0nathan-ll0yd/cli/modules (new path)
```

Identical file sets (45 = 45, none unique to either side); `diff -r` reports zero differences. The extra files in the sibling checkout are all non-shipping (`.terraform/` caches, per-module lockfiles, `tests/`, `.omc/` scratch).

**2. Every changed line outside `variables.tf` is a module source path.** 32 added, 32 removed, matching module-for-module:

| Module                                                                                 | Count  |
| -------------------------------------------------------------------------------------- | ------ |
| lambda                                                                                 | 21     |
| queue                                                                                  | 4      |
| core, api-gateway, observability, storage, dynamodb, eventbridge, database/aurora-dsql | 1 each |

**3. Zero graph changes.** No `resource`, `data`, `module`, or `output` block was added or removed anywhere in the diff.

**4. Secret wiring is untouched.** All 17 `data.sops_file.secrets.data[...]` references are byte-identical to `main`, and `infra/sops.tf` is unchanged.

## `variables.tf`: 8 declarations removed, 0 added

The fix removes every **secrets-bound** env var, which is a superset of the 5 sensitive ones. Each removed variable is provably superseded by SOPS wiring, and each had **zero** `var.X` references anywhere in `infra/`:

| Removed variable        | Superseded by                                              |
| ----------------------- | ---------------------------------------------------------- |
| `apns_team`             | `data.sops_file.secrets.data["apns.staging.team"]`         |
| `apns_key_id`           | `data.sops_file.secrets.data["apns.staging.keyId"]`        |
| `apns_signing_key`      | `data.sops_file.secrets.data["apns.staging.signingKey"]`   |
| `apns_default_topic`    | `data.sops_file.secrets.data["apns.staging.defaultTopic"]` |
| `github_personal_token` | `data.sops_file.secrets.data["github.issue.token"]`        |
| `auth_secret`           | `data.sops_file.secrets.data["platform.key"]`              |
| `apple_client_id`       | `data.sops_file.secrets.data["signInWithApple.config"]`    |
| `apple_client_secret`   | `data.sops_file.secrets.data["signInWithApple.authKey"]`   |

Correctly **retained**: `apns_host` and `apple_app_bundle_identifier` also have zero `var.X` references, but they are plain literals (`"api.sandbox.push.apple.com"`, `"lifegames.OfflineMediaDownloader"`), not secrets-bound — so the generator keeps them. The removal criterion is SOPS binding, not disuse.

**No secret wiring was dropped.** Every secret previously reachable is still reachable, through the same data source.

## `bin/pre-deploy-check.sh` — three bugs fixed

1. **Swallowed stderr (`:151`).** `tofu state show ... 2> /dev/null | sed | head` discarded the error while `pipefail` + `set -e` killed the script — a hard tofu failure surfaced as a bare exit 1. Now captures stderr, warns, and continues (the image pin is best-effort).
2. **Init only when `.terraform` was absent (`:138`).** A _stale_ cache was never repaired, so the gate stayed wedged. `tofu init` is idempotent and re-installs modules when source addresses change, so it now runs unconditionally and self-heals.
3. **Under-reported destroys (found while verifying).** The hand-rolled tally used `grep -c ... || echo 0`, which appended a second zero (`+0\n0 to add`), and matched only `will be created` / `will be destroyed` — so a resource that `must be replaced` counted as neither and printed **`-0 to destroy`** on a plan that destroys one resource. Now reports tofu's authoritative `Plan:` line with an explicit replace warning.

Before / after on the same plan:

```
-  Summary: +0
-  0 to add, ~20 to change, -0
-  0 to destroy
+  Summary: Plan: 1 to add, 20 to change, 1 to destroy.
+  WARNING: 1 resource(s) must be REPLACED (destroy + re-create):
+       terraform_data.rerun_migration must be replaced
```

## Staging `tofu plan` (read-only, not applied)

`pnpm deploy:check:staging` now runs correctly. It exits **2 (drift detected)** — the gate working as designed, not failing:

```
Plan: 1 to add, 20 to change, 1 to destroy.
```

Attribute-level, the entire diff is:

| Change          | Resources                        | Attributes                                   |
| --------------- | -------------------------------- | -------------------------------------------- |
| Update in place | 20 `aws_lambda_function`         | `source_code_hash`, `last_modified` **only** |
| Replace         | `terraform_data.rerun_migration` | `triggers_replace`, `id`                     |

- **The 20 lambda updates are pre-existing code drift, not from this PR** — staging is running older bundles than `main` (#605/#606/#607 merged without a deploy). No infra attribute changes, only the code hash.
- **The single destroy is `terraform_data.rerun_migration`**, the migration re-run trigger, which is designed to be replaced on each deploy. It is a `terraform_data` node with no cloud-side resource.
- **No unexpected destroys.** Nothing else is replaced or destroyed.
- **No secret or environment-block changes** appear anywhere in the plan.
- **No module path churn reached the graph** (zero occurrences of either module path in the plan output) — direct confirmation the source swap is a no-op.

## Dependency strategy note

No `pnpm-workspace.yaml` change was needed: `@j0nathan-ll0yd/cli` is already listed bare in `minimumReleaseAgeExclude` under the atlas 0016 closure, so the 24h `minimumReleaseAge: 1440` floor did not block `2.7.0` despite it being published minutes earlier. The bare-name convention worked exactly as intended. The lockfile change is surgical — only the `@j0nathan-ll0yd/cli` entry.

## Verification

- `pnpm precheck` (`mantle ci --mode pre-push`): **14 passed, 3 skipped, 0 failed**
- `shellcheck bin/*.sh`: clean
- `shfmt -i 2 -ci -sr -d bin/*.sh`: clean
- Pre-commit hooks (secret scan, dependency-cruiser, docs structure): passed
- `pnpm deploy:check:staging`: runs to completion, reports drift accurately

## Reviewer request

Please review the `tofu plan` summary above and confirm the 20 `source_code_hash` updates plus the `terraform_data.rerun_migration` replace are expected before any staging apply. **Do not merge-and-deploy in one step** — the apply should be a deliberate, separate action.
