### PR TITLE
fix(deps): move off broken pnpm 11.13.0 to 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=24.0.0",
     "pnpm": ">=11.0.0"
   },
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.22.0",
   "type": "module",
   "scripts": {
     "adr:new": "./bin/adr-new.sh",


### PR DESCRIPTION
## What
`packageManager: pnpm@11.13.0` → `pnpm@11.22.0`.

## Why
pnpm 11.13.0 is a broken upstream release (`@pnpm/exe` shipped without a binary → `ERR_PNPM_BROKEN_PNPM_RELEASE`). It only worked where a runner baked pnpm via corepack; `pnpm/action-setup` 6.0.10 and any non-baked runner hard-fail on it. 11.22.0 (latest 11.x) installs cleanly. Lockfile unchanged (same lockfileVersion + resolution).