### PR TITLE
ci: Docker-free Build job + pin-integrity gate for StartFileUpload image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: [self-hosted, linux, arm64, node-integration]
+    runs-on: [self-hosted, linux, arm64, node]
+    # id-token: write only takes effect when AWS_ROLE_CI_ECR_READ is set (job stays
+    # Docker-free and AWS-free otherwise; gate 2c below no-ops on a missing secret).
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Gate 2b (below) diffs this PR against its base branch, which needs the
+          # base ref present locally — a depth-1 checkout has only HEAD.
+          fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: '.nvmrc'
@@ -170,10 +180,101 @@ jobs:
         run: pnpm config set '//npm.pkg.github.com/:_authToken' "$NODE_AUTH_TOKEN"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      # Docker-free build (no container-Lambda image build/push here — see
+      # docker/start-file-upload.pin.README.md). Only esbuild + typecheck run.
       - name: Build
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
-        run: pnpm build
+        run: pnpm build:ci
+
+      # --- Pin-integrity gate (composite, Docker-free) -----------------------
+      # Verifies the committed docker/start-file-upload.pin.json still describes
+      # the image that would actually get deployed for this commit. See the plan
+      # at .omc/plans/omd-prebuilt-container-lambda-2026-08-16.md ("CI pin-integrity
+      # gate") and docker/start-file-upload.pin.README.md.
+
+      # 2a. Bundle match: the pinned image's baked index.mjs must equal the one
+      # `pnpm build:ci` just produced for this commit. This is the Docker-free proof
+      # that the pinned image still serves this commit's code, and it covers code
+      # imported transitively (via #services/*, #domain/*, etc.), not only edits
+      # under src/lambdas/sqs/StartFileUpload/.
+      - name: Verify pinned bundle hash (gate 2a)
+        run: |
+          set -euo pipefail
+          bundle="build/lambdas/StartFileUpload/index.mjs"
+          if [[ ! -f "$bundle" ]]; then
+            echo "::error::$bundle was not produced by the build step — cannot verify the pin."
+            exit 1
+          fi
+          actual_hash="sha256:$(sha256sum "$bundle" | cut -d' ' -f1)"
+          pinned_hash="$(node -e "console.log(JSON.parse(require('fs').readFileSync('docker/start-file-upload.pin.json','utf8')).bundleHash)")"
+          if [[ "$actual_hash" != "$pinned_hash" ]]; then
+            echo "::error::StartFileUpload bundle hash mismatch. Pinned bundleHash ($pinned_hash) does not match" \
+                 "the bundle produced from this commit ($actual_hash). The handler or a transitively-imported" \
+                 "module (e.g. src/services/**, src/domain/**) changed without a repin. Run" \
+                 "bin/refresh-download-image.sh to rebuild the image and repin docker/start-file-upload.pin.json."
+            exit 1
+          fi
+          echo "Pinned bundleHash matches this commit's build: $actual_hash"
+
+      # 2b. Non-code inputs: layers/** (cookies, bgutil requirements) and
+      # docker/Dockerfile.download are baked into the image but are NOT part of the
+      # esbuild bundle, so gate 2a cannot see them change. If either changed in this
+      # PR without a pin update, the image is stale.
+      - name: Verify non-code image inputs are repinned (gate 2b)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD)"
+          pin_changed="$(grep -c '^docker/start-file-upload\.pin\.json$' <<< "$changed" || true)"
+          inputs_changed="$(grep -cE '^(layers/|docker/Dockerfile\.download$)' <<< "$changed" || true)"
+          if [[ "$inputs_changed" -gt 0 && "$pin_changed" -eq 0 ]]; then
+            echo "::error::layers/** or docker/Dockerfile.download changed in this PR but" \
+                 "docker/start-file-upload.pin.json did not. These inputs are baked into the" \
+                 "StartFileUpload image but are invisible to gate 2a's bundle hash — image inputs" \
+                 "changed; run bin/refresh-download-image.sh to repin."
+            exit 1
+          fi
+          echo "No unrepinned changes to layers/** or docker/Dockerfile.download."
+
+      # 2c. Digest exists in ECR (soft — requires AWS_ROLE_CI_ECR_READ, a
+      # USER-provisioned least-privilege role: ecr:DescribeImages + ecr:BatchGetImage
+      # scoped to the start-file-upload repo, account 514454346828, us-west-2. Until
+      # that role is provisioned this step is skipped entirely; gates 2a/2b above are
+      # the correctness-critical, Docker-free, AWS-free stale-image detectors, and
+      # `mantle deploy` fails closed if the pinned digest is genuinely missing.
+      # (The `secrets` context cannot be read directly in a step `if:` — capture it via
+      # a step output first, matching the check-creds pattern in deploy-production.yml.)
+      - name: Check ECR-read role configuration (gate 2c)
+        id: check-ecr-role
+        run: |
+          if [ -z "${{ secrets.AWS_ROLE_CI_ECR_READ }}" ]; then
+            echo "::notice::AWS_ROLE_CI_ECR_READ is not configured — skipping gate 2c (digest-exists-in-ECR)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Configure AWS credentials (ECR read, gate 2c)
+        if: steps.check-ecr-role.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_CI_ECR_READ }}
+          aws-region: us-west-2
+      - name: Verify pinned digest exists in ECR (gate 2c)
+        if: steps.check-ecr-role.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          digest="$(node -e "console.log(JSON.parse(require('fs').readFileSync('docker/start-file-upload.pin.json','utf8')).digest)")"
+          if [[ "$digest" == sha256:PENDING* ]]; then
+            echo "::warning::pin.digest is still the bootstrap placeholder ($digest) — run" \
+                 "bin/refresh-download-image.sh to push a real image before deploying."
+            exit 0
+          fi
+          repo="stag/start-file-upload"
+          aws ecr describe-images --repository-name "$repo" --image-ids "imageDigest=$digest" \
+            --query 'imageDetails[0].imageManifestMediaType' --output text
+
 
   conventions:
     name: Convention Checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,8 +272,23 @@ jobs:
             exit 0
           fi
           repo="stag/start-file-upload"
-          aws ecr describe-images --repository-name "$repo" --image-ids "imageDigest=$digest" \
-            --query 'imageDetails[0].imageManifestMediaType' --output text
+          media_type="$(aws ecr describe-images --repository-name "$repo" --image-ids "imageDigest=$digest" \
+            --query 'imageDetails[0].imageManifestMediaType' --output text)"
+          # Backstop for the refresh script's --provenance=false/--sbom=false: an OCI image
+          # INDEX (or Docker manifest list) is undeployable to AWS Lambda even though the
+          # digest itself resolves in ECR, so this must be a hard assertion, not a print.
+          case "$media_type" in
+            *image.index* | *manifest.list*)
+              echo "::error::pin.digest ($digest) resolves in ECR to an OCI image INDEX" \
+                   "($media_type), not a single image manifest. AWS Lambda rejects indexes." \
+                   "Re-run bin/refresh-download-image.sh (with --provenance=false --sbom=false)" \
+                   "to push a deployable single-manifest image and repin."
+              exit 1
+              ;;
+            *)
+              echo "OK: pinned digest is a single image manifest ($media_type)."
+              ;;
+          esac
 
 
   conventions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
                  "bin/refresh-download-image.sh to push a real image before deploying."
             exit 0
           fi
-          repo="stag/start-file-upload"
+          repo="staging/start-file-upload"
           media_type="$(aws ecr describe-images --repository-name "$repo" --image-ids "imageDigest=$digest" \
             --query 'imageDetails[0].imageManifestMediaType' --output text)"
           # Backstop for the refresh script's --provenance=false/--sbom=false: an OCI image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,31 +246,38 @@ jobs:
       # `mantle deploy` fails closed if the pinned digest is genuinely missing.
       # (The `secrets` context cannot be read directly in a step `if:` — capture it via
       # a step output first, matching the check-creds pattern in deploy-production.yml.)
-      - name: Check ECR-read role configuration (gate 2c)
+      # Gate 2c makes a live AWS OIDC + ECR call, so BOTH prerequisites are checked here
+      # (before any AWS step): the read-role must be configured AND the pin must carry a
+      # real digest. With the bootstrap placeholder there is nothing in ECR to verify, and
+      # configuring AWS creds would hang on the self-hosted runner's egress firewall (STS
+      # is not reachable until a real refresh is needed). So skip the AWS steps entirely
+      # until the digest is real.
+      - name: Check gate 2c prerequisites (ECR-read role and real digest)
         id: check-ecr-role
         run: |
           if [ -z "${{ secrets.AWS_ROLE_CI_ECR_READ }}" ]; then
             echo "::notice::AWS_ROLE_CI_ECR_READ is not configured — skipping gate 2c (digest-exists-in-ECR)."
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=true" >> "$GITHUB_OUTPUT"
+            echo "should_check=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          digest="$(node -e "console.log(JSON.parse(require('fs').readFileSync('docker/start-file-upload.pin.json','utf8')).digest)")"
+          if [[ "$digest" == sha256:PENDING* ]]; then
+            echo "::warning::pin.digest is still the bootstrap placeholder ($digest) — run bin/refresh-download-image.sh to push a real image before deploying. Skipping gate 2c (no AWS call)."
+            echo "should_check=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_check=true" >> "$GITHUB_OUTPUT"
       - name: Configure AWS credentials (ECR read, gate 2c)
-        if: steps.check-ecr-role.outputs.configured == 'true'
+        if: steps.check-ecr-role.outputs.should_check == 'true'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_CI_ECR_READ }}
           aws-region: us-west-2
       - name: Verify pinned digest exists in ECR (gate 2c)
-        if: steps.check-ecr-role.outputs.configured == 'true'
+        if: steps.check-ecr-role.outputs.should_check == 'true'
         run: |
           set -euo pipefail
           digest="$(node -e "console.log(JSON.parse(require('fs').readFileSync('docker/start-file-upload.pin.json','utf8')).digest)")"
-          if [[ "$digest" == sha256:PENDING* ]]; then
-            echo "::warning::pin.digest is still the bootstrap placeholder ($digest) — run" \
-                 "bin/refresh-download-image.sh to push a real image before deploying."
-            exit 0
-          fi
           repo="staging/start-file-upload"
           media_type="$(aws ecr describe-images --repository-name "$repo" --image-ids "imageDigest=$digest" \
             --query 'imageDetails[0].imageManifestMediaType' --output text)"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -56,7 +56,7 @@ jobs:
             layers/yt-dlp/cookies/youtube-cookies.enc > layers/yt-dlp/cookies/youtube-cookies.txt
 
       - name: Build
-        run: pnpm run build
+        run: pnpm run build:ci
 
       - name: Run unit tests
         run: pnpm test
@@ -133,12 +133,6 @@ jobs:
           sops --decrypt secrets.prod.enc.yaml > secrets.prod.yaml
           sops decrypt --output-type binary \
             layers/yt-dlp/cookies/youtube-cookies.enc > layers/yt-dlp/cookies/youtube-cookies.txt
-
-      - name: Build Lambda layers
-        if: steps.check-creds.outputs.configured == 'true'
-        run: |
-          ./bin/build-deno-layer.sh
-          ./bin/build-bgutil-layer.sh
 
       - name: Deploy to Production
         if: steps.check-creds.outputs.configured == 'true'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: ./.github/actions/setup-homebrew-tools
 
       - name: Build
-        run: pnpm run build
+        run: pnpm run build:ci
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6
@@ -80,11 +80,6 @@ jobs:
           export SOPS_AGE_KEY_FILE=/tmp/age-key.txt
           ENV_SUFFIX=${{ inputs.environment == 'production' && 'prod' || 'staging' }}
           sops --decrypt secrets.${ENV_SUFFIX}.enc.yaml > secrets.${ENV_SUFFIX}.yaml
-
-      - name: Build Lambda layers
-        run: |
-          ./bin/build-deno-layer.sh
-          ./bin/build-bgutil-layer.sh
 
       - name: Rollback deployment
         env:

--- a/.github/workflows/update-yt-dlp.yml
+++ b/.github/workflows/update-yt-dlp.yml
@@ -162,10 +162,16 @@ jobs:
           - [ ] CI/CD tests pending
 
           ## Deployment Process
+          This bump changes \`docker/Dockerfile.download\`, so CI's pin-integrity gate (2b)
+          will go red until the image is repinned — \`pnpm run build\`/\`pnpm run deploy:staging\`
+          alone do NOT repin \`docker/start-file-upload.pin.json\`.
           1. Merge this PR
-          2. Run \`pnpm run build\` to rebuild the StartFileUpload container with the new yt-dlp
-          3. Run \`pnpm run deploy:staging\` to push the new image
-          4. Monitor CloudWatch logs for any download issues after deployment
+          2. On a host with Docker (the Mac Studio CI host), run \`bin/refresh-download-image.sh\`
+             to rebuild + push the StartFileUpload image with the new yt-dlp and commit the
+             repinned \`docker/start-file-upload.pin.json\`
+          3. Push that commit so CI's gate 2b/2a go green
+          4. Run \`pnpm run deploy:staging\` to deploy
+          5. Monitor CloudWatch logs for any download issues after deployment
 
           ## Rollback Procedure
           If issues occur after deployment:
@@ -173,7 +179,9 @@ jobs:
           sed -i '' "s|^ARG YTDLP_VERSION=.*|ARG YTDLP_VERSION=${CURRENT_VERSION}|" docker/Dockerfile.download  # macOS; drop the '' on Linux
           git commit -am "chore(deps): revert yt-dlp to ${CURRENT_VERSION}"
           git push
-          pnpm run build && pnpm run deploy:staging
+          ./bin/refresh-download-image.sh  # rebuilds, pushes, and repins for the reverted version
+          git push
+          pnpm run deploy:staging
           \`\`\`
           EOF
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,8 @@ pnpm run deploy:staging        # Deploy to staging (local agents)
 
 **Note**: Staging is the only deployable stage — Terraform state is remote (S3, `infra-staging.tfstate`, native lockfile) and `allowedStages: ['staging']` hard-refuses anything else until stage-scoped state keys land (mantle Phase 2d). CI does not deploy (`ci.deploy: false`).
 
+**StartFileUpload container image**: routine builds (`pnpm run build:ci` = `mantle build --skip-container`, used by CI and this deploy path) are Docker-free — the `StartFileUpload` container Lambda is referenced by a pinned ECR manifest digest in `docker/start-file-upload.pin.json` instead of being rebuilt every time. Run `bin/refresh-download-image.sh` on a host with Docker (the Mac Studio CI host) to rebuild + push the image and repin when `docker/Dockerfile.download`, `layers/**`, or the `StartFileUpload` bundle (including transitively-imported `src/services/**` etc.) change. See `docker/start-file-upload.pin.README.md`.
+
 Before running migrations against a live stage, use these validation commands:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A serverless YouTube media downloader with a companion [iOS App](https://github.
 # Install dependencies
 pnpm install
 
-# Build all Lambda functions
-npx mantle build
+# Build all Lambda functions (Docker-free: skips the StartFileUpload container image)
+pnpm run build:ci
 
 # Deploy to staging
 npx mantle deploy --stage staging
@@ -19,6 +19,13 @@ npx mantle deploy --stage staging
 # Deploy to production
 npx mantle deploy --stage production
 ```
+
+Routine builds (CI and local `build:ci`) are Docker-free — `StartFileUpload`
+(`packageType: 'container'`) is referenced by a pinned ECR image digest
+(`docker/start-file-upload.pin.json`) instead of being rebuilt on every change. Refresh
+that image with `bin/refresh-download-image.sh` (operator-run on a host with Docker) when
+`docker/Dockerfile.download`, `layers/**`, or the `StartFileUpload` bundle change — see
+`docker/start-file-upload.pin.README.md`.
 
 ## Architecture
 

--- a/bin/refresh-download-image.sh
+++ b/bin/refresh-download-image.sh
@@ -60,8 +60,15 @@ if [[ ! -f "$BUNDLE" ]]; then
 fi
 
 echo "==> Building + pushing ${IMAGE}:${tag} (linux/amd64)"
+# --provenance=false --sbom=false: the docker-container buildx driver (needed for
+# cross-building linux/amd64 on this arm64 fleet) attaches provenance/SBOM attestations
+# by default, which turns the pushed artifact into an OCI image INDEX rather than a
+# single image manifest. AWS Lambda container images must be a single-arch manifest;
+# an index digest would produce an undeployable pin. Disable both.
 docker buildx build \
   --platform linux/amd64 \
+  --provenance=false \
+  --sbom=false \
   -f "$DOCKERFILE" \
   --push \
   -t "${IMAGE}:${tag}" \
@@ -74,6 +81,25 @@ if [[ -z "$digest" || "$digest" == "undefined" ]]; then
   cat "$META_FILE" >&2
   exit 1
 fi
+
+echo "==> Verifying the pushed artifact is a single image manifest, not an index"
+manifest_type="$(docker buildx imagetools inspect "${IMAGE}@${digest}" --raw | node -e "
+  let data = '';
+  process.stdin.on('data', (chunk) => { data += chunk; });
+  process.stdin.on('end', () => { console.log(JSON.parse(data).mediaType); });
+")"
+case "$manifest_type" in
+  *image.index* | *manifest.list*)
+    echo "ERROR: pushed artifact ${IMAGE}@${digest} is an OCI image INDEX ($manifest_type)," \
+         "not a single image manifest. AWS Lambda rejects indexes. This means" \
+         "--provenance=false/--sbom=false did not take effect, or the buildx driver" \
+         "in use still attaches attestations. Refusing to write an undeployable pin." >&2
+    exit 1
+    ;;
+  *)
+    echo "OK: pushed artifact is a single image manifest ($manifest_type)."
+    ;;
+esac
 
 bundle_hash="sha256:$(sha256sum "$BUNDLE" | cut -d' ' -f1)"
 

--- a/bin/refresh-download-image.sh
+++ b/bin/refresh-download-image.sh
@@ -12,7 +12,7 @@
 #   - ECR login: aws ecr get-login-password --region us-west-2 | \
 #       docker login --username AWS --password-stdin 514454346828.dkr.ecr.us-west-2.amazonaws.com
 #   - AWS credentials with ecr:GetAuthorizationToken + push access to the
-#     stag/start-file-upload repository.
+#     staging/start-file-upload repository.
 #
 # Run: ./bin/refresh-download-image.sh
 #
@@ -30,8 +30,12 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 ECR_REGISTRY="514454346828.dkr.ecr.us-west-2.amazonaws.com"
-NAME_PREFIX="stag" # resource_prefix customVariable; this repo only deploys staging today
-ECR_REPO="${NAME_PREFIX}/start-file-upload"
+# The ECR repo is named ${module.core.name_prefix}/start-file-upload, and name_prefix ==
+# var.environment == the deploy stage ("staging") -- NOT the deprecated resource_prefix
+# customVariable ("stag"/"prod"), which is S3-bucket-naming-only. This script is
+# staging-only per allowedStages, so the stage is fixed here.
+STAGE="staging"
+ECR_REPO="${STAGE}/start-file-upload"
 IMAGE="${ECR_REGISTRY}/${ECR_REPO}"
 
 DOCKERFILE="docker/Dockerfile.download"

--- a/bin/refresh-download-image.sh
+++ b/bin/refresh-download-image.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# refresh-download-image.sh
+# Builds + pushes the StartFileUpload container-Lambda image (docker/Dockerfile.download)
+# and repins docker/start-file-upload.pin.json to the pushed digest. Operator-run on the
+# Mac Studio host (it has the Colima Docker daemon) -- see the plan:
+# .omc/plans/omd-prebuilt-container-lambda-2026-08-16.md ("Image refresh (occasional)").
+#
+# Prerequisites:
+#   - Docker (Colima context) with buildx and QEMU/binfmt for linux/amd64 emulation
+#     (this fleet is arm64; the Lambda runtime is x86_64).
+#   - ECR login: aws ecr get-login-password --region us-west-2 | \
+#       docker login --username AWS --password-stdin 514454346828.dkr.ecr.us-west-2.amazonaws.com
+#   - AWS credentials with ecr:GetAuthorizationToken + push access to the
+#     stag/start-file-upload repository.
+#
+# Run: ./bin/refresh-download-image.sh
+#
+# CI automation note: this script is currently run BY HAND. Automating it (Phase 2 --
+# an isolated rootless-DinD ci-runners lane) requires pushing the repinned commit back
+# to trigger CI, which needs a USER-provisioned fine-grained PAT (OMD_REFRESH_PAT,
+# contents:write on this repo only) passed to actions/checkout -- github.token pushes
+# do not re-trigger `on: pull_request` workflow runs (GitHub anti-recursion). Not
+# implemented here; see plan Q2.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ECR_REGISTRY="514454346828.dkr.ecr.us-west-2.amazonaws.com"
+NAME_PREFIX="stag" # resource_prefix customVariable; this repo only deploys staging today
+ECR_REPO="${NAME_PREFIX}/start-file-upload"
+IMAGE="${ECR_REGISTRY}/${ECR_REPO}"
+
+DOCKERFILE="docker/Dockerfile.download"
+BUNDLE="build/lambdas/StartFileUpload/index.mjs"
+PIN_FILE="docker/start-file-upload.pin.json"
+META_FILE="$(mktemp -t sfu-meta.XXXXXX.json)"
+trap 'rm -f "$META_FILE"' EXIT
+
+if ! command -v docker &> /dev/null; then
+  echo "ERROR: docker is required (Colima context). See this script's header." >&2
+  exit 1
+fi
+
+git_short_sha="$(git rev-parse --short HEAD)"
+tag="sha-${git_short_sha}"
+
+echo "==> Decrypting YouTube cookies"
+./bin/decrypt-cookies.sh
+
+echo "==> Building the app bundle (same bundler as CI: mantle build --skip-container)"
+pnpm build:ci
+
+if [[ ! -f "$BUNDLE" ]]; then
+  echo "ERROR: $BUNDLE was not produced by pnpm build:ci." >&2
+  exit 1
+fi
+
+echo "==> Building + pushing ${IMAGE}:${tag} (linux/amd64)"
+docker buildx build \
+  --platform linux/amd64 \
+  -f "$DOCKERFILE" \
+  --push \
+  -t "${IMAGE}:${tag}" \
+  --metadata-file "$META_FILE" \
+  .
+
+digest="$(node -e "console.log(JSON.parse(require('fs').readFileSync('${META_FILE}','utf8'))['containerimage.digest'])")"
+if [[ -z "$digest" || "$digest" == "undefined" ]]; then
+  echo "ERROR: could not read containerimage.digest from ${META_FILE}." >&2
+  cat "$META_FILE" >&2
+  exit 1
+fi
+
+bundle_hash="sha256:$(sha256sum "$BUNDLE" | cut -d' ' -f1)"
+
+echo "==> Writing ${PIN_FILE}"
+cat > "$PIN_FILE" <<EOF
+{
+  "digest": "${digest}",
+  "bundleHash": "${bundle_hash}",
+  "tag": "${tag}"
+}
+EOF
+
+echo "==> Committing the pin"
+git add "$PIN_FILE"
+git commit -m "chore(docker): repin start-file-upload image to ${tag}"
+
+echo ""
+echo "Done. Pushed ${IMAGE}:${tag} (${digest}) and committed ${PIN_FILE}."
+echo "Push this commit (and the branch/PR it belongs to) to re-run CI's pin-integrity gate."

--- a/docker/Dockerfile.download
+++ b/docker/Dockerfile.download
@@ -40,11 +40,15 @@ ADD https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86
 RUN cd /tmp && unzip deno.zip && chmod +x deno && mv deno /opt/bin/deno && rm deno.zip
 
 # --- ffmpeg + ffprobe (static build for stream muxing and analysis) ---
-# BtbN/FFmpeg-Builds: track the never-purged `latest` tag with the n7.1 branch asset.
-# (The timestamped autobuild-* tags are NOT immutable -- BtbN deletes old ones, which
-# 404'd the build. `latest` always exists; the n7.1 asset stays on the stable 7.1 line.)
-ARG FFMPEG_BUILD=latest
-ARG FFMPEG_ASSET=ffmpeg-n7.1-latest-linux64-gpl-7.1
+# BtbN/FFmpeg-Builds: pinned to a dated autobuild release + its exact versioned asset
+# name (NOT `latest` / `-latest-`). `latest` is a moving pointer -- a same-tag rebuild
+# is a silent no-op under this Lambda's IMMUTABLE ECR repo (F2, see
+# .omc/plans/omd-prebuilt-container-lambda-2026-08-16.md in ci-runners-private). BtbN
+# keeps a rolling window of dated autobuild-* releases (30 releases / ~15 months
+# observed 2026-08-16), so a dated tag stays resolvable for a comfortable window; bump
+# both ARGs together (verify the asset URL resolves) when the pin needs to move.
+ARG FFMPEG_BUILD=autobuild-2026-08-13-17-03
+ARG FFMPEG_ASSET=ffmpeg-n7.1.5-12-g1fdbca85aa-linux64-gpl-7.1
 ADD https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BUILD}/${FFMPEG_ASSET}.tar.xz /tmp/ffmpeg.tar.xz
 RUN cd /tmp && tar xf ffmpeg.tar.xz --wildcards '*/bin/ffmpeg' '*/bin/ffprobe' --strip-components=2 \
   && chmod +x ffmpeg ffprobe && mv ffmpeg ffprobe /opt/bin/ && rm ffmpeg.tar.xz

--- a/docker/start-file-upload.pin.README.md
+++ b/docker/start-file-upload.pin.README.md
@@ -1,0 +1,64 @@
+# start-file-upload.pin.json
+
+Pin record for the `StartFileUpload` container-Lambda image. Read by CI's Docker-free
+pin-integrity gate (`.github/workflows/ci.yml`, Build job) and, once the mantle
+framework change for `imageDigestFile` ships (worker-2, `feat/prebuilt-image-digest-mode`
+on `mantle`), by `mantle deploy` itself. See the plan:
+`.omc/plans/omd-prebuilt-container-lambda-2026-08-16.md`.
+
+## Schema
+
+```json
+{
+  "digest": "sha256:<ECR manifest digest>",
+  "bundleHash": "sha256:<hex sha256 of build/lambdas/StartFileUpload/index.mjs>",
+  "tag": "sha-<gitshort>"
+}
+```
+
+- `digest` — the immutable ECR manifest digest `mantle deploy` wires into
+  `image_uri_start_file_upload`. Authoritative; `tag` is a disposable handle only.
+- `bundleHash` — sha256 of the exact `index.mjs` baked into that image. CI's gate 2a
+  recomputes this from the current commit's `pnpm build:ci` output and fails the build
+  on a mismatch. **Invariant:** both `bin/refresh-download-image.sh` and CI compute this
+  from `mantle build --skip-container` (`pnpm build:ci`) — never a hand-rolled esbuild
+  call — so both sides bundle identically for the same Mantle version.
+- `tag` — a disposable, content-unique tag (`sha-<gitshort>`) used only because the ECR
+  repo is `IMMUTABLE`; not consumed by the digest-based deploy path.
+
+## Bootstrap state (this commit)
+
+This file was bootstrapped, not produced by a real refresh:
+
+- `bundleHash` is REAL — computed via `pnpm build:ci` against this commit's
+  `src/lambdas/sqs/StartFileUpload/**` and its transitive imports.
+- `digest` is a PLACEHOLDER (`sha256:PENDING-FIRST-REFRESH`). No image has been pushed
+  to ECR for this bundle yet. CI's gate 2c (digest-exists-in-ECR) treats this placeholder
+  as a soft warning, not a failure — gate 2c only runs when `AWS_ROLE_CI_ECR_READ` is
+  configured, and gates 2a/2b (Docker-free, AWS-free) are the correctness-critical checks
+  in Phase 0.
+- Run `bin/refresh-download-image.sh` on the Mac Studio host (it has the Colima Docker
+  daemon) to build + push the real image and replace this placeholder with a real digest.
+  Do this before the first `mantle deploy --stage staging` that relies on prebuilt-image
+  mode.
+
+## `imageDigestFile` wiring status (step 6 of Phase 0)
+
+`src/lambdas/sqs/StartFileUpload/index.ts` does **not** yet set
+`defineLambda({ imageDigestFile: 'docker/start-file-upload.pin.json' })`. The installed
+`@j0nathan-ll0yd/cli` (2.7.0, from GitHub Packages) predates the `imageDigestFile` field
+add landing on `mantle` (`feat/prebuilt-image-digest-mode`, worker-2). Adding the field
+today is a no-op either way (unknown `defineLambda` fields are not read), but leaving it
+out avoids describing a contract this repo's installed CLI does not implement yet, and
+keeps `mantle check` config validation honest about what's actually wired.
+
+**Next step once mantle ships `imageDigestFile`:** bump `@j0nathan-ll0yd/cli` in this
+repo, then add `imageDigestFile: 'docker/start-file-upload.pin.json'` to the
+`defineLambda({...})` call in `src/lambdas/sqs/StartFileUpload/index.ts`. That flips
+`mantle build`/`mantle deploy` into prebuilt-image mode (skip `docker build`, skip
+`docker info`/ECR login/push, wire `image_uri_start_file_upload` from `pin.digest`,
+fail closed if the digest is missing from ECR). Until then, CI's Build job is
+Docker-free via `pnpm build:ci` (`mantle build --skip-container`, which mantle already
+supports independent of `imageDigestFile`), and `mantle deploy` for `StartFileUpload`
+still needs to run on a host with Docker (the Mac Studio) — i.e. Phase 0 unblocks CI,
+Phase 1 (the mantle field, once wired here) unblocks deploy too.

--- a/docker/start-file-upload.pin.json
+++ b/docker/start-file-upload.pin.json
@@ -1,0 +1,5 @@
+{
+  "digest": "sha256:PENDING-FIRST-REFRESH",
+  "bundleHash": "sha256:6baefefd446b78d6617685d81ebc38784f6be3bc4087e532a4cc674762603a50",
+  "tag": "sha-bootstrap"
+}

--- a/infra/lambda_start_file_upload.tf
+++ b/infra/lambda_start_file_upload.tf
@@ -21,11 +21,11 @@ resource "aws_ecr_lifecycle_policy" "start_file_upload" {
   policy = jsonencode({
     rules = [{
       rulePriority = 1
-      description  = "Retain last 5 images"
+      description  = "Retain last 30 images"
       selection = {
         tagStatus   = "any"
         countType   = "imageCountMoreThan"
-        countNumber = 5
+        countNumber = 30
       }
       action = { type = "expire" }
     }]

--- a/mantle.config.ts
+++ b/mantle.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
   // deploy would rename everything staging->prod, destroying the live stack; the
   // CLI refuses it until stage-scoped state keys land (mantle Phase 2d).
   allowedStages: ['staging'],
+  // Raised from the CLI default (5) to 30 (~1 year of refreshes at the observed
+  // ~2/month StartFileUpload image-refresh cadence + a comfortable rollback window).
+  // Drives the ECR lifecycle policy `countNumber` on the StartFileUpload container
+  // repo (infra-api.ts). See .omc/plans/omd-prebuilt-container-lambda-2026-08-16.md, Q3.
+  containerRegistry: {imageRetentionCount: 30},
   customVariables: [
     {
       name: 'resource_prefix',


### PR DESCRIPTION
Fixes the red Build job on main (it requires Docker on the node-integration label, which has no Docker socket). Routine CI is now Docker-free: Build runs on the node label via pnpm build:ci. Adds a composite pin-integrity gate (bundle-hash match, layers/Dockerfile path guard, soft ECR digest+media-type assertion gated on AWS_ROLE_CI_ECR_READ), bin/refresh-download-image.sh (operator-run image refresh), an immutable ffmpeg pin, ECR retention 5 to 30, and de-stales the deploy-production and rollback workflows. The imageDigestFile handler wiring is deferred until the mantle prebuilt-image release lands.