### PR TITLE
fix(dsql): reassign+drop orphaned legacy roles so permissions cleanup stops warning

### DIFF
--- a/migrations/0006_drop_legacy_lambda_roles.sql
+++ b/migrations/0006_drop_legacy_lambda_roles.sql
@@ -1,0 +1,131 @@
+-- Retire 13 legacy per-Lambda PG roles left over from the pre-rename role scheme.
+--
+-- Why this migration exists:
+-- applyPermissions() in @j0nathan-ll0yd/database drops orphan `lambda_%` roles on
+-- every deploy, but it issues a bare `DROP ROLE` with no privilege cleanup first.
+-- Each of these roles still holds table ACL grants (pg_shdepend deptype='a' on
+-- pg_class), so every deploy logs:
+--   Warning: could not drop role <X>: role "X" cannot be dropped because some
+--   objects depend on it
+-- This migration removes the blocking grants so the DROP succeeds. The upstream
+-- cleanup then finds nothing to do and the warnings stop.
+--
+-- Aurora DSQL compatibility:
+-- `DROP OWNED BY` / `REASSIGN OWNED BY` are absent from the Aurora DSQL supported-SQL
+-- reference in either direction, so they are not used here. `REVOKE (ON, FROM, CASCADE,
+-- RESTRICT)` is explicitly listed as supported DCL, and `DROP ROLE` is documented in the
+-- DSQL troubleshooting guide (it is exactly the command emitting the warning above).
+-- No `ALTER ... OWNER TO` is needed: all 11 tables in `public` are owned by `admin` and
+-- none of these roles owns any object (verified via pg_class.relowner).
+-- No `AWS IAM REVOKE` is needed: none of these roles has a row in
+-- sys.iam_pg_role_mappings, which is also the proof that no Lambda can reach them --
+-- a Lambda authenticates to DSQL through an IAM-to-PG-role mapping, and there is none.
+--
+-- Every REVOKE below corresponds to a real ACL entry observed in staging pg_class.relacl.
+
+-- lambda_download_orchestrator (superseded: DownloadOrchestrator Lambda removed)
+REVOKE ALL PRIVILEGES ON files FROM lambda_download_orchestrator;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_download_orchestrator;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_files FROM lambda_download_orchestrator;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_download_orchestrator;
+--> statement-breakpoint
+
+-- lambda_failure_handler (superseded: FailureHandler Lambda removed)
+REVOKE ALL PRIVILEGES ON files FROM lambda_failure_handler;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_failure_handler;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_files FROM lambda_failure_handler;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_failure_handler;
+--> statement-breakpoint
+
+-- lambda_file_helpers (superseded: FileHelpers Lambda removed)
+REVOKE ALL PRIVILEGES ON files FROM lambda_file_helpers;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_file_helpers;
+--> statement-breakpoint
+
+-- lambda_files_file_id_delete (superseded by lambda_files_by_id_delete)
+REVOKE ALL PRIVILEGES ON files FROM lambda_files_file_id_delete;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_files_file_id_delete;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_files FROM lambda_files_file_id_delete;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_files_file_id_delete;
+--> statement-breakpoint
+
+-- lambda_list_files (superseded by lambda_files_get)
+REVOKE ALL PRIVILEGES ON files FROM lambda_list_files;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_files FROM lambda_list_files;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_list_files;
+--> statement-breakpoint
+
+-- lambda_login_user (superseded by lambda_user_login)
+REVOKE ALL PRIVILEGES ON users FROM lambda_login_user;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON sessions FROM lambda_login_user;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON accounts FROM lambda_login_user;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_login_user;
+--> statement-breakpoint
+
+-- lambda_logout_user (superseded by lambda_user_logout)
+REVOKE ALL PRIVILEGES ON sessions FROM lambda_logout_user;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_logout_user;
+--> statement-breakpoint
+
+-- lambda_push_helpers (superseded: PushHelpers Lambda removed)
+REVOKE ALL PRIVILEGES ON devices FROM lambda_push_helpers;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_devices FROM lambda_push_helpers;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_push_helpers;
+--> statement-breakpoint
+
+-- lambda_refresh_token (superseded by lambda_user_refresh)
+REVOKE ALL PRIVILEGES ON sessions FROM lambda_refresh_token;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_refresh_token;
+--> statement-breakpoint
+
+-- lambda_register_device (superseded by lambda_device_register)
+REVOKE ALL PRIVILEGES ON devices FROM lambda_register_device;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_devices FROM lambda_register_device;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_register_device;
+--> statement-breakpoint
+
+-- lambda_register_user (superseded by lambda_user_register)
+REVOKE ALL PRIVILEGES ON users FROM lambda_register_user;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_register_user;
+--> statement-breakpoint
+
+-- lambda_s3_recovery (superseded: S3Recovery Lambda removed)
+REVOKE ALL PRIVILEGES ON files FROM lambda_s3_recovery;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_s3_recovery;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_files FROM lambda_s3_recovery;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_s3_recovery;
+--> statement-breakpoint
+
+-- lambda_webhook_feedly (superseded by lambda_feedly_webhook)
+REVOKE ALL PRIVILEGES ON files FROM lambda_webhook_feedly;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_webhook_feedly;
+--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON user_files FROM lambda_webhook_feedly;
+--> statement-breakpoint
+DROP ROLE IF EXISTS lambda_webhook_feedly;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1747165200000,
       "tag": "0005_backfill_user_files",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1755043200000,
+      "tag": "0006_drop_legacy_lambda_roles",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Problem

Every staging deploy logged 13 non-fatal warnings from the DSQL permissions step:

```
Warning: could not drop role lambda_failure_handler: role "lambda_failure_handler" cannot be dropped because some objects depend on it
```

Recurring log noise that can mask real permission errors, and stale PG roles retained live grants on production-path tables in staging DSQL.

## Where the cleanup lives + fix layer (C70)

**The cleanup is NOT OMD-owned.** It lives upstream in `@j0nathan-ll0yd/database@2.0.0`, in `applyPermissions()` (`dist/index.mjs:107-145`), invoked from `src/lambdas/standalone/MigrateDSQL/index.ts:33`.

The upstream code correctly revokes `AWS IAM GRANT` mappings first, then issues a **bare `DROP ROLE`** with no privilege cleanup:

```js
await db.execute(sql.raw(`DROP ROLE IF EXISTS "${role}"`));   // dist/index.mjs:134
} catch (dropErr) {
  logger?.(`  Warning: could not drop role ${role}: ...`);    // dist/index.mjs:139
}
```

It handles IAM mappings but never the role's **object ACL grants**, which are the actual blocker here.

### ⚠️ Upstream fix needed in mantle

The true root-cause fix belongs in `@j0nathan-ll0yd/database` (like #346 was): `applyPermissions()` should revoke the role's object privileges before `DROP ROLE`, rather than warn and move on. Suggested upstream change — before the `DROP ROLE`, enumerate and revoke:

```sql
SELECT c.relname FROM pg_class c
JOIN pg_shdepend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass
WHERE d.refobjid = '<role>'::regrole AND d.deptype = 'a';
-- then: REVOKE ALL PRIVILEGES ON <each> FROM <role>;
```

`DROP OWNED BY` is the natural implementation but is **not documented for Aurora DSQL** (see below), so upstream should use explicit REVOKE for the `aurora-dsql` provider.

This PR is the OMD-local remediation: it clears the blocking grants so the upstream cleanup succeeds. It fixes staging permanently, but the upstream defect remains for any other Mantle instance that renames a Lambda.

## Confirmed-obsolete role list + evidence

All 13 roles that failed to drop, with proof each is dead:

| Legacy role | Blocking ACL grants | Superseded by | IAM mapping? |
|---|---|---|---|
| `lambda_download_orchestrator` | files, file_downloads, user_files | DownloadOrchestrator Lambda removed | none |
| `lambda_failure_handler` | files, file_downloads, user_files | FailureHandler Lambda removed | none |
| `lambda_file_helpers` | files | FileHelpers Lambda removed | none |
| `lambda_files_file_id_delete` | files, file_downloads, user_files | `lambda_files_by_id_delete` | none |
| `lambda_list_files` | files, user_files | `lambda_files_get` | none |
| `lambda_login_user` | users, sessions, accounts | `lambda_user_login` | none |
| `lambda_logout_user` | sessions | `lambda_user_logout` | none |
| `lambda_push_helpers` | devices, user_devices | PushHelpers Lambda removed | none |
| `lambda_refresh_token` | sessions | `lambda_user_refresh` | none |
| `lambda_register_device` | devices, user_devices | `lambda_device_register` | none |
| `lambda_register_user` | users | `lambda_user_register` | none |
| `lambda_s3_recovery` | files, file_downloads, user_files | S3Recovery Lambda removed | none |
| `lambda_webhook_feedly` | files, file_downloads, user_files | `lambda_feedly_webhook` | none |

**The decisive evidence is the IAM mapping column.** A Lambda reaches DSQL only through an IAM-role→PG-role mapping. `sys.iam_pg_role_mappings` contained **19 rows, none for any of these 13**:

```
19 mappings, all staging-<Fn> → live roles (ApiGatewayAuthorizer, CleanupExpiredRecords,
DevTools, DeviceEvent, DeviceRegister, EndpointCleanupHelpers, FeedlyWebhook,
FilesByIdDelete, FilesGet, PruneDevices, S3ObjectCreated, SendPushNotification,
StartFileUpload, UserDelete, UserLogin, UserLogout, UserRefresh, UserRegister, UserSubscribe)
```

No mapping ⇒ no Lambda can authenticate as these roles ⇒ dropping them cannot break anything. Corroborated by `permissions/permissions.sql` + `permissions/lambda_dev_tools.sql` defining exactly the 19 live roles, and by `pg_shdepend` showing **zero `sys.iam_auth_member` dependencies** for all 13.

### What actually blocked the DROP

`pg_shdepend` showed 28 rows of `deptype='a'` (ACL) on `pg_class` for the 13 roles — plain table grants, e.g.:

```
files.relacl = {admin=arwdDxt/admin, ..., lambda_file_helpers=arw/admin,
                lambda_download_orchestrator=arw/admin, lambda_failure_handler=rw/admin,
                lambda_s3_recovery=arw/admin, lambda_list_files=r/admin, ...}
```

Notably **none of the 13 owns any object** — `pg_class.relowner` for every table in `public` is `admin`, and a query for `relowner LIKE 'lambda_%'` returned zero rows. So no ownership transfer was required at all.

## DSQL-compat approach

Per the [Aurora DSQL supported-SQL reference](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-features.html):

- **`REVOKE` is explicitly supported** DCL (clauses `ON`, `FROM`, `CASCADE`, `RESTRICT`). ✅
- **`DROP ROLE` works** — it is the exact command producing the warning, and is documented in the [DSQL troubleshooting guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/troubleshooting.html) under this error string.
- **`DROP OWNED BY` / `REASSIGN OWNED BY` appear nowhere in the Aurora DSQL docs** — not in the supported list, not in the unsupported list. Unverified in either direction, so **not used**.

So the fix takes the documented fallback path from the task spec: **explicit per-object `REVOKE`, then `DROP ROLE`**. `ALTER ... OWNER TO` was unnecessary (nothing is owned). `AWS IAM REVOKE` was unnecessary (no mappings). Every one of the 28 REVOKEs corresponds to a real ACL entry observed in staging `relacl`.

### `mantle db check-dsql` output

```
0006_drop_legacy_lambda_roles
  [1] OK -- Retire 13 legacy per-Lambda PG roles left over from the pre-rename role schem
  [2] OK REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_download_orchestrator;
  [3] OK REVOKE ALL PRIVILEGES ON user_files FROM lambda_download_orchestrator;
  [4] OK DROP ROLE IF EXISTS lambda_download_orchestrator;
  [5] OK -- lambda_failure_handler (superseded: FailureHandler Lambda removed) REVOKE ALL
  [6] OK REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_failure_handler;
  [7] OK REVOKE ALL PRIVILEGES ON user_files FROM lambda_failure_handler;
  [8] OK DROP ROLE IF EXISTS lambda_failure_handler;
  [9] OK -- lambda_file_helpers (superseded: FileHelpers Lambda removed) REVOKE ALL PRIVI
  [10] OK DROP ROLE IF EXISTS lambda_file_helpers;
  [11] OK -- lambda_files_file_id_delete (superseded by lambda_files_by_id_delete) REVOKE
  [12] OK REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_files_file_id_delete;
  [13] OK REVOKE ALL PRIVILEGES ON user_files FROM lambda_files_file_id_delete;
  [14] OK DROP ROLE IF EXISTS lambda_files_file_id_delete;
  [15] OK -- lambda_list_files (superseded by lambda_files_get) REVOKE ALL PRIVILEGES ON f
  [16] OK REVOKE ALL PRIVILEGES ON user_files FROM lambda_list_files;
  [17] OK DROP ROLE IF EXISTS lambda_list_files;
  [18] OK -- lambda_login_user (superseded by lambda_user_login) REVOKE ALL PRIVILEGES ON
  [19] OK REVOKE ALL PRIVILEGES ON sessions FROM lambda_login_user;
  [20] OK REVOKE ALL PRIVILEGES ON accounts FROM lambda_login_user;
  [21] OK DROP ROLE IF EXISTS lambda_login_user;
  [22] OK -- lambda_logout_user (superseded by lambda_user_logout) REVOKE ALL PRIVILEGES O
  [23] OK DROP ROLE IF EXISTS lambda_logout_user;
  [24] OK -- lambda_push_helpers (superseded: PushHelpers Lambda removed) REVOKE ALL PRIVI
  [25] OK REVOKE ALL PRIVILEGES ON user_devices FROM lambda_push_helpers;
  [26] OK DROP ROLE IF EXISTS lambda_push_helpers;
  [27] OK -- lambda_refresh_token (superseded by lambda_user_refresh) REVOKE ALL PRIVILEGE
  [28] OK DROP ROLE IF EXISTS lambda_refresh_token;
  [29] OK -- lambda_register_device (superseded by lambda_device_register) REVOKE ALL PRIV
  [30] OK REVOKE ALL PRIVILEGES ON user_devices FROM lambda_register_device;
  [31] OK DROP ROLE IF EXISTS lambda_register_device;
  [32] OK -- lambda_register_user (superseded by lambda_user_register) REVOKE ALL PRIVILEG
  [33] OK DROP ROLE IF EXISTS lambda_register_user;
  [34] OK -- lambda_s3_recovery (superseded: S3Recovery Lambda removed) REVOKE ALL PRIVILE
  [35] OK REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_s3_recovery;
  [36] OK REVOKE ALL PRIVILEGES ON user_files FROM lambda_s3_recovery;
  [37] OK DROP ROLE IF EXISTS lambda_s3_recovery;
  [38] OK -- lambda_webhook_feedly (superseded by lambda_feedly_webhook) REVOKE ALL PRIVIL
  [39] OK REVOKE ALL PRIVILEGES ON file_downloads FROM lambda_webhook_feedly;
  [40] OK REVOKE ALL PRIVILEGES ON user_files FROM lambda_webhook_feedly;
  [41] OK DROP ROLE IF EXISTS lambda_webhook_feedly;

Summary:
  Total statements: 70
  Compatible: 56
  Index (auto-ASYNC): 14

All statements are DSQL-compatible.
```

**41 statements, zero missing `--> statement-breakpoint` markers.** Each statement executes in its own transaction on the `aurora-dsql` path (`applyMigrationDsql`), satisfying DSQL's one-DDL-per-transaction limit — the constraint behind the earlier staging outage.

## Before / after on a real staging deploy

**Before** — `staging-MigrateDSQL`, request `a77c3505-3c0a-4c02-b01f-67843f085287` (PR #608's deploy, 2026-08-12T21:01:19Z), filter `could not drop role`:

```
13 events — lambda_failure_handler, lambda_register_device, lambda_file_helpers,
lambda_register_user, lambda_files_file_id_delete, lambda_push_helpers,
lambda_refresh_token, lambda_login_user, lambda_s3_recovery, lambda_logout_user,
lambda_webhook_feedly, lambda_list_files, lambda_download_orchestrator
```

**After** — `pnpm run deploy:staging` on this branch:

```
Apply complete! Resources: 1 added, 2 changed, 1 destroyed.

{"migrations":{"applied":1,"migrations":[{"tag":"0006_drop_legacy_lambda_roles",
 "hash":"0d8b3261...","durationMs":964.300786}]},
 "permissions":{"applied":73,"skipped":19,"errors":[],"droppedRoles":[]},
 "validation":{"valid":52,"gaps":[],"reapplied":52}}
```

CloudWatch filter `could not drop role` → **`No log events found`**. Filter `Warning` (any warning at all) → **`No log events found`**.

`droppedRoles: []` with `errors: []` is the tell: the upstream cleanup found **no orphans left to drop**.

**Steady state re-verified** with a second direct invocation:

```
{"migrations":{"applied":0,"migrations":[]},
 "permissions":{"applied":73,"skipped":19,"errors":[],"droppedRoles":[]},
 "validation":{"valid":52,"gaps":[],"reapplied":52}}
```

### Warning counts

| | `could not drop role` | any `Warning` |
|---|---|---|
| Before | **13** | 13 |
| After | **0** | **0** |

### Roles gone

```sql
SELECT rolname FROM pg_roles WHERE rolname IN (<the 13>);
-- []  (empty)

SELECT count(*) FROM pg_roles WHERE rolname LIKE 'lambda_%';
-- 19   (was 32)
```

### Live access NOT broken

Post-deploy ACLs show every live role's grants intact and only the legacy entries removed:

```
files      = {admin=arwdDxt/admin, lambda_s3_object_created=r, lambda_start_file_upload=arw,
              lambda_feedly_webhook=ar, lambda_files_get=ar, lambda_files_by_id_delete=rd,
              lambda_dev_tools=r}
sessions   = {admin=arwdDxt/admin, lambda_api_gateway_authorizer=rw, lambda_cleanup_expired_records=rd,
              lambda_user_login=arwd, lambda_user_logout=arwd, lambda_user_refresh=arwd,
              lambda_user_register=arwd, lambda_dev_tools=r}
users      = {admin=arwdDxt/admin, lambda_user_delete=rd, lambda_user_login=arw, lambda_user_logout=arw,
              lambda_user_refresh=arw, lambda_user_register=arw, lambda_dev_tools=r}
user_files = {admin=arwdDxt/admin, lambda_s3_object_created=r, lambda_start_file_upload=r,
              lambda_user_delete=rd, lambda_feedly_webhook=ar, lambda_files_get=r,
              lambda_files_by_id_delete=rd, lambda_dev_tools=r}
```

`validation: {valid: 52, gaps: [], reapplied: 52}` — zero grant gaps.

**Smoke test** — `pnpm run test:remote:list:staging` (exercises `FilesGet` → `lambda_files_get` → `files`/`user_files`):

```
▶ GET https://lp7du05n2b.execute-api.us-west-2.amazonaws.com/prod/files
{ "contents": [ { "fileId": "wRG7lAGdRII", "status": "Downloaded", ... } ], "keyCount": 1 }
▶ HTTP 200
```

Real rows returned, so the DB read path is genuinely exercised — not just a healthy-looking empty response.

## Scope notes

- Staging is the only environment for OMD; no production stage exists and none was targeted.
- `npx mantle ci` passes locally: **13 passed, 4 skipped, 0 failed**.
- An incidental `infra/.terraform.lock.hcl` multi-platform-hash change from `tofu init` was reverted to keep this diff focused.
